### PR TITLE
unique ID in balanced constraint

### DIFF
--- a/app/brewblox/blox/ActuatorAnalogConstraintsProto.cpp
+++ b/app/brewblox/blox/ActuatorAnalogConstraintsProto.cpp
@@ -25,9 +25,14 @@ public:
     {
     }
 
-    cbox::obj_id_t balancerId()
+    cbox::obj_id_t balancerId() const
     {
         return lookup.getId();
+    }
+
+    uint8_t requesterId() const
+    {
+        return m_balanced.requesterId();
     }
 
     virtual uint8_t id() const override final
@@ -98,6 +103,7 @@ getAnalogConstraints(blox_AnalogConstraints& msg, const ActuatorAnalogConstraine
         } break;
         case blox_AnalogConstraint_balanced_tag: {
             auto obj = reinterpret_cast<CboxBalanced*>((*it).get());
+            msg.constraints[i].constraint.balanced.id = obj->requesterId();
             msg.constraints[i].constraint.balanced.balancerId = obj->balancerId();
             msg.constraints[i].constraint.balanced.granted = cnl::unwrap(obj->granted());
         } break;

--- a/app/brewblox/blox/BalancerBlock.h
+++ b/app/brewblox/blox/BalancerBlock.h
@@ -21,7 +21,7 @@ protected:
         Balancer_t* balancerPtr = reinterpret_cast<Balancer_t*>(*arg);
         for (const auto& requester : balancerPtr->clients()) {
             auto act = blox_Balancer_BalancedActuator();
-            act.id = 0;
+            act.id = requester.id;
             act.requested = cnl::unwrap(requester.requested);
             act.granted = cnl::unwrap(requester.granted);
             if (!pb_encode_tag_for_field(stream, field)) {

--- a/app/brewblox/proto/ActuatorPwm.proto
+++ b/app/brewblox/proto/ActuatorPwm.proto
@@ -10,7 +10,7 @@ message ActuatorPwm {
   option (brewblox_msg).objtype = ActuatorPwm;
 
   uint32 actuatorId = 1 [ (brewblox).objtype = ActuatorDigitalInterface, (nanopb).int_size = IS_16 ];
-  uint32 period = 3;
+  uint32 period = 3 [ (brewblox).unit = Time, (brewblox).scale = 1000 ];
   sint32 setting = 4 [ (brewblox).logged = true, (brewblox).scale = 4096, (nanopb).int_size = IS_32 ];
   sint32 value = 5 [ (brewblox).logged = true, (brewblox).scale = 4096, (nanopb).int_size = IS_32, (brewblox).readonly = true ];
   AnalogConstraints constrainedBy = 6;

--- a/app/brewblox/proto/AnalogConstraints.proto
+++ b/app/brewblox/proto/AnalogConstraints.proto
@@ -9,6 +9,7 @@ message AnalogConstraint {
   message Balanced {
     uint32 balancerId = 1 [ (brewblox).objtype = BalancerInterface, (nanopb).int_size = IS_16 ];
     uint32 granted = 2 [ (brewblox).scale = 4096, (brewblox).readonly = true ];
+    uint32 id = 3 [ (brewblox).readonly = true, (nanopb).int_size = IS_8 ];
   }
 
   oneof constraint {

--- a/app/brewblox/proto/Balancer.proto
+++ b/app/brewblox/proto/Balancer.proto
@@ -9,7 +9,7 @@ message Balancer {
   option (brewblox_msg).objtype = Balancer;
 
   message BalancedActuator {
-    uint32 id = 1 [ (brewblox).objtype = ActuatorAnalogInterface, (nanopb).int_size = IS_16, (brewblox).readonly = true ];
+    uint32 id = 1 [ (brewblox).readonly = true, (nanopb).int_size = IS_8 ];
     sint32 requested = 2 [ (brewblox).scale = 4096, (nanopb).int_size = IS_32, (brewblox).readonly = true ];
     sint32 granted = 3 [ (brewblox).scale = 4096, (nanopb).int_size = IS_32, (brewblox).readonly = true ];
   }

--- a/app/brewblox/proto/Balancer.proto
+++ b/app/brewblox/proto/Balancer.proto
@@ -9,9 +9,9 @@ message Balancer {
   option (brewblox_msg).objtype = Balancer;
 
   message BalancedActuator {
-    uint32 id = 1 [ (brewblox).readonly = true, (nanopb).int_size = IS_8 ];
-    sint32 requested = 2 [ (brewblox).scale = 4096, (nanopb).int_size = IS_32, (brewblox).readonly = true ];
-    sint32 granted = 3 [ (brewblox).scale = 4096, (nanopb).int_size = IS_32, (brewblox).readonly = true ];
+    uint32 id = 1 [ (brewblox).logged = true, (brewblox).readonly = true, (nanopb).int_size = IS_8 ];
+    sint32 requested = 2 [ (brewblox).logged = true, (brewblox).scale = 4096, (nanopb).int_size = IS_32, (brewblox).readonly = true ];
+    sint32 granted = 3 [ (brewblox).logged = true, (brewblox).scale = 4096, (nanopb).int_size = IS_32, (brewblox).readonly = true ];
   }
 
   repeated BalancedActuator clients = 1 [ (brewblox).logged = true, (brewblox).readonly = true ];

--- a/app/brewblox/proto/Mutex.proto
+++ b/app/brewblox/proto/Mutex.proto
@@ -8,5 +8,5 @@ package blox;
 message Mutex {
   option (brewblox_msg).objtype = Mutex;
 
-  uint32 differentActuatorWait = 1;
+  uint32 differentActuatorWait = 1 [ (brewblox).unit = Time, (brewblox).scale = 1000 ];
 }

--- a/app/brewblox/proto/Pid.proto
+++ b/app/brewblox/proto/Pid.proto
@@ -41,7 +41,7 @@ message Pid {
   sint32 d = 18 [ (brewblox).logged = true, (brewblox).scale = 4096, (nanopb).int_size = IS_32, (brewblox).readonly = true ];
 
   sint32 error = 19 [ (brewblox).logged = true, (brewblox).unit = DeltaTemp, (brewblox).scale = 4096, (nanopb).int_size = IS_32, (brewblox).readonly = true ];
-  sint32 integral = 20 [ (brewblox).logged = true, (brewblox).unit = DeltaTempTime, (brewblox).scale = 4096, (nanopb).int_size = IS_32, (brewblox).readonly = true ];
-  sint32 derivative = 21 [ (brewblox).logged = true, (brewblox).unit = DeltaTempPerTime, (brewblox).scale = 8388608, (nanopb).int_size = IS_32, (brewblox).readonly = true ];
+  sint32 integral = 20 [ (brewblox).logged = true, (brewblox).unit = DeltaTempLongTime, (brewblox).scale = 14745600, (nanopb).int_size = IS_32, (brewblox).readonly = true ];
+  sint32 derivative = 21 [ (brewblox).logged = true, (brewblox).unit = DeltaTempPerLongTime, (brewblox).scale = 2330, (nanopb).int_size = IS_32, (brewblox).readonly = true ];
   repeated uint32 strippedFields = 99 [ (brewblox).readonly = true, (nanopb).int_size = IS_16, (nanopb).max_count = 4 ];
 }

--- a/app/brewblox/proto/brewblox.proto
+++ b/app/brewblox/proto/brewblox.proto
@@ -46,6 +46,9 @@ message BrewbloxOptions {
     Time = 4;
     InverseTemp = 5;
     DeltaTempTime = 6;
+    LongTime = 7;
+    DeltaTempLongTime = 8;
+    DeltaTempPerLongTime = 9;
   }
   UnitType unit = 1;
   uint32 scale = 2;

--- a/app/brewblox/test/BalancerAndMutexBlock_test.cpp
+++ b/app/brewblox/test/BalancerAndMutexBlock_test.cpp
@@ -159,8 +159,8 @@ SCENARIO("Two PWM actuators can be constrained by a balancer", "[balancer]")
         auto decoded = blox::Balancer();
         testBox.processInputToProto(decoded);
         CHECK(testBox.lastReplyHasStatusOk());
-        CHECK(decoded.ShortDebugString() == "clients { requested: 327680 granted: 204800 } "  // 80*4096, 50*4096
-                                            "clients { requested: 327680 granted: 204800 }"); // 80*4096, 50*4096
+        CHECK(decoded.ShortDebugString() == "clients { id: 1 requested: 327680 granted: 204800 } "  // 80*4096, 50*4096
+                                            "clients { id: 2 requested: 327680 granted: 204800 }"); // 80*4096, 50*4096
     }
 
     // read mutex
@@ -212,7 +212,7 @@ SCENARIO("Two PWM actuators can be constrained by a balancer", "[balancer]")
                                             "period: 4000 setting: 204800 "
                                             "constrainedBy { "
                                             "constraints { "
-                                            "balanced { balancerId: 100 granted: 204800 } "
+                                            "balanced { balancerId: 100 granted: 204800 id: 1 } "
                                             "limiting: true } "
                                             "unconstrained: 327680 }");
     }
@@ -230,7 +230,7 @@ SCENARIO("Two PWM actuators can be constrained by a balancer", "[balancer]")
                                             "period: 4000 setting: 204800 "
                                             "constrainedBy { "
                                             "constraints { "
-                                            "balanced { balancerId: 100 granted: 204800 } "
+                                            "balanced { balancerId: 100 granted: 204800 id: 2 } "
                                             "limiting: true } "
                                             "unconstrained: 327680 }");
     }


### PR DESCRIPTION
This PR adds a unique ID for each balancer client.
The UI can use this to find the actual actuator that holds the balanced constraint and display it in the balancer.