### PR TITLE
change integral scaling and fix too aggressive anti-windup in PID

### DIFF
--- a/app/brewblox/blox/PidBlock.h
+++ b/app/brewblox/blox/PidBlock.h
@@ -97,7 +97,7 @@ public:
         message.i = cnl::unwrap(pid.i());
         message.d = cnl::unwrap(pid.d());
         message.error = cnl::unwrap(pid.error());
-        message.integral = cnl::unwrap(Pid::out_t(pid.integral()));
+        message.integral = cnl::unwrap(pid.integral());
         message.derivative = cnl::unwrap(pid.derivative());
 
         stripped.copyToMessage(message.strippedFields, message.strippedFields_count, 4);

--- a/app/brewblox/proto/Pid.proto
+++ b/app/brewblox/proto/Pid.proto
@@ -41,7 +41,7 @@ message Pid {
   sint32 d = 18 [ (brewblox).logged = true, (brewblox).scale = 4096, (nanopb).int_size = IS_32, (brewblox).readonly = true ];
 
   sint32 error = 19 [ (brewblox).logged = true, (brewblox).unit = DeltaTemp, (brewblox).scale = 4096, (nanopb).int_size = IS_32, (brewblox).readonly = true ];
-  sint32 integral = 20 [ (brewblox).logged = true, (brewblox).unit = DeltaTempTime, (brewblox).scale = 4096, (nanopb).int_size = IS_32, (brewblox).readonly = true ];
+  sint64 integral = 20 [ (brewblox).logged = true, (brewblox).unit = DeltaTempTime, (brewblox).scale = 4096, (nanopb).int_size = IS_64, (brewblox).readonly = true ];
   sint32 derivative = 21 [ (brewblox).logged = true, (brewblox).unit = DeltaTempPerTime, (brewblox).scale = 8388608, (nanopb).int_size = IS_32, (brewblox).readonly = true ];
   repeated uint32 strippedFields = 99 [ (brewblox).readonly = true, (nanopb).int_size = IS_16, (nanopb).max_count = 4 ];
 }

--- a/app/brewblox/proto/Pid.proto
+++ b/app/brewblox/proto/Pid.proto
@@ -41,7 +41,7 @@ message Pid {
   sint32 d = 18 [ (brewblox).logged = true, (brewblox).scale = 4096, (nanopb).int_size = IS_32, (brewblox).readonly = true ];
 
   sint32 error = 19 [ (brewblox).logged = true, (brewblox).unit = DeltaTemp, (brewblox).scale = 4096, (nanopb).int_size = IS_32, (brewblox).readonly = true ];
-  sint64 integral = 20 [ (brewblox).logged = true, (brewblox).unit = DeltaTempTime, (brewblox).scale = 4096, (nanopb).int_size = IS_64, (brewblox).readonly = true ];
+  sint32 integral = 20 [ (brewblox).logged = true, (brewblox).unit = DeltaTempTime, (brewblox).scale = 4096, (nanopb).int_size = IS_32, (brewblox).readonly = true ];
   sint32 derivative = 21 [ (brewblox).logged = true, (brewblox).unit = DeltaTempPerTime, (brewblox).scale = 8388608, (nanopb).int_size = IS_32, (brewblox).readonly = true ];
   repeated uint32 strippedFields = 99 [ (brewblox).readonly = true, (nanopb).int_size = IS_16, (nanopb).max_count = 4 ];
 }

--- a/app/brewblox/test/PidBlock_test.cpp
+++ b/app/brewblox/test/PidBlock_test.cpp
@@ -134,17 +134,17 @@ SCENARIO("A Blox Pid object can be created from streamed protobuf data")
     CHECK(testBox.lastReplyHasStatusOk());
 
     CHECK(cnl::wrap<Pid::out_t>(decoded.p()) == Approx(10.0).epsilon(0.01));
-    CHECK(cnl::wrap<Pid::out_t>(decoded.i()) == Approx(10.0 * 1.0 * 1000 / 2000).epsilon(0.05));
+    CHECK(cnl::wrap<Pid::out_t>(decoded.i()) == Approx(10.0 * 1.0 * 1000 / 2000).epsilon(0.01));
     CHECK(cnl::wrap<Pid::out_t>(decoded.d()) == 0);
-    CHECK(cnl::wrap<Pid::out_t>(decoded.outputvalue()) == Approx(15.0).epsilon(0.05));
+    CHECK(cnl::wrap<Pid::out_t>(decoded.outputvalue()) == Approx(15.0).epsilon(0.01));
 
     // only nonzero values are shown in the debug string
     CHECK(decoded.ShortDebugString() == "inputId: 102 outputId: 103 "
                                         "inputValue: 81920 inputSetting: 86016 "
-                                        "outputValue: 60990 outputSetting: 60990 "
+                                        "outputValue: 61425 outputSetting: 61425 "
                                         "filterThreshold: 4096 "
                                         "enabled: true active: true "
                                         "kp: 40960 ti: 2000 td: 200 "
-                                        "p: 40950 i: 20040 "
-                                        "error: 4095 integral: 8388607 derivative: -1");
+                                        "p: 40950 i: 20475 "
+                                        "error: 4095 integral: 8388607");
 }

--- a/app/brewblox/test/PidBlock_test.cpp
+++ b/app/brewblox/test/PidBlock_test.cpp
@@ -141,10 +141,10 @@ SCENARIO("A Blox Pid object can be created from streamed protobuf data")
     // only nonzero values are shown in the debug string
     CHECK(decoded.ShortDebugString() == "inputId: 102 outputId: 103 "
                                         "inputValue: 81920 inputSetting: 86016 "
-                                        "outputValue: 60518 outputSetting: 60518 "
+                                        "outputValue: 60990 outputSetting: 60990 "
                                         "filterThreshold: 4096 "
                                         "enabled: true active: true "
                                         "kp: 40960 ti: 2000 td: 200 "
-                                        "p: 40950 i: 19568 "
-                                        "error: 4095 integral: 19568 derivative: -1");
+                                        "p: 40950 i: 20040 "
+                                        "error: 4095 integral: 8388607 derivative: -1");
 }

--- a/app/brewblox/test/PidBlock_test.cpp
+++ b/app/brewblox/test/PidBlock_test.cpp
@@ -119,9 +119,9 @@ SCENARIO("A Blox Pid object can be created from streamed protobuf data")
     testBox.processInput();
     CHECK(testBox.lastReplyHasStatusOk());
 
-    // update 100 times (PID updates every second, t is in ms)
+    // update 1000 seconds (PID updates every second, t is in ms)
     uint32_t t = 0;
-    for (; t < 1000000; ++t) {
+    for (; t < 1000'000; ++t) {
         testBox.update(t);
     }
 
@@ -146,5 +146,5 @@ SCENARIO("A Blox Pid object can be created from streamed protobuf data")
                                         "enabled: true active: true "
                                         "kp: 40960 ti: 2000 td: 200 "
                                         "p: 40950 i: 20475 "
-                                        "error: 4095 integral: 8388607");
+                                        "error: 4095 integral: 40950000");
 }

--- a/app/brewblox/test/PidBlock_test.cpp
+++ b/app/brewblox/test/PidBlock_test.cpp
@@ -146,5 +146,5 @@ SCENARIO("A Blox Pid object can be created from streamed protobuf data")
                                         "enabled: true active: true "
                                         "kp: 40960 ti: 2000 td: 200 "
                                         "p: 40950 i: 20475 "
-                                        "error: 4095 integral: 40950000");
+                                        "error: 4095 integral: 4096000");
 }

--- a/lib/inc/Pid.h
+++ b/lib/inc/Pid.h
@@ -29,7 +29,7 @@ class Pid {
 public:
     using in_t = fp12_t;
     using out_t = fp12_t;
-    using integral_t = safe_elastic_fixed_point<11, 30, int64_t>;
+    using integral_t = safe_elastic_fixed_point<29, 12, int64_t>;
     using derivative_t = safe_elastic_fixed_point<1, 23, int32_t>;
 
 private:

--- a/lib/inc/Pid.h
+++ b/lib/inc/Pid.h
@@ -46,7 +46,7 @@ private:
     integral_t m_integral = integral_t{0};
     derivative_t m_derivative = derivative_t{0};
 
-    uint8_t m_inputFailureCount = 0;
+    uint8_t m_inputFailureCount = 255; // force a reset on init
 
     // settings
     in_t m_kp = in_t{0};        // proportional gain

--- a/lib/inc/Pid.h
+++ b/lib/inc/Pid.h
@@ -30,6 +30,7 @@ public:
     using in_t = fp12_t;
     using out_t = fp12_t;
     using integral_t = safe_elastic_fixed_point<29, 12, int64_t>;
+    using integral_external_t = safe_elastic_fixed_point<19, 12, int64_t>;
     using derivative_t = safe_elastic_fixed_point<1, 23, int32_t>;
 
 private:
@@ -78,9 +79,16 @@ public:
         return m_error;
     }
 
-    auto integral() const
+    integral_external_t integral() const
     {
-        return m_integral;
+        // m_integral is scaled with Kp (because m_p is added each second)
+        // scale back before returning value
+        if (m_kp == 0) {
+            return integral_external_t(0);
+        }
+        auto rounder = m_integral >= 0 ? m_kp / 2 : -m_kp / 2;
+        auto result = (m_integral + rounder) / m_kp;
+        return result;
     }
 
     auto derivative() const

--- a/lib/src/Pid.cpp
+++ b/lib/src/Pid.cpp
@@ -49,8 +49,13 @@ Pid::update()
     m_error = m_filter.read();
     m_p = m_kp * m_error;
 
-    m_integral = (m_ti != 0) ? m_integral + m_p / m_ti : 0;
-    m_i = m_integral;
+    if (m_ti != 0) {
+        m_integral += m_p;
+        m_i = m_integral / m_ti;
+    } else {
+        m_integral = 0;
+        m_ti = 0;
+    }
 
     m_derivative = m_filter.readDerivative<decltype(m_derivative)>();
     m_d = m_kp * (m_derivative * m_td);
@@ -79,8 +84,8 @@ Pid::update()
                     // clipped to actuator min or max set in target actuator
                     // calculate anti-windup from setting instead of actual value, so it doesn't dip under the maximum
                     antiWindup = 3 * (pidResult - outputSetting); // anti windup gain is 3
-                    // make sure anti-windup is at least increment when clipping to prevent further windup
-                    antiWindup = (m_p >= 0) ? std::max(m_p / m_ti, antiWindup) : std::min(m_p / m_ti, antiWindup);
+                    // make sure anti-windup is at least m_p when clipping to prevent further windup
+                    antiWindup = (m_p >= 0) ? std::max(m_p, antiWindup) : std::min(m_p, antiWindup);
                 } else {
 
                     // Actuator could be not reaching set value due to physics or limits in its target actuator
@@ -103,11 +108,11 @@ Pid::update()
 
                 // make sure integral does not cross zero and does not increase by anti-windup
 
-                decltype(m_integral) newIntegral = m_integral - antiWindup;
+                integral_t newIntegral = m_integral - antiWindup;
                 if (m_integral >= 0) {
-                    m_integral = std::clamp(newIntegral, decltype(m_integral)(0), m_integral);
+                    m_integral = std::clamp(newIntegral, integral_t(0), m_integral);
                 } else {
-                    m_integral = std::clamp(newIntegral, m_integral, decltype(m_integral)(0));
+                    m_integral = std::clamp(newIntegral, m_integral, integral_t(0));
                 }
             }
         }

--- a/lib/src/Pid.cpp
+++ b/lib/src/Pid.cpp
@@ -98,7 +98,7 @@ Pid::update()
 
                         // Anti windup gain is 3
                         antiWindup = 3 * (pidResult - achievedValue);
-
+ 
                         // Disable anti-windup if integral part dominates. But only if it counteracts p.
                         if (m_i < 0 && m_p < 0 && m_i < 3 * m_p) {
                             antiWindup = 0;

--- a/lib/src/Pid.cpp
+++ b/lib/src/Pid.cpp
@@ -29,6 +29,9 @@ Pid::update()
             active(true);
         }
         auto inputError = input->setting() - input->value();
+        if (m_inputFailureCount >= 10) {
+            m_filter.reset(inputError);
+        }
         m_filter.add(inputError);
         m_inputFailureCount = 0;
     } else {

--- a/lib/test_catch/PidTest.cpp
+++ b/lib/test_catch/PidTest.cpp
@@ -87,6 +87,7 @@ SCENARIO("PID Test with mock actuator", "[pid]")
 
         CHECK(pid.p() == Approx(10).epsilon(0.001));
         CHECK(pid.i() == Approx(10).epsilon(0.001));
+        CHECK(pid.integral() == Approx(2000).epsilon(0.001));
         CHECK(pid.d() == 0);
         CHECK(actuator->setting() == Approx(10.0 * (1.0 + 2000 * 1.0 / 2000)).epsilon(0.001));
     }
@@ -113,6 +114,7 @@ SCENARIO("PID Test with mock actuator", "[pid]")
         CHECK(pid.error() == Approx(1.23).epsilon(0.01)); // the filter introduces some delay, which is why this is not 1.0
         CHECK(pid.p() == Approx(12.3).epsilon(0.01));
         CHECK(pid.i() == Approx(accumulatedError * (10.0 / 2000)).epsilon(0.001));
+        CHECK(pid.integral() == Approx(accumulatedError).epsilon(0.001));
         CHECK(pid.d() == Approx(-10 * 9.0 / 900 * 200).epsilon(0.001));
 
         CHECK(actuator->setting() == pid.p() + pid.i() + pid.d());
@@ -140,6 +142,7 @@ SCENARIO("PID Test with mock actuator", "[pid]")
         CHECK(pid.error() == Approx(-1.23).epsilon(0.01)); // the filter introduces some delay, which is why this is not 1.0
         CHECK(pid.p() == Approx(12.3).epsilon(0.01));
         CHECK(pid.i() == Approx(accumulatedError * (-10.0 / 2000)).epsilon(0.001));
+        CHECK(pid.integral() == Approx(accumulatedError).epsilon(0.001));
         CHECK(pid.d() == Approx(-10 * 9.0 / 900 * 200).epsilon(0.001));
 
         CHECK(actuator->setting() == pid.p() + pid.i() + pid.d());
@@ -166,6 +169,7 @@ SCENARIO("PID Test with mock actuator", "[pid]")
         CHECK(integratorValueWithoutAntiWindup == Approx(50.0).epsilon(0.01));
         CHECK(pid.p() == Approx(10).epsilon(0.01));
         CHECK(pid.i() == Approx(10).epsilon(0.01)); // anti windup limits this to 10
+        CHECK(pid.integral() == Approx(2000).epsilon(0.001));
         CHECK(pid.d() == Approx(0).margin(0.01));
 
         CHECK(actuator->setting() == Approx(20).epsilon(0.01));
@@ -181,6 +185,7 @@ SCENARIO("PID Test with mock actuator", "[pid]")
         CHECK(integratorValueWithoutAntiWindup == Approx(-50.0).epsilon(0.01));
         CHECK(pid.p() == Approx(-10).epsilon(0.01));
         CHECK(pid.i() == Approx(0).margin(0.01)); // anti windup limits this to 0
+        CHECK(pid.integral() == Approx(0).margin(0.01));
         CHECK(pid.d() == Approx(0).margin(0.01));
 
         CHECK(actuator->setting() == Approx(0).margin(0.01));
@@ -222,6 +227,7 @@ SCENARIO("PID Test with mock actuator", "[pid]")
         CHECK(integratorValueWithoutAntiWindup == Approx(-50.0).epsilon(0.01));
         CHECK(pid.p() == Approx(-10).epsilon(0.01));
         CHECK(pid.i() == Approx(0).margin(0.01)); // anti windup limits this to 0
+        CHECK(pid.integral() == Approx(0).margin(0.01));
         CHECK(pid.d() == Approx(0).margin(0.01));
 
         CHECK(actuator->setting() == Approx(0).margin(0.01));
@@ -248,7 +254,7 @@ SCENARIO("PID Test with mock actuator", "[pid]")
         double integratorValueWithoutAntiWindup = accumulatedError * (10.0 / 2000);
         CHECK(integratorValueWithoutAntiWindup == Approx(50.0).epsilon(0.01));
         CHECK(pid.p() == Approx(10).epsilon(0.01));
-        CHECK(pid.i() == Approx(13.33).epsilon(0.01)); // anti windup limits this to 13.33 (clipped output + proportional part / 3)
+        CHECK(pid.i() == Approx(13.33).epsilon(0.01)); // anti windup limits this to 13.33 (clipped output + error / 3)
         CHECK(pid.d() == Approx(0).margin(0.01));
 
         CHECK(actuator->setting() == Approx(23.33).epsilon(0.01));

--- a/lib/test_catch/PidTest.cpp
+++ b/lib/test_catch/PidTest.cpp
@@ -77,18 +77,18 @@ SCENARIO("PID Test with mock actuator", "[pid]")
         }
 
         CHECK(pid.p() == Approx(10).epsilon(0.001));
-        CHECK(pid.i() == Approx(5).epsilon(0.05));
+        CHECK(pid.i() == Approx(5).epsilon(0.001));
         CHECK(pid.d() == 0);
-        CHECK(actuator->setting() == Approx(10.0 * (1.0 + 1000 * 1.0 / 2000)).epsilon(0.02));
+        CHECK(actuator->setting() == Approx(10.0 * (1.0 + 1000 * 1.0 / 2000)).epsilon(0.001));
 
         for (int32_t i = 0; i < 1000; ++i) {
             pid.update();
         }
 
         CHECK(pid.p() == Approx(10).epsilon(0.001));
-        CHECK(pid.i() == Approx(10).epsilon(0.05));
+        CHECK(pid.i() == Approx(10).epsilon(0.001));
         CHECK(pid.d() == 0);
-        CHECK(actuator->setting() == Approx(10.0 * (1.0 + 2000 * 1.0 / 2000)).epsilon(0.02));
+        CHECK(actuator->setting() == Approx(10.0 * (1.0 + 2000 * 1.0 / 2000)).epsilon(0.001));
     }
 
     WHEN("Proportional, Integral and Derivative are enabled, the output value is correct with positive Kp")
@@ -110,10 +110,10 @@ SCENARIO("PID Test with mock actuator", "[pid]")
         }
 
         CHECK(mockVal == 29);
-        CHECK(pid.error() == Approx(1.2).epsilon(0.05)); // the filter introduces some delay, which is why this is not 1.0
-        CHECK(pid.p() == Approx(12).epsilon(0.05));
-        CHECK(pid.i() == Approx(accumulatedError * (10.0 / 2000)).epsilon(0.01));
-        CHECK(pid.d() == Approx(-10 * 9.0 / 900 * 200).epsilon(0.01));
+        CHECK(pid.error() == Approx(1.23).epsilon(0.01)); // the filter introduces some delay, which is why this is not 1.0
+        CHECK(pid.p() == Approx(12.3).epsilon(0.01));
+        CHECK(pid.i() == Approx(accumulatedError * (10.0 / 2000)).epsilon(0.001));
+        CHECK(pid.d() == Approx(-10 * 9.0 / 900 * 200).epsilon(0.001));
 
         CHECK(actuator->setting() == pid.p() + pid.i() + pid.d());
     }
@@ -137,10 +137,10 @@ SCENARIO("PID Test with mock actuator", "[pid]")
         }
 
         CHECK(mockVal == 21);
-        CHECK(pid.error() == Approx(-1.2).epsilon(0.05)); // the filter introduces some delay, which is why this is not 1.0
-        CHECK(pid.p() == Approx(12).epsilon(0.05));
-        CHECK(pid.i() == Approx(accumulatedError * (-10.0 / 2000)).epsilon(0.01));
-        CHECK(pid.d() == Approx(-10 * 9.0 / 900 * 200).epsilon(0.01));
+        CHECK(pid.error() == Approx(-1.23).epsilon(0.01)); // the filter introduces some delay, which is why this is not 1.0
+        CHECK(pid.p() == Approx(12.3).epsilon(0.01));
+        CHECK(pid.i() == Approx(accumulatedError * (-10.0 / 2000)).epsilon(0.001));
+        CHECK(pid.d() == Approx(-10 * 9.0 / 900 * 200).epsilon(0.001));
 
         CHECK(actuator->setting() == pid.p() + pid.i() + pid.d());
     }
@@ -163,7 +163,7 @@ SCENARIO("PID Test with mock actuator", "[pid]")
         }
 
         double integratorValueWithoutAntiWindup = accumulatedError * (10.0 / 2000);
-        CHECK(integratorValueWithoutAntiWindup == Approx(50.0).epsilon(0.05));
+        CHECK(integratorValueWithoutAntiWindup == Approx(50.0).epsilon(0.01));
         CHECK(pid.p() == Approx(10).epsilon(0.01));
         CHECK(pid.i() == Approx(10).epsilon(0.01)); // anti windup limits this to 10
         CHECK(pid.d() == Approx(0).margin(0.01));
@@ -178,7 +178,7 @@ SCENARIO("PID Test with mock actuator", "[pid]")
         }
 
         integratorValueWithoutAntiWindup = accumulatedError * (10.0 / 2000);
-        CHECK(integratorValueWithoutAntiWindup == Approx(-50.0).epsilon(0.05));
+        CHECK(integratorValueWithoutAntiWindup == Approx(-50.0).epsilon(0.01));
         CHECK(pid.p() == Approx(-10).epsilon(0.01));
         CHECK(pid.i() == Approx(0).margin(0.01)); // anti windup limits this to 0
         CHECK(pid.d() == Approx(0).margin(0.01));
@@ -204,7 +204,7 @@ SCENARIO("PID Test with mock actuator", "[pid]")
         }
 
         double integratorValueWithoutAntiWindup = accumulatedError * (-10.0 / 2000);
-        CHECK(integratorValueWithoutAntiWindup == Approx(50.0).epsilon(0.05));
+        CHECK(integratorValueWithoutAntiWindup == Approx(50.0).epsilon(0.01));
         CHECK(pid.p() == Approx(10).epsilon(0.01));
         CHECK(pid.i() == Approx(10).epsilon(0.01)); // anti windup limits this to 10
         CHECK(pid.d() == Approx(0).margin(0.01));
@@ -219,7 +219,7 @@ SCENARIO("PID Test with mock actuator", "[pid]")
         }
 
         integratorValueWithoutAntiWindup = accumulatedError * (-10.0 / 2000);
-        CHECK(integratorValueWithoutAntiWindup == Approx(-50.0).epsilon(0.05));
+        CHECK(integratorValueWithoutAntiWindup == Approx(-50.0).epsilon(0.01));
         CHECK(pid.p() == Approx(-10).epsilon(0.01));
         CHECK(pid.i() == Approx(0).margin(0.01)); // anti windup limits this to 0
         CHECK(pid.d() == Approx(0).margin(0.01));
@@ -246,7 +246,7 @@ SCENARIO("PID Test with mock actuator", "[pid]")
         pid.update();
 
         double integratorValueWithoutAntiWindup = accumulatedError * (10.0 / 2000);
-        CHECK(integratorValueWithoutAntiWindup == Approx(50.0).epsilon(0.05));
+        CHECK(integratorValueWithoutAntiWindup == Approx(50.0).epsilon(0.01));
         CHECK(pid.p() == Approx(10).epsilon(0.01));
         CHECK(pid.i() == Approx(13.33).epsilon(0.01)); // anti windup limits this to 13.33 (clipped output + proportional part / 3)
         CHECK(pid.d() == Approx(0).margin(0.01));
@@ -261,7 +261,7 @@ SCENARIO("PID Test with mock actuator", "[pid]")
         }
 
         integratorValueWithoutAntiWindup = accumulatedError * (10.0 / 2000);
-        CHECK(integratorValueWithoutAntiWindup == Approx(-50.0).epsilon(0.05));
+        CHECK(integratorValueWithoutAntiWindup == Approx(-50.0).epsilon(0.01));
         CHECK(pid.p() == Approx(-10).epsilon(0.01));
         CHECK(pid.i() == Approx(0).margin(0.01)); // anti windup limits this to 0
         CHECK(pid.d() == Approx(0).margin(0.01));
@@ -287,7 +287,7 @@ SCENARIO("PID Test with mock actuator", "[pid]")
         }
 
         double integratorValueWithoutAntiWindup = accumulatedError * (-10.0 / 2000);
-        CHECK(integratorValueWithoutAntiWindup == Approx(50.0).epsilon(0.05));
+        CHECK(integratorValueWithoutAntiWindup == Approx(50.0).epsilon(0.01));
         CHECK(pid.p() == Approx(10).epsilon(0.01));
         CHECK(pid.i() == Approx(13.33).epsilon(0.01)); // anti windup limits this to 13.33 (clipped output + proportional part / 3)
         CHECK(pid.d() == Approx(0).margin(0.01));
@@ -302,7 +302,7 @@ SCENARIO("PID Test with mock actuator", "[pid]")
         }
 
         integratorValueWithoutAntiWindup = accumulatedError * (-10.0 / 2000);
-        CHECK(integratorValueWithoutAntiWindup == Approx(-50.0).epsilon(0.05));
+        CHECK(integratorValueWithoutAntiWindup == Approx(-50.0).epsilon(0.01));
         CHECK(pid.p() == Approx(-10).epsilon(0.01));
         CHECK(pid.i() == Approx(0).margin(0.01)); // anti windup limits this to 0
         CHECK(pid.d() == Approx(0).margin(0.01));
@@ -478,14 +478,14 @@ SCENARIO("PID Test with PWM actuator", "[pid]")
         run1000seconds();
 
         CHECK(pid.p() == Approx(10).epsilon(0.001));
-        CHECK(pid.i() == Approx(5).epsilon(0.05));
+        CHECK(pid.i() == Approx(5).epsilon(0.01));
         CHECK(pid.d() == 0);
         CHECK(actuator->setting() == Approx(10.0 * (1.0 + 1000 * 1.0 / 2000)).epsilon(0.02));
 
         run1000seconds();
 
         CHECK(pid.p() == Approx(10).epsilon(0.001));
-        CHECK(pid.i() == Approx(10).epsilon(0.05));
+        CHECK(pid.i() == Approx(10).epsilon(0.01));
         CHECK(pid.d() == 0);
         CHECK(actuator->setting() == Approx(10.0 * (1.0 + 2000 * 1.0 / 2000)).epsilon(0.02));
     }
@@ -518,9 +518,9 @@ SCENARIO("PID Test with PWM actuator", "[pid]")
         }
 
         CHECK(mockVal == 29);
-        CHECK(pid.error() == Approx(1.2).epsilon(0.05)); // the filter introduces some delay, which is why this is not 1.0
-        CHECK(pid.p() == Approx(12).epsilon(0.05));
-        CHECK(pid.i() == Approx(accumulatedError * (10.0 / 2000)).epsilon(0.05));
+        CHECK(pid.error() == Approx(1.23).epsilon(0.01)); // the filter introduces some delay, which is why this is not 1.0
+        CHECK(pid.p() == Approx(12.3).epsilon(0.01));
+        CHECK(pid.i() == Approx(accumulatedError * (10.0 / 2000)).epsilon(0.01));
         CHECK(pid.d() == Approx(-10 * 9.0 / 900 * 200).epsilon(0.01));
 
         CHECK(actuator->setting() == pid.p() + pid.i() + pid.d());
@@ -554,9 +554,9 @@ SCENARIO("PID Test with PWM actuator", "[pid]")
         }
 
         CHECK(mockVal == 21);
-        CHECK(pid.error() == Approx(-1.2).epsilon(0.05)); // the filter introduces some delay, which is why this is not 1.0
-        CHECK(pid.p() == Approx(12).epsilon(0.05));
-        CHECK(pid.i() == Approx(accumulatedError * (-10.0 / 2000)).epsilon(0.05));
+        CHECK(pid.error() == Approx(-1.23).epsilon(0.01)); // the filter introduces some delay, which is why this is not 1.0
+        CHECK(pid.p() == Approx(12.3).epsilon(0.01));
+        CHECK(pid.i() == Approx(accumulatedError * (-10.0 / 2000)).epsilon(0.01));
         CHECK(pid.d() == Approx(-10 * 9.0 / 900 * 200).epsilon(0.01));
 
         CHECK(actuator->setting() == pid.p() + pid.i() + pid.d());


### PR DESCRIPTION
PWM was not reaching 100% due to aggressive anti-windup in PID.
This PR changes how it is calculated:
- Integral fixed point precision is changed to match normal precision
- Integral is incremented with actual error and not scaled by 1/Ti before adding

We should probably adapt devcon to scale integral from C*s to C*h to avoid very large numbers. Needs discussion on where to apply unit conversion/scaling.

Added:
- Reset PID input filter to actual input value after the input has been invalid for over 10 seconds and on system init. This prevents a very high derivative at startup.