### PR TITLE
Alpine firmware flasher

### DIFF
--- a/docker/flasher/Dockerfile
+++ b/docker/flasher/Dockerfile
@@ -5,8 +5,7 @@ ENV PARTICLE_VERSION=1.0.0
 ENV PARTICLE_RELEASES=https://github.com/particle-iot/firmware/releases/download/v${PARTICLE_VERSION}
 
 
-RUN apt-get update \
-    && apt-get install -y usbutils \
+RUN apk add --no-cache usbutils curl bash \
     && echo 'python serial-switcher.py' > ./prepare \
     \
     && curl -sL -o bootloader-p1.bin ${PARTICLE_RELEASES}/bootloader-${PARTICLE_VERSION}-p1.bin \
@@ -15,7 +14,8 @@ RUN apt-get update \
     \
     && curl -sL -o bootloader-photon.bin ${PARTICLE_RELEASES}/bootloader-${PARTICLE_VERSION}-photon.bin \
     && curl -sL -o system-part1-photon.bin ${PARTICLE_RELEASES}/system-part1-${PARTICLE_VERSION}-photon.bin \
-    && curl -sL -o system-part2-photon.bin ${PARTICLE_RELEASES}/system-part2-${PARTICLE_VERSION}-photon.bin
+    && curl -sL -o system-part2-photon.bin ${PARTICLE_RELEASES}/system-part2-${PARTICLE_VERSION}-photon.bin \
+    && apk del curl
 
 
 COPY ./brewblox-p1 ./brewblox-p1

--- a/docker/particle/Dockerfile
+++ b/docker/particle/Dockerfile
@@ -1,10 +1,13 @@
-FROM node:11
+FROM node:11-alpine
 
 WORKDIR /app
 
-RUN apt-get update \
-    && npm install particle-cli \
-    && apt-get install -y dfu-util python-pip \
-    && pip install pyserial
+RUN apk add --no-cache make gcc g++ python linux-headers udev \
+  && npm install serialport --build-from-source=serialport \
+  && npm install particle-cli \
+  && apk add --no-cache py2-pip \
+  && apk add --no-cache --repository http://dl-3.alpinelinux.org/alpine/edge/testing/ dfu-util \
+  && pip install pyserial \
+  && apk del make gcc g++ linux-headers udev py2-pip
 
 ENTRYPOINT [ "node_modules/.bin/particle" ]


### PR DESCRIPTION
WIP for reducing flasher image size.
I only changed the amd version yet, but it seems to work.

Next steps:
- Update rpi image to also use alpine (do we really need 2? the files seem identical)
- If possible, use node serialport module to trigger DFU and listening mode so we can remove python from the image
- Remove unneeded build artifacts (elf, map, etc). Only binaries need to be included. Should save 80mb