### PR TITLE
Fix new stages added to a filter chain not being initialized properly

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -93,7 +93,6 @@
   "cquery.highlighting.enabled.staticMemberVariables": true,
   "cquery.highlighting.enabled.globalVariables": true,
   "cquery.cacheDirectory": "${workspaceFolder}/.vscode/cquery_cached_index/",
-  "cquery.formatting.enabled": true,
   "C_Cpp.autocomplete": "Disabled",
   "C_Cpp.formatting": "Disabled",
   "C_Cpp.errorSquiggles": "Disabled",
@@ -101,5 +100,8 @@
   "C_Cpp.default.cppStandard": "c++14",
   "C_Cpp.intelliSenseEngineFallback": "Disabled",
   "C_Cpp.default.intelliSenseMode": "clang-x64",
-  "editor.formatOnSave": true
+  "editor.formatOnSave": true,
+  "cquery.formatting.enabled": false,
+  "cquery.diagnostics.onType": false,
+  "cquery.misc.discoverSystemIncludes": false,
 }

--- a/app/brewblox/OneWireScanningFactory.h
+++ b/app/brewblox/OneWireScanningFactory.h
@@ -64,7 +64,6 @@ public:
 
     virtual std::shared_ptr<cbox::Object> scan() override final
     {
-        auto newAddr = OneWireAddress();
         while (true) {
             if (auto newAddr = next()) {
                 bool found = false;

--- a/controlbox/src/cbox/Box.cpp
+++ b/controlbox/src/cbox/Box.cpp
@@ -723,7 +723,7 @@ Box::reloadStoredObject(const obj_id_t& id)
     }
 
     bool handlerCalled = false;
-    auto streamHandler = [this, &cobj, &handlerCalled](RegionDataIn& objInStorage) -> CboxError {
+    auto streamHandler = [&cobj, &handlerCalled](RegionDataIn& objInStorage) -> CboxError {
         handlerCalled = true;
         RegionDataIn objWithoutCrc(objInStorage, objInStorage.available() - 1);
 

--- a/controlbox/src/cbox/ConnectionsStringStream.h
+++ b/controlbox/src/cbox/ConnectionsStringStream.h
@@ -87,7 +87,7 @@ public:
         }
         std::unique_ptr<Connection> retval = std::move(connectionQueue.front());
         connectionQueue.pop();
-        return std::move(retval);
+        return retval;
     }
 };
 } // end namespace cbox

--- a/controlbox/test/Box_test.cpp
+++ b/controlbox/test/Box_test.cpp
@@ -1031,7 +1031,7 @@ SCENARIO("A controlbox Box")
         THEN("A list of IDs of newly created objects is returned")
         {
             expected << addCrc("00000C") << "|"
-                     << addCrc("00")          // status
+                     << addCrc("00")              // status
                      << "," << addCrc("6400E803") // new object id 100
                      << "," << addCrc("6500E803") // new object id 101
                      << "," << addCrc("6600E803") // new object id 102

--- a/lib/inc/ActuatorDigitalChangeLogged.h
+++ b/lib/inc/ActuatorDigitalChangeLogged.h
@@ -66,7 +66,7 @@ public:
         state(val, lastUpdateTime);
     };
 
-    State state() const
+    State state() const override
     {
         return actuator.state();
     };

--- a/lib/inc/Balancer.h
+++ b/lib/inc/Balancer.h
@@ -169,7 +169,7 @@ public:
         return val;
     }
 
-    virtual uint8_t id() const
+    virtual uint8_t id() const override final
     {
         return ID;
     }

--- a/lib/inc/IirFilter.h
+++ b/lib/inc/IirFilter.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include <limits>
 #include <cstdint>
+#include <limits>
 
 #define FILTER_ORDER 6
 
@@ -20,7 +20,6 @@ private:
     int64_t yv[FILTER_ORDER + 1];
     uint8_t paramsIdx;
     int32_t fastStepThreshold;
-    uint8_t fastStepsRemaining;
 
     FilterParams const& params() const;
     int64_t shift(const int64_t val) const;

--- a/lib/src/IirFilter.cpp
+++ b/lib/src/IirFilter.cpp
@@ -11,7 +11,6 @@ IirFilter::IirFilter(const uint8_t& idx, const int32_t& threshold)
     , yv{0}
     , paramsIdx(idx)
     , fastStepThreshold(threshold)
-    , fastStepsRemaining(FILTER_ORDER + 1)
 {
 }
 

--- a/lib/test_catch/FpFilterChainTest.cpp
+++ b/lib/test_catch/FpFilterChainTest.cpp
@@ -195,4 +195,29 @@ SCENARIO("Fixed point filterchain using temp_t")
             CHECK(findStepResponseDelay(chains[6], 0.9) == 2496);
         }
     }
+
+    WHEN("A different filterchain spec is chosen when the filter is in steady state")
+    {
+        auto chain = FpFilterChain<temp_t>(0);
+
+        chain.setParams(3, temp_t(10)); // 5min
+        uint32_t count = 0;
+        while (count++ < 210) {
+            chain.add(temp_t(2));
+        }
+        REQUIRE(chain.read() == Approx(temp_t(1)).margin(1));
+
+        chain.setParams(5, temp_t(10)); // 20min
+        REQUIRE(chain.read() == Approx(temp_t(1)).margin(1));
+
+        THEN("The filter output stays between expected boundaries")
+        {
+            uint32_t count = 0;
+            while (count++ < 100) {
+                chain.add(temp_t(2));
+                CHECK(chain.read() <= temp_t(2));
+                CHECK(chain.read() >= temp_t(0.99));
+            }
+        }
+    }
 }

--- a/lib/test_catch/PidTest.cpp
+++ b/lib/test_catch/PidTest.cpp
@@ -584,8 +584,6 @@ SCENARIO("PID Test with PWM actuator", "[pid]")
         setpoint->setting(20);
         sensor->value(21);
 
-        temp_t mockVal;
-
         auto start = now;
         while (now <= start + 1000'000) {
             if (now >= nextPwmUpdate) {
@@ -625,8 +623,6 @@ SCENARIO("PID Test with PWM actuator", "[pid]")
 
         setpoint->setting(20);
         sensor->value(25);
-
-        temp_t mockVal;
 
         auto start = now;
         while (now <= start + 1000'000) {

--- a/wrapped_make.sh
+++ b/wrapped_make.sh
@@ -8,5 +8,6 @@ rm "$MY_DIR/compile_commands.json"
 pushd "$MY_DIR" > /dev/null
 cat ./**/compile_commands.json > compile_commands.json \
   && sed -i -e ':a;N;$!ba;s/\]\n\n\[/,/g' compile_commands.json
+chmod 777 compile_commands.json
 popd > /dev/null
 rm "compile_commands.json"


### PR DESCRIPTION
When filtering of a PID is set from 5m to 20m, the filter chain is made longer.

The newly added filters were not initialized, which resulted in the error being very high temporarily.