### PR TITLE
rework built docker images; enable travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,8 +19,6 @@ env:
 script:
   - cd ./docker
   - docker-compose run --rm compiler bash run-ci.sh
-  - bash build-simulator.sh
-  - bash build-flasher.sh
 
 notifications:
   slack:
@@ -30,6 +28,8 @@ before_deploy:
   docker login -u ${DOCKER_USER} -p ${DOCKER_PASSWORD};
   export CLEAN_TRAVIS_BRANCH=$(echo "${TRAVIS_BRANCH}" | tr '/' '-' | tr '[:upper:]' '[:lower:]');
   export TAG_VERSION=$(git describe --tags);
+  bash build-simulator.sh;
+  bash build-flasher.sh;
 
 deploy:
   # Deploy latest and version tag to Docker Hub on tagged commits

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,13 +4,49 @@ sudo: required
 
 services:
   - docker
-  
+
+# Required Travis env variables:
+# - DOCKER_USER
+# - DOCKER_PASSWORD (secret)
+# - GITHUB_REPO
+
 script:
   - cd ./docker
-  - docker-compose pull compiler
   - docker-compose run --rm compiler bash run-ci.sh
+  - bash build-simulator.sh
+  - bash build-flasher.sh
 
 notifications:
   slack:
     secure: AoLzFHi7c7sRdcsMIzCgG3amg/1acImECO21Q3LXf6i6++ytqrvgTiQMQp9k1XJq+WVlrRiP7NDl3o8oMQv9nR/xrNXhosYHXVHAYY/B1nh4jl4pp8hPTMQUJcac64w1zbJMMqlABbawelVg8qF4zn+TNX+io8APERoycBpQgT4=
 
+before_deploy:
+  docker login -u ${DOCKER_USER} -p ${DOCKER_PASSWORD};
+  export CLEAN_TRAVIS_BRANCH=$(echo "${TRAVIS_BRANCH}" | tr '/' '-' | tr '[:upper:]' '[:lower:]');
+  export TAG_VERSION=$(git describe --tags);
+  export SIM_REPO=brewblox/firmware-simulator;
+  export FLASH_REPO=brewblox/firmware-flasher;
+
+deploy:
+  # Deploy latest and version tag to Docker Hub on tagged commits
+  - provider: script
+    script:
+      bash push-local.sh ${SIM_REPO} latest;
+      bash push-local.sh ${SIM_REPO} ${TAG_VERSION};
+      bash push-local.sh ${FLASH_REPO} latest;
+      bash push-local.sh ${FLASH_REPO} ${TAG_VERSION};
+    skip_cleanup: true
+    on:
+      tags: true
+
+  # Deploy to Docker Hub on any push to an upstream development branch, tagged as branch name
+  - provider: script
+    script:
+      bash push-local.sh ${SIM_REPO} ${CLEAN_TRAVIS_BRANCH};
+      bash push-local.sh ${FLASH_REPO} ${CLEAN_TRAVIS_BRANCH};
+    skip_cleanup: true
+    on:
+      tags: false
+      repo: ${GITHUB_REPO}
+      all_branches: true
+      condition: ${TRAVIS_BRANCH} != master

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,16 @@ sudo: required
 services:
   - docker
 
+env:
+  global:
+    # Both docker and github repo names are case sensitive
+    - SIM_REPO=brewblox/firmware-simulator
+    - FLASH_REPO=brewblox/firmware-flasher
+    - GITHUB_REPO=BrewBlox/brewblox-firmware
+
 # Required Travis env variables:
 # - DOCKER_USER
 # - DOCKER_PASSWORD (secret)
-# - GITHUB_REPO
 
 script:
   - cd ./docker
@@ -24,8 +30,6 @@ before_deploy:
   docker login -u ${DOCKER_USER} -p ${DOCKER_PASSWORD};
   export CLEAN_TRAVIS_BRANCH=$(echo "${TRAVIS_BRANCH}" | tr '/' '-' | tr '[:upper:]' '[:lower:]');
   export TAG_VERSION=$(git describe --tags);
-  export SIM_REPO=brewblox/firmware-simulator;
-  export FLASH_REPO=brewblox/firmware-flasher;
 
 deploy:
   # Deploy latest and version tag to Docker Hub on tagged commits

--- a/docker/build-compiler.sh
+++ b/docker/build-compiler.sh
@@ -1,0 +1,7 @@
+#! /usr/bin/env bash
+set -e
+
+# The compiler image is expected to remain relatively stable
+# It does not contain any firmware code - just the software required to compile the firmware
+
+docker build -t brewblox/firmware-compiler compiler

--- a/docker/build-flasher.sh
+++ b/docker/build-flasher.sh
@@ -4,16 +4,16 @@ set -e
 docker run \
     --rm \
     --volume $(pwd)/../:/firmware \
-    --name simulator-compiler \
+    --name flasher-compiler \
     brewblox/firmware-compiler \
     bash -c '
         set -e
         cd /firmware/build
         rm -rf /firmware/docker/simulator/target
         bash compile-proto.sh
-        make clean APP=brewblox PLATFORM=gcc
-        make APP=brewblox PLATFORM=gcc
-        cp -r /firmware/build/target /firmware/docker/simulator/target
+        make clean APP=brewblox PLATFORM=p1
+        make APP=brewblox PLATFORM=p1
+        cp -r /firmware/build/target/brewblox-p1 /firmware/docker/flasher/brewblox
     '
 
-docker build -t brewblox/firmware-simulator:local simulator
+docker build -t brewblox/firmware-flasher:local flasher

--- a/docker/build-flasher.sh
+++ b/docker/build-flasher.sh
@@ -13,7 +13,10 @@ docker run \
         bash compile-proto.sh
         make clean APP=brewblox PLATFORM=p1
         make APP=brewblox PLATFORM=p1
-        cp -r /firmware/build/target/brewblox-p1 /firmware/docker/flasher/brewblox
+        cp -r /firmware/build/target/brewblox-p1 /firmware/docker/flasher/brewblox-p1
+        make clean APP=brewblox PLATFORM=photon
+        make APP=brewblox PLATFORM=photon
+        cp -r /firmware/build/target/brewblox-photon /firmware/docker/flasher/brewblox-photon
     '
 
 docker build -t brewblox/firmware-flasher:local flasher

--- a/docker/build-particle.sh
+++ b/docker/build-particle.sh
@@ -1,0 +1,7 @@
+#! /usr/bin/env bash
+set -e
+
+# The particle image is expected to remain relatively stable
+# It wraps the Particle CLI in a docker image, so it can easily be used to flash the firmware
+
+docker build -t brewblox/firmware-particle particle

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,29 +1,15 @@
 version: '2'
 services:
   compiler:
-    build: ./compiler/
     image: brewblox/firmware-compiler
     container_name: firmware-compiler
     privileged: true
-    # user: 1000:1000 # set this to what running 'id' on a shell returns to prevent the build results being owned by root 
     volumes:
         - ../:/firmware
-        # - "/etc/timezone:/etc/timezone:ro"
-        # - "/etc/localtime:/etc/localtime:ro"
     command: tail -f /dev/null
-    # environment:
-    #    - COMPOSE_CONVERT_WINDOWS_PATHS=1
 
-  simulator-compiler:
-    build: ./simulator-compiler/
-    image: brewblox/firmware-simulator-compiler
-    container_name: firmware-simulator-compiler
-    volumes:
-        - ../:/firmware
-        
   simulator:
-    build: ./simulator/
-    image: brewblox/firmware-simulator:develop
+    image: brewblox/firmware-simulator:local
     privileged: true
     container_name: firmware-simulator
     volumes:
@@ -34,9 +20,8 @@ services:
         - "8332:8332"
         # http
         - "8380:80"
-        
+
   coverage-simulator:
-    build: ./compiler/
     image: brewblox/firmware-compiler
     container_name: firmware-coverage-simulator
     volumes:
@@ -50,9 +35,4 @@ services:
         - "8380:80"
         # websocket display emulation
         - "8380:7376"
-    command: bash run-simulator.sh        
-
-networks:
-    default:
-      driver: bridge
-
+    command: bash run-simulator.sh

--- a/docker/flasher/.gitignore
+++ b/docker/flasher/.gitignore
@@ -1,0 +1,1 @@
+brewblox

--- a/docker/flasher/.gitignore
+++ b/docker/flasher/.gitignore
@@ -1,1 +1,2 @@
-brewblox
+brewblox-p1
+brewblox-photon

--- a/docker/flasher/Dockerfile
+++ b/docker/flasher/Dockerfile
@@ -1,0 +1,17 @@
+FROM brewblox/firmware-particle
+
+WORKDIR /app
+
+COPY ./brewblox/brewblox.bin ./
+COPY ./serial-switcher.py ./
+
+RUN echo 'python serial-switcher.py' > ./prepare \
+    && echo 'node_modules/.bin/particle flash --usb --yes brewblox.bin' > ./flash
+
+ENTRYPOINT [ "bash" ]
+
+# The container must be restarted after preparing the device
+# Example calls:
+
+# docker run --rm --privileged brewblox/firmware-flasher:local prepare
+# docker run --rm --privileged brewblox/firmware-flasher:local flash

--- a/docker/flasher/Dockerfile
+++ b/docker/flasher/Dockerfile
@@ -1,12 +1,29 @@
 FROM brewblox/firmware-particle
 
 WORKDIR /app
+ENV PARTICLE_VERSION=0.8.0-rc.12
+ENV PARTICLE_RELEASES=https://github.com/particle-iot/firmware/releases/download/v${PARTICLE_VERSION}
 
-COPY ./brewblox/brewblox.bin ./
+
+RUN apt-get update \
+    && apt-get install -y usbutils \
+    && echo 'python serial-switcher.py' > ./prepare \
+    \
+    && curl -sL -o bootloader-p1.bin ${PARTICLE_RELEASES}/bootloader-${PARTICLE_VERSION}-p1.bin \
+    && curl -sL -o system-part1-p1.bin ${PARTICLE_RELEASES}/system-part1-${PARTICLE_VERSION}-p1.bin \
+    && curl -sL -o system-part2-p1.bin ${PARTICLE_RELEASES}/system-part2-${PARTICLE_VERSION}-p1.bin \
+    \
+    && curl -sL -o bootloader-photon.bin ${PARTICLE_RELEASES}/bootloader-${PARTICLE_VERSION}-photon.bin \
+    && curl -sL -o system-part1-photon.bin ${PARTICLE_RELEASES}/system-part1-${PARTICLE_VERSION}-photon.bin \
+    && curl -sL -o system-part2-photon.bin ${PARTICLE_RELEASES}/system-part2-${PARTICLE_VERSION}-photon.bin
+
+
+COPY ./brewblox-p1 ./brewblox-p1
+COPY ./brewblox-photon ./brewblox-photon
 COPY ./serial-switcher.py ./
+COPY ./flash ./
+COPY ./bootloader ./
 
-RUN echo 'python serial-switcher.py' > ./prepare \
-    && echo 'node_modules/.bin/particle flash --usb --yes brewblox.bin' > ./flash
 
 ENTRYPOINT [ "bash" ]
 
@@ -15,3 +32,4 @@ ENTRYPOINT [ "bash" ]
 
 # docker run --rm --privileged brewblox/firmware-flasher:local prepare
 # docker run --rm --privileged brewblox/firmware-flasher:local flash
+# docker run --rm --privileged -it brewblox/firmware-flasher:local bootloader

--- a/docker/flasher/bootloader
+++ b/docker/flasher/bootloader
@@ -1,0 +1,15 @@
+#! /usr/bin/env bash
+set -e
+
+USB_FLASH="node_modules/.bin/particle flash --usb --yes"
+SERIAL_FLASH="node_modules/.bin/particle serial flash"
+
+if [[ -n $(lsusb -d 2b04:c006) ]]; then
+    echo "Flashing Photon bootloader..."
+    ${SERIAL_FLASH} bootloader-photon.bin
+fi
+
+if [[ -n $(lsusb -d 2b04:c008) ]]; then
+    echo "Flashing P1 bootloader..."
+    ${SERIAL_FLASH} bootloader-p1.bin
+fi

--- a/docker/flasher/flash
+++ b/docker/flasher/flash
@@ -1,0 +1,24 @@
+#! /usr/bin/env bash
+set -e
+
+USB_FLASH="node_modules/.bin/particle flash --usb --yes"
+
+if [[ -n $(lsusb -d 2b04:d006) ]]; then
+    echo "Flashing Photon..."
+    echo "Flashing System 1 file..."
+    ${USB_FLASH} system-part1-photon.bin
+    echo "Flashing System 2 file..."
+    ${USB_FLASH} system-part2-photon.bin
+    echo "Flashing Firmware file..."
+    ${USB_FLASH} brewblox-photon/brewblox.bin
+fi
+
+if [[ -n $(lsusb -d 2b04:d008) ]]; then
+    echo "Flashing P1..."
+    echo "Flashing System 1 file..."
+    ${USB_FLASH} system-part1-p1.bin
+    echo "Flashing System 2 file..."
+    ${USB_FLASH} system-part2-p1.bin
+    echo "Flashing Firmware file..."
+    ${USB_FLASH} brewblox-p1/brewblox.bin
+fi

--- a/docker/flasher/serial-switcher.py
+++ b/docker/flasher/serial-switcher.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python
+
+import sys
+
+import serial
+
+baudRate = 14400
+neutralBaudRate = 9600
+portName = "/dev/ttyACM0"
+
+if len(sys.argv) > 1:
+    portName = int(sys.argv[1])
+
+if len(sys.argv) > 2:
+    baudRate = sys.argv[2]
+
+try:
+    ser = serial.Serial(portName, baudRate)
+    ser.close()
+    ser = serial.Serial(portName, neutralBaudRate)
+    ser.close()
+
+except Exception:
+    pass

--- a/docker/particle/Dockerfile
+++ b/docker/particle/Dockerfile
@@ -1,0 +1,10 @@
+FROM node:latest
+
+WORKDIR /app
+
+RUN apt-get update \
+    && npm install particle-cli \
+    && apt-get install -y dfu-util python-pip \
+    && pip install pyserial
+
+ENTRYPOINT [ "node_modules/.bin/particle" ]

--- a/docker/push-local.sh
+++ b/docker/push-local.sh
@@ -1,0 +1,16 @@
+#! /usr/bin/env bash
+set -e
+
+# The build scripts generate :local tags of images
+# This script retags and pushes those images
+#
+# First argument should always be the docker repo name
+# Second argument is the tag name they should be pushed as
+# Leave this blank to set it to the git branch name
+
+CLEAN_BRANCH_NAME=$(echo "$(git rev-parse --abbrev-ref HEAD)" | tr '/' '-' | tr '[:upper:]' '[:lower:]');
+REPO=$1
+TAG=${2:-${CLEAN_BRANCH_NAME}}
+
+docker tag ${REPO}:local ${REPO}:${TAG}
+docker push ${REPO}:${TAG}

--- a/docker/simulator-compiler/Dockerfile
+++ b/docker/simulator-compiler/Dockerfile
@@ -1,7 +1,0 @@
-FROM brewblox/firmware-compiler
-WORKDIR /firmware/build
-CMD rm -rf  /firmware/docker/simulator/target \
-  && bash compile-proto.sh \
-  && make clean APP=brewblox PLATFORM=gcc \
-  && make APP=brewblox PLATFORM=gcc \
-  && cp -r /firmware/build/target /firmware/docker/simulator/target


### PR DESCRIPTION
@elcojacobs 

Changes:
- Creates simulator and flasher images on upstream push (same logic as other brewblox repositories)
- Adds flasher image:
  - pre-packaged with brewblox.bin
  - Must be run in two steps: 
```
docker run --rm --privileged brewblox/firmware-flasher prepare
docker run --rm --privileged brewblox/firmware-flasher flash
```