### PR TITLE
EEPROM performance fixes

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -48,6 +48,104 @@
             "problemMatcher": "$gcc"
         },
         {
+            "label": "build_p1_docker",
+            "command": "docker-compose",
+            "args": [
+                "exec",
+                "compiler",
+                "make",
+                "APP=brewblox",
+                "PLATFORM=p1"
+            ],
+            "group": "build",
+            "options": {
+                "cwd": "${workspaceFolder}/docker"
+            },
+            "presentation": {
+                "echo": true,
+                "reveal": "always",
+                "focus": true,
+                "panel": "shared",
+                "showReuseMessage": false,
+                "clear": false
+            },
+            "problemMatcher": "$gcc"
+        },
+        {
+            "label": "flash_p1_docker",
+            "command": "docker-compose",
+            "args": [
+                "exec",
+                "compiler",
+                "make",
+                "APP=brewblox",
+                "PLATFORM=p1",
+                "program-dfu"
+            ],
+            "group": "build",
+            "options": {
+                "cwd": "${workspaceFolder}/docker"
+            },
+            "presentation": {
+                "echo": true,
+                "reveal": "always",
+                "focus": true,
+                "panel": "shared",
+                "showReuseMessage": false,
+                "clear": false
+            },
+            "problemMatcher": "$gcc",
+            "dependsOn": [
+                "trigger_dfu_p1_docker",
+                "restart_compiler",
+            ]
+        },
+        {
+            "label": "trigger_dfu_p1_docker",
+            "command": "docker",
+            "args": [
+                "run",
+                "--rm",
+                "--privileged",
+                "brewblox/firmware-flasher:develop",
+                "trigger-dfu"
+            ],
+            "group": "build",
+            "options": {
+                "cwd": "${workspaceFolder}/docker"
+            },
+            "presentation": {
+                "echo": true,
+                "reveal": "always",
+                "focus": true,
+                "panel": "shared",
+                "showReuseMessage": false,
+                "clear": false
+            },
+            "problemMatcher": "$gcc"
+        },
+        {
+            "label": "restart_compiler",
+            "command": "docker-compose",
+            "args": [
+                "restart",
+                "compiler",
+            ],
+            "group": "build",
+            "options": {
+                "cwd": "${workspaceFolder}/docker"
+            },
+            "presentation": {
+                "echo": true,
+                "reveal": "always",
+                "focus": true,
+                "panel": "shared",
+                "showReuseMessage": false,
+                "clear": false
+            },
+            "problemMatcher": "$gcc"
+        },
+        {
             "label": "touch_gcc",
             "type": "shell",
             "command": "touch",

--- a/app/brewblox/main.cpp
+++ b/app/brewblox/main.cpp
@@ -182,6 +182,10 @@ setup()
 
     StartupScreen::setProgress(100);
 
+    // perform pending EEPROM erase while we're waiting. Can take up to 500ms and stalls all code execution
+    // This avoids having to do it later when writing to EEPROM
+    EEPROM.performPendingErase();
+
     StartupScreen::setStep("Ready!");
 
     while (ticks.millis() < 5000) {

--- a/controlbox/src/cbox/Box.cpp
+++ b/controlbox/src/cbox/Box.cpp
@@ -510,9 +510,14 @@ Box::clearObjects(DataIn& in, HexCrcDataOut& out)
     }
 
     // remove user objects from storage
-    for (auto cit = objects.cbegin(); cit != objects.cend(); cit++) {
-        storage.disposeObject(cit->id());
+    auto cit = objects.cbegin();
+    while (cit != objects.cend()) {
+        auto id = cit->id();
+        cit++;
+        bool mergeDisposed = cit == objects.cend(); // merge disposed blocks on last delete
+        storage.disposeObject(id, mergeDisposed);
     }
+
     // remove all user objects from vector
     objects.clear();
 
@@ -520,7 +525,7 @@ Box::clearObjects(DataIn& in, HexCrcDataOut& out)
 }
 
 /**
- * 
+ * Search scannable buses for new objects and create them
  *
  */
 

--- a/controlbox/src/cbox/EepromObjectStorage.h
+++ b/controlbox/src/cbox/EepromObjectStorage.h
@@ -210,18 +210,21 @@ public:
         return CboxError::OK;
     }
 
-    virtual bool disposeObject(const storage_id_t& id) override final
+    virtual bool disposeObject(const storage_id_t& id, bool mergeDisposed = true) override final
     {
         RegionDataIn block = getObjectReader(id, true); // sets reader to data start of block data
+        bool found = false;
         if (block.available() > 0) {
             // overwrite block type with disposed block
             uint16_t dataStart = reader.offset();
             uint16_t blockTypeOffset = dataStart - objectHeaderLength();
             eeprom.writeByte(blockTypeOffset, static_cast<uint8_t>(BlockType::disposed_block));
-            mergeDisposedBlocks();
-            return true;
+            found = true;
         }
-        return false;
+        if (mergeDisposed) {
+            mergeDisposedBlocks();
+        }
+        return found;
     }
 
     virtual void clear() override final

--- a/controlbox/src/cbox/ObjectStorage.h
+++ b/controlbox/src/cbox/ObjectStorage.h
@@ -19,8 +19,8 @@
 
 #pragma once
 
-#include <functional>
 #include <cstdint>
+#include <functional>
 
 namespace cbox {
 
@@ -42,7 +42,7 @@ public:
     virtual CboxError retrieveObjects(
         const std::function<CboxError(const storage_id_t& id, RegionDataIn&)>& handler)
         = 0;
-    virtual bool disposeObject(const storage_id_t& id) = 0;
+    virtual bool disposeObject(const storage_id_t& id, bool mergeDisposed = true) = 0;
 
     virtual void clear() = 0;
 };

--- a/controlbox/test/Box_test.cpp
+++ b/controlbox/test/Box_test.cpp
@@ -124,11 +124,7 @@ SCENARIO("A controlbox Box")
             box.hexCommunicate();
 
             expected << addCrc("000002020001E90333333333")
-                     << "|" << addCrc("41"        // INVALID_OBJECT_TYPE
-                                      "0200"      // object id 2
-                                      "01"        // profiles 0x01
-                                      "E803"      // object type 1000
-                                      "33333333") // object data
+                     << "|" << addCrc("41") // INVALID_OBJECT_TYPE
                      << "\n";
             CHECK(out->str() == expected.str());
         }
@@ -367,11 +363,7 @@ SCENARIO("A controlbox Box")
             box.hexCommunicate();
 
             expected << addCrc("000002640000E80314141414") << "|" // command repetition
-                     << addCrc("41"                               // status invalid object type
-                               "6400"                             // id 100
-                               "00"                               // profiles 0x00
-                               "FFFF"                             // type InactiveObject
-                               "E803")                            // actual type 1000
+                     << addCrc("41")                              // status invalid object type
                      << "\n";
 
             CHECK(out->str() == expected.str());


### PR DESCRIPTION
When searching EEPROM for a specific block, the storage handler was spooling by actually reading data it didn't even use.
Reading from EEPROM is slow, so this caused very bad EEPROM performance in some scenarios that are EEPROM heavy (clear objects and reset_objects).
The controller code now skips ahead instead of actually reading.

A second change is that when EEPROM storage is full, no new objects are created and the controller returns an error.

I also added to perform a pending page erase at boot, so it won't stall the code later.