### PR TITLE
Fix mutex wait time not being applied correctly in all cases

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -93,7 +93,6 @@
   "cquery.highlighting.enabled.staticMemberVariables": true,
   "cquery.highlighting.enabled.globalVariables": true,
   "cquery.cacheDirectory": "${workspaceFolder}/.vscode/cquery_cached_index/",
-  "cquery.formatting.enabled": true,
   "C_Cpp.autocomplete": "Disabled",
   "C_Cpp.formatting": "Disabled",
   "C_Cpp.errorSquiggles": "Disabled",
@@ -101,5 +100,8 @@
   "C_Cpp.default.cppStandard": "c++14",
   "C_Cpp.intelliSenseEngineFallback": "Disabled",
   "C_Cpp.default.intelliSenseMode": "clang-x64",
-  "editor.formatOnSave": true
+  "editor.formatOnSave": true,
+  "cquery.formatting.enabled": false,
+  "cquery.diagnostics.onType": false,
+  "cquery.misc.discoverSystemIncludes": false,
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -251,5 +251,49 @@
             },
             "problemMatcher": "$gcc"
         },
+        {
+            "label": "build lib tests local",
+            "type": "shell",
+            "command": "make",
+            "args": [
+                "-C",
+                "../lib/test_catch"
+            ],
+            "group": "build",
+            "options": {
+                "cwd": "${workspaceFolder}/docker"
+            },
+            "presentation": {
+                "echo": true,
+                "reveal": "always",
+                "focus": true,
+                "panel": "shared",
+                "showReuseMessage": false,
+                "clear": true
+            },
+            "problemMatcher": "$gcc"
+        },
+        {
+            "label": "build app tests local",
+            "type": "shell",
+            "command": "make",
+            "args": [
+                "-C",
+                "../app/brewblox/test"
+            ],
+            "group": "build",
+            "options": {
+                "cwd": "${workspaceFolder}/docker"
+            },
+            "presentation": {
+                "echo": true,
+                "reveal": "always",
+                "focus": true,
+                "panel": "shared",
+                "showReuseMessage": false,
+                "clear": true
+            },
+            "problemMatcher": "$gcc"
+        },
     ]
 }

--- a/app/brewblox/OneWireScanningFactory.h
+++ b/app/brewblox/OneWireScanningFactory.h
@@ -64,7 +64,6 @@ public:
 
     virtual std::shared_ptr<cbox::Object> scan() override final
     {
-        auto newAddr = OneWireAddress();
         while (true) {
             if (auto newAddr = next()) {
                 bool found = false;

--- a/app/brewblox/blox/MutexBlock.h
+++ b/app/brewblox/blox/MutexBlock.h
@@ -29,6 +29,7 @@ public:
     {
         blox_Mutex message = blox_Mutex_init_zero;
         message.differentActuatorWait = m_mutex.differentActuatorWait();
+        message.waitRemaining = m_mutex.waitRemaining();
 
         return streamProtoTo(out, &message, blox_Mutex_fields, blox_Mutex_size);
     }
@@ -42,7 +43,9 @@ public:
     virtual cbox::update_t
     update(const cbox::update_t& now) override final
     {
-        return update_never(now);
+        // ensure mutex always has recent system time
+        m_mutex.update(now);
+        return now + 1;
     }
 
     virtual void*

--- a/app/brewblox/proto/Mutex.proto
+++ b/app/brewblox/proto/Mutex.proto
@@ -9,4 +9,5 @@ message Mutex {
   option (brewblox_msg).objtype = Mutex;
 
   uint32 differentActuatorWait = 1 [ (brewblox).unit = Time, (brewblox).scale = 1000 ];
+  uint32 waitRemaining = 2 [ (brewblox).readonly = true, (brewblox).unit = Time, (brewblox).scale = 1000 ];
 }

--- a/app/brewblox/test/BalancerAndMutexBlock_test.cpp
+++ b/app/brewblox/test/BalancerAndMutexBlock_test.cpp
@@ -29,25 +29,12 @@
 #include "proto/test/cpp/Balancer.test.pb.h"
 #include "proto/test/cpp/Mutex.test.pb.h"
 
-SCENARIO("Two PWM actuators can be constrained by a balancer", "[balancer]")
+SCENARIO("Two pin actuators are constrained by a mutex", "[balancer, mutex]")
 {
     BrewBloxTestBox testBox;
     using commands = cbox::Box::CommandID;
 
     testBox.reset();
-
-    // create balancer
-    testBox.put(uint16_t(0)); // msg id
-    testBox.put(commands::CREATE_OBJECT);
-    testBox.put(cbox::obj_id_t(100));
-    testBox.put(uint8_t(0xFF));
-    testBox.put(BalancerBlock::staticTypeId());
-    {
-        auto newBalancer = blox::Balancer();
-        testBox.put(newBalancer);
-    }
-    testBox.processInput();
-    CHECK(testBox.lastReplyHasStatusOk());
 
     // create mutex
     testBox.put(uint16_t(0)); // msg id
@@ -63,204 +50,304 @@ SCENARIO("Two PWM actuators can be constrained by a balancer", "[balancer]")
     testBox.processInput();
     CHECK(testBox.lastReplyHasStatusOk());
 
+    auto setPin = [&testBox](cbox::obj_id_t id, blox::AD_State state) {
+        // configure pin actuator by writing to the object
+        testBox.put(uint16_t(0)); // msg id
+        testBox.put(commands::WRITE_OBJECT);
+        testBox.put(id);
+        testBox.put(uint8_t(0xFF));
+        testBox.put(ActuatorPinBlock::staticTypeId());
+
+        auto pinMsg = blox::ActuatorPin();
+        pinMsg.set_state(state);
+        pinMsg.set_invert(false);
+        auto constraintPtr = pinMsg.mutable_constrainedby()->add_constraints();
+        constraintPtr->set_mutex(101);
+        testBox.put(pinMsg);
+
+        testBox.processInput();
+        CHECK(testBox.lastReplyHasStatusOk());
+    };
+
     // configure pin actuator 1
-    testBox.put(uint16_t(0)); // msg id
-    testBox.put(commands::WRITE_OBJECT);
-    testBox.put(cbox::obj_id_t(10)); // system object 10 is a predefined pin actuator
-    testBox.put(uint8_t(0xFF));
-    testBox.put(ActuatorPinBlock::staticTypeId());
-    {
-        auto newPin = blox::ActuatorPin();
-        newPin.set_state(blox::AD_State_Active);
-        newPin.set_invert(false);
-        auto constraintPtr = newPin.mutable_constrainedby()->add_constraints();
-        constraintPtr->set_mutex(101);
-        testBox.put(newPin);
-    }
-
-    testBox.processInput();
-    CHECK(testBox.lastReplyHasStatusOk());
-
-    // create pwm actuator 1
-    testBox.put(uint16_t(0)); // msg id
-    testBox.put(commands::CREATE_OBJECT);
-    testBox.put(cbox::obj_id_t(201));
-    testBox.put(uint8_t(0xFF));
-    testBox.put(ActuatorPwmBlock::staticTypeId());
-
-    {
-        auto newPwm = blox::ActuatorPwm();
-        newPwm.set_actuatorid(10);
-        newPwm.set_setting(cnl::unwrap(ActuatorAnalog::value_t(80)));
-        newPwm.set_period(4000);
-
-        auto c = newPwm.mutable_constrainedby()->add_constraints();
-        auto balanced = new blox::AnalogConstraint_Balanced();
-        balanced->set_balancerid(100);
-        c->set_allocated_balanced(balanced);
-
-        testBox.put(newPwm);
-    }
-    testBox.processInput();
-    CHECK(testBox.lastReplyHasStatusOk());
-
+    setPin(10, blox::AD_State_Active);
     // configure pin actuator 2
-    testBox.put(uint16_t(0)); // msg id
-    testBox.put(commands::WRITE_OBJECT);
-    testBox.put(cbox::obj_id_t(11)); // system object 11 is a predefined pin actuator
-    testBox.put(uint8_t(0xFF));
-    testBox.put(ActuatorPinBlock::staticTypeId());
+    setPin(11, blox::AD_State_Active);
 
+    THEN("The objects read back as expected")
     {
-        auto newPin = blox::ActuatorPin();
-        newPin.set_state(blox::AD_State_Active);
-        newPin.set_invert(false);
-        auto constraintPtr = newPin.mutable_constrainedby()->add_constraints();
-        constraintPtr->set_mutex(101);
-        testBox.put(newPin);
+        // read mutex
+        testBox.put(uint16_t(0)); // msg id
+        testBox.put(commands::READ_OBJECT);
+        testBox.put(cbox::obj_id_t(101));
+
+        {
+            auto decoded = blox::Mutex();
+            testBox.processInputToProto(decoded);
+            CHECK(testBox.lastReplyHasStatusOk());
+            CHECK(decoded.ShortDebugString() == "differentActuatorWait: 100");
+        }
+
+        // read a pin actuator 1, which is active
+        testBox.put(uint16_t(0)); // msg id
+        testBox.put(commands::READ_OBJECT);
+        testBox.put(cbox::obj_id_t(10));
+
+        {
+            auto decoded = blox::ActuatorPin();
+            testBox.processInputToProto(decoded);
+            CHECK(testBox.lastReplyHasStatusOk());
+            CHECK(decoded.ShortDebugString() == "state: Active constrainedBy { constraints { mutex: 101 } unconstrained: Active }");
+        }
+
+        // read a pin actuator 2, which is constrained and inactive
+        testBox.put(uint16_t(0)); // msg id
+        testBox.put(commands::READ_OBJECT);
+        testBox.put(cbox::obj_id_t(11));
+
+        {
+            auto decoded = blox::ActuatorPin();
+            testBox.processInputToProto(decoded);
+            CHECK(testBox.lastReplyHasStatusOk());
+            CHECK(decoded.ShortDebugString() == "constrainedBy { constraints { mutex: 101 limiting: true } unconstrained: Active }");
+        }
     }
 
-    testBox.processInput();
-    CHECK(testBox.lastReplyHasStatusOk());
-
-    // create pwm actuator 2
-    testBox.put(uint16_t(0)); // msg id
-    testBox.put(commands::CREATE_OBJECT);
-    testBox.put(cbox::obj_id_t(301));
-    testBox.put(uint8_t(0xFF));
-    testBox.put(ActuatorPwmBlock::staticTypeId());
-
+    WHEN("actuator 2 is toggled, it remains constrained while actuator 1 is active")
     {
-        auto newPwm = blox::ActuatorPwm();
-        newPwm.set_actuatorid(11);
-        newPwm.set_setting(cnl::unwrap(ActuatorAnalog::value_t(80)));
-        newPwm.set_period(4000);
+        auto readPin = [&testBox](cbox::obj_id_t id) {
+            testBox.put(uint16_t(0)); // msg id
+            testBox.put(commands::READ_OBJECT);
+            testBox.put(id);
 
-        auto c = newPwm.mutable_constrainedby()->add_constraints();
-        auto balanced = new blox::AnalogConstraint_Balanced();
-        balanced->set_balancerid(100);
-        c->set_allocated_balanced(balanced);
+            auto decoded = blox::ActuatorPin();
+            testBox.processInputToProto(decoded);
+            CHECK(testBox.lastReplyHasStatusOk());
 
-        testBox.put(newPwm);
+            return decoded.state();
+        };
+        setPin(10, blox::AD_State_Active);
+        setPin(11, blox::AD_State_Inactive);
+        testBox.update(1);
+
+        setPin(11, blox::AD_State_Active);
+        CHECK(readPin(11) == blox::AD_State_Inactive);
+        testBox.update(2);
+
+        setPin(11, blox::AD_State_Active);
+        CHECK(readPin(11) == blox::AD_State_Inactive);
+
+        setPin(11, blox::AD_State_Inactive);
+        CHECK(readPin(11) == blox::AD_State_Inactive);
+        testBox.update(3);
+
+        setPin(11, blox::AD_State_Active);
+        CHECK(readPin(11) == blox::AD_State_Inactive);
+        testBox.update(4);
+
+        AND_WHEN("Actuator 1 is turned OFF")
+        {
+            setPin(10, blox::AD_State_Inactive);
+            CHECK(readPin(10) == blox::AD_State_Inactive);
+            testBox.update(5);
+
+            THEN("Actuator 2 can only turn on after the minimum wait time has passed")
+            {
+                testBox.update(6);
+                setPin(11, blox::AD_State_Active);
+                CHECK(readPin(11) == blox::AD_State_Inactive);
+
+                testBox.update(10);
+                setPin(11, blox::AD_State_Active);
+                CHECK(readPin(11) == blox::AD_State_Inactive);
+
+                testBox.update(103);
+                setPin(11, blox::AD_State_Active);
+                CHECK(readPin(11) == blox::AD_State_Inactive);
+
+                testBox.update(104);
+                setPin(11, blox::AD_State_Active);
+                CHECK(readPin(11) == blox::AD_State_Active);
+            }
+
+            THEN("Activating actuator 1 resets the wait time")
+            {
+                setPin(11, blox::AD_State_Active);
+                CHECK(readPin(11) == blox::AD_State_Inactive);
+
+                testBox.update(10);
+                setPin(11, blox::AD_State_Active);
+                CHECK(readPin(11) == blox::AD_State_Inactive);
+
+                testBox.update(50);
+                setPin(10, blox::AD_State_Active);
+                CHECK(readPin(10) == blox::AD_State_Active);
+
+                testBox.update(60);
+                setPin(10, blox::AD_State_Inactive);
+                CHECK(readPin(10) == blox::AD_State_Inactive);
+
+                testBox.update(61);
+                setPin(11, blox::AD_State_Active);
+                CHECK(readPin(11) == blox::AD_State_Inactive);
+
+                testBox.update(120);
+                setPin(11, blox::AD_State_Active);
+                CHECK(readPin(11) == blox::AD_State_Inactive);
+
+                testBox.update(155);
+                setPin(11, blox::AD_State_Active);
+                CHECK(readPin(11) == blox::AD_State_Inactive);
+
+                testBox.update(160);
+                setPin(11, blox::AD_State_Active);
+                CHECK(readPin(11) == blox::AD_State_Active);
+            }
+        }
     }
 
-    testBox.processInput();
-    CHECK(testBox.lastReplyHasStatusOk());
-
-    testBox.update(0);
-    testBox.update(1000);
-
-    // read balancer
-    testBox.put(uint16_t(0)); // msg id
-    testBox.put(commands::READ_OBJECT);
-    testBox.put(cbox::obj_id_t(100));
-
+    WHEN("The pins are driven by 2 balanced PWM actuators")
     {
-        auto decoded = blox::Balancer();
-        testBox.processInputToProto(decoded);
+
+        // create balancer
+        testBox.put(uint16_t(0)); // msg id
+        testBox.put(commands::CREATE_OBJECT);
+        testBox.put(cbox::obj_id_t(100));
+        testBox.put(uint8_t(0xFF));
+        testBox.put(BalancerBlock::staticTypeId());
+        {
+            auto newBalancer = blox::Balancer();
+            testBox.put(newBalancer);
+        }
+        testBox.processInput();
         CHECK(testBox.lastReplyHasStatusOk());
-        CHECK(decoded.ShortDebugString() == "clients { id: 1 requested: 327680 granted: 204800 } "  // 80*4096, 50*4096
-                                            "clients { id: 2 requested: 327680 granted: 204800 }"); // 80*4096, 50*4096
-    }
 
-    // read mutex
-    testBox.put(uint16_t(0)); // msg id
-    testBox.put(commands::READ_OBJECT);
-    testBox.put(cbox::obj_id_t(101));
+        // create pwm actuator 1
+        testBox.put(uint16_t(0)); // msg id
+        testBox.put(commands::CREATE_OBJECT);
+        testBox.put(cbox::obj_id_t(201));
+        testBox.put(uint8_t(0xFF));
+        testBox.put(ActuatorPwmBlock::staticTypeId());
 
-    {
-        auto decoded = blox::Mutex();
-        testBox.processInputToProto(decoded);
+        {
+            auto newPwm = blox::ActuatorPwm();
+            newPwm.set_actuatorid(10);
+            newPwm.set_setting(cnl::unwrap(ActuatorAnalog::value_t(80)));
+            newPwm.set_period(4000);
+
+            auto c = newPwm.mutable_constrainedby()->add_constraints();
+            auto balanced = new blox::AnalogConstraint_Balanced();
+            balanced->set_balancerid(100);
+            c->set_allocated_balanced(balanced);
+
+            testBox.put(newPwm);
+        }
+        testBox.processInput();
         CHECK(testBox.lastReplyHasStatusOk());
-        CHECK(decoded.ShortDebugString() == "differentActuatorWait: 100");
-    }
 
-    // read a pin actuator 1
-    testBox.put(uint16_t(0)); // msg id
-    testBox.put(commands::READ_OBJECT);
-    testBox.put(cbox::obj_id_t(10));
+        // create pwm actuator 2
+        testBox.put(uint16_t(0)); // msg id
+        testBox.put(commands::CREATE_OBJECT);
+        testBox.put(cbox::obj_id_t(301));
+        testBox.put(uint8_t(0xFF));
+        testBox.put(ActuatorPwmBlock::staticTypeId());
 
-    {
-        auto decoded = blox::ActuatorPin();
-        testBox.processInputToProto(decoded);
+        {
+            auto newPwm = blox::ActuatorPwm();
+            newPwm.set_actuatorid(11);
+            newPwm.set_setting(cnl::unwrap(ActuatorAnalog::value_t(80)));
+            newPwm.set_period(4000);
+
+            auto c = newPwm.mutable_constrainedby()->add_constraints();
+            auto balanced = new blox::AnalogConstraint_Balanced();
+            balanced->set_balancerid(100);
+            c->set_allocated_balanced(balanced);
+
+            testBox.put(newPwm);
+        }
+
+        testBox.processInput();
         CHECK(testBox.lastReplyHasStatusOk());
-        CHECK(decoded.ShortDebugString() == "constrainedBy { constraints { mutex: 101 limiting: true } unconstrained: Active }");
-    }
 
-    // read a pin actuator 2
-    testBox.put(uint16_t(0)); // msg id
-    testBox.put(commands::READ_OBJECT);
-    testBox.put(cbox::obj_id_t(11));
+        testBox.update(0);
+        testBox.update(1000);
 
-    {
-        auto decoded = blox::ActuatorPin();
-        testBox.processInputToProto(decoded);
-        CHECK(testBox.lastReplyHasStatusOk());
-        CHECK(decoded.ShortDebugString() == "state: Active constrainedBy { constraints { mutex: 101 } unconstrained: Active }");
-    }
+        // read balancer
+        testBox.put(uint16_t(0)); // msg id
+        testBox.put(commands::READ_OBJECT);
+        testBox.put(cbox::obj_id_t(100));
 
-    // read a pwm actuator 1
-    testBox.put(uint16_t(0)); // msg id
-    testBox.put(commands::READ_OBJECT);
-    testBox.put(cbox::obj_id_t(201));
+        {
+            auto decoded = blox::Balancer();
+            testBox.processInputToProto(decoded);
+            CHECK(testBox.lastReplyHasStatusOk());
+            CHECK(decoded.ShortDebugString() == "clients { id: 1 requested: 327680 granted: 204800 } "  // 80*4096, 50*4096
+                                                "clients { id: 2 requested: 327680 granted: 204800 }"); // 80*4096, 50*4096
+        }
 
-    {
-        auto decoded = blox::ActuatorPwm();
-        testBox.processInputToProto(decoded);
-        CHECK(testBox.lastReplyHasStatusOk());
-        CHECK(decoded.ShortDebugString() == "actuatorId: 10 "
-                                            "period: 4000 setting: 204800 "
-                                            "constrainedBy { "
-                                            "constraints { "
-                                            "balanced { balancerId: 100 granted: 204800 id: 1 } "
-                                            "limiting: true } "
-                                            "unconstrained: 327680 } " 
-                                            "drivenActuatorId: 10");
-    }
+        // read a pwm actuator 1
+        testBox.put(uint16_t(0)); // msg id
+        testBox.put(commands::READ_OBJECT);
+        testBox.put(cbox::obj_id_t(201));
 
-    // read a pwm actuator 2
-    testBox.put(uint16_t(0)); // msg id
-    testBox.put(commands::READ_OBJECT);
-    testBox.put(cbox::obj_id_t(301));
+        {
+            auto decoded = blox::ActuatorPwm();
+            testBox.processInputToProto(decoded);
+            CHECK(testBox.lastReplyHasStatusOk());
+            CHECK(decoded.ShortDebugString() == "actuatorId: 10 "
+                                                "period: 4000 setting: 204800 "
+                                                "constrainedBy { "
+                                                "constraints { "
+                                                "balanced { balancerId: 100 granted: 204800 id: 1 } "
+                                                "limiting: true } "
+                                                "unconstrained: 327680 } "
+                                                "drivenActuatorId: 10");
+        }
 
-    {
-        auto decoded = blox::ActuatorPwm();
-        testBox.processInputToProto(decoded);
-        CHECK(testBox.lastReplyHasStatusOk());
-        CHECK(decoded.ShortDebugString() == "actuatorId: 11 "
-                                            "period: 4000 setting: 204800 "
-                                            "constrainedBy { "
-                                            "constraints { "
-                                            "balanced { balancerId: 100 granted: 204800 id: 2 } "
-                                            "limiting: true } "
-                                            "unconstrained: 327680 } " 
-                                            "drivenActuatorId: 11");
-    }
+        // read a pwm actuator 2
+        testBox.put(uint16_t(0)); // msg id
+        testBox.put(commands::READ_OBJECT);
+        testBox.put(cbox::obj_id_t(301));
 
-    // run for a while
-    for (ticks_millis_t now = 1001; now < 50000; ++now) {
-        testBox.update(now);
-    }
+        {
+            auto decoded = blox::ActuatorPwm();
+            testBox.processInputToProto(decoded);
+            CHECK(testBox.lastReplyHasStatusOk());
+            CHECK(decoded.ShortDebugString() == "actuatorId: 11 "
+                                                "period: 4000 setting: 204800 "
+                                                "constrainedBy { "
+                                                "constraints { "
+                                                "balanced { balancerId: 100 granted: 204800 id: 2 } "
+                                                "limiting: true } "
+                                                "unconstrained: 327680 } "
+                                                "drivenActuatorId: 11");
+        }
 
-    // read a pwm actuator 1
-    testBox.put(uint16_t(0)); // msg id
-    testBox.put(commands::READ_OBJECT);
-    testBox.put(cbox::obj_id_t(201));
+        // run for a while
+        for (ticks_millis_t now = 1001; now < 50000; ++now) {
+            testBox.update(now);
+        }
 
-    {
-        auto decoded = blox::ActuatorPwm();
-        testBox.processInputToProto(decoded);
-        CHECK(decoded.value() == Approx(cnl::unwrap(ActuatorAnalog::value_t(50))).epsilon(0.03));
-    }
+        // read a pwm actuator 1
+        testBox.put(uint16_t(0)); // msg id
+        testBox.put(commands::READ_OBJECT);
+        testBox.put(cbox::obj_id_t(201));
 
-    // read a pwm actuator 2
-    testBox.put(uint16_t(0)); // msg id
-    testBox.put(commands::READ_OBJECT);
-    testBox.put(cbox::obj_id_t(301));
+        {
+            auto decoded = blox::ActuatorPwm();
+            testBox.processInputToProto(decoded);
+            CHECK(decoded.value() == Approx(cnl::unwrap(ActuatorAnalog::value_t(50))).epsilon(0.03));
+        }
 
-    {
-        auto decoded = blox::ActuatorPwm();
-        testBox.processInputToProto(decoded);
-        CHECK(decoded.value() == Approx(cnl::unwrap(ActuatorAnalog::value_t(50))).epsilon(0.03));
+        // read a pwm actuator 2
+        testBox.put(uint16_t(0)); // msg id
+        testBox.put(commands::READ_OBJECT);
+        testBox.put(cbox::obj_id_t(301));
+
+        {
+            auto decoded = blox::ActuatorPwm();
+            testBox.processInputToProto(decoded);
+            CHECK(decoded.value() == Approx(cnl::unwrap(ActuatorAnalog::value_t(50))).epsilon(0.03));
+        }
     }
 }

--- a/controlbox/src/cbox/Box.cpp
+++ b/controlbox/src/cbox/Box.cpp
@@ -723,7 +723,7 @@ Box::reloadStoredObject(const obj_id_t& id)
     }
 
     bool handlerCalled = false;
-    auto streamHandler = [this, &cobj, &handlerCalled](RegionDataIn& objInStorage) -> CboxError {
+    auto streamHandler = [&cobj, &handlerCalled](RegionDataIn& objInStorage) -> CboxError {
         handlerCalled = true;
         RegionDataIn objWithoutCrc(objInStorage, objInStorage.available() - 1);
 

--- a/controlbox/src/cbox/ConnectionsStringStream.h
+++ b/controlbox/src/cbox/ConnectionsStringStream.h
@@ -87,7 +87,7 @@ public:
         }
         std::unique_ptr<Connection> retval = std::move(connectionQueue.front());
         connectionQueue.pop();
-        return std::move(retval);
+        return retval;
     }
 };
 } // end namespace cbox

--- a/controlbox/test/Box_test.cpp
+++ b/controlbox/test/Box_test.cpp
@@ -1031,7 +1031,7 @@ SCENARIO("A controlbox Box")
         THEN("A list of IDs of newly created objects is returned")
         {
             expected << addCrc("00000C") << "|"
-                     << addCrc("00")          // status
+                     << addCrc("00")              // status
                      << "," << addCrc("6400E803") // new object id 100
                      << "," << addCrc("6500E803") // new object id 101
                      << "," << addCrc("6600E803") // new object id 102

--- a/docker/start-compiler.sh
+++ b/docker/start-compiler.sh
@@ -1,6 +1,7 @@
 #! /usr/bin/env bash
 touch .env
 ENV_MOUNTDIR="$(grep MOUNTDIR .env)"
+
 if [ -z "$ENV_MOUNTDIR" ]; then
   MOUNTDIR=$(dirname "$(pwd)")
   echo "Configuring '$MOUNTDIR' as mount path in container"
@@ -22,6 +23,23 @@ if [ -z "$ENV_MAKE_ARGS" ]; then
   echo "MAKE_ARGS=$MAKE_ARGS" >> .env
 else
   echo "Using make args '$ENV_MAKE_ARGS'"
+fi
+
+ENV_UID="$(grep DOCKER_UID .env)"
+ENV_GID="$(grep DOCKER_GID .env)"
+if [ -z "$ENV_UID" ]; then
+  DOCKER_UID=$(id -u)
+  echo "Configuring DOCKER_UID=$DOCKER_UID"
+  echo "DOCKER_UID=$DOCKER_UID" >> .env
+else
+  echo "Using $ENV_UID"
+fi
+if [ -z "$ENV_GID" ]; then
+  DOCKER_GID=$(id -u)
+  echo "Configuring DOCKER_GID=$DOCKER_GID"
+  echo "DOCKER_GID=$DOCKER_GID" >> .env
+else
+  echo "Using $ENV_GID"
 fi
 
 docker-compose up -d compiler

--- a/lib/inc/ActuatorDigitalChangeLogged.h
+++ b/lib/inc/ActuatorDigitalChangeLogged.h
@@ -66,7 +66,7 @@ public:
         state(val, lastUpdateTime);
     };
 
-    State state() const
+    State state() const override
     {
         return actuator.state();
     };

--- a/lib/inc/Balancer.h
+++ b/lib/inc/Balancer.h
@@ -169,7 +169,7 @@ public:
         return val;
     }
 
-    virtual uint8_t id() const
+    virtual uint8_t id() const override final
     {
         return ID;
     }

--- a/lib/inc/IirFilter.h
+++ b/lib/inc/IirFilter.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include <limits>
 #include <cstdint>
+#include <limits>
 
 #define FILTER_ORDER 6
 
@@ -20,7 +20,6 @@ private:
     int64_t yv[FILTER_ORDER + 1];
     uint8_t paramsIdx;
     int32_t fastStepThreshold;
-    uint8_t fastStepsRemaining;
 
     FilterParams const& params() const;
     int64_t shift(const int64_t val) const;

--- a/lib/src/IirFilter.cpp
+++ b/lib/src/IirFilter.cpp
@@ -11,7 +11,6 @@ IirFilter::IirFilter(const uint8_t& idx, const int32_t& threshold)
     , yv{0}
     , paramsIdx(idx)
     , fastStepThreshold(threshold)
-    , fastStepsRemaining(FILTER_ORDER + 1)
 {
 }
 

--- a/lib/test_catch/ActuatorDigitalConstrained_test.cpp
+++ b/lib/test_catch/ActuatorDigitalConstrained_test.cpp
@@ -163,6 +163,26 @@ SCENARIO("Mutex contraint", "[constraints]")
             }
             CHECK(now == 1002);
         }
+
+        THEN("Toggling actuator 1 again resets the wait time")
+        {
+            constrained2.state(State::Active, ++now);
+            CHECK(constrained2.state() == State::Inactive);
+
+            while (constrained2.state() != State::Active && now < 500) {
+                constrained2.state(State::Active, ++now);
+            }
+
+            constrained1.state(State::Active, ++now);
+            constrained1.state(State::Inactive, ++now);
+
+            while (constrained2.state() != State::Active && now < 2000) {
+                constrained2.state(State::Active, ++now);
+                constrained2.state(State::Active, ++now);
+            }
+
+            CHECK(now == 1502);
+        }
     }
 
     WHEN("The state is changed without providing the current time, it is applied using the last update time")

--- a/lib/test_catch/FpFilterChainTest.cpp
+++ b/lib/test_catch/FpFilterChainTest.cpp
@@ -195,4 +195,29 @@ SCENARIO("Fixed point filterchain using temp_t")
             CHECK(findStepResponseDelay(chains[6], 0.9) == 2496);
         }
     }
+
+    WHEN("A different filterchain spec is chosen when the filter is in steady state")
+    {
+        auto chain = FpFilterChain<temp_t>(0);
+
+        chain.setParams(3, temp_t(10)); // 5min
+        uint32_t count = 0;
+        while (count++ < 210) {
+            chain.add(temp_t(2));
+        }
+        REQUIRE(chain.read() == Approx(temp_t(1)).margin(1));
+
+        chain.setParams(5, temp_t(10)); // 20min
+        REQUIRE(chain.read() == Approx(temp_t(1)).margin(1));
+
+        THEN("The filter output stays between expected boundaries")
+        {
+            uint32_t count = 0;
+            while (count++ < 100) {
+                chain.add(temp_t(2));
+                CHECK(chain.read() <= temp_t(2));
+                CHECK(chain.read() >= temp_t(0.99));
+            }
+        }
+    }
 }

--- a/lib/test_catch/PidTest.cpp
+++ b/lib/test_catch/PidTest.cpp
@@ -584,8 +584,6 @@ SCENARIO("PID Test with PWM actuator", "[pid]")
         setpoint->setting(20);
         sensor->value(21);
 
-        temp_t mockVal;
-
         auto start = now;
         while (now <= start + 1000'000) {
             if (now >= nextPwmUpdate) {
@@ -625,8 +623,6 @@ SCENARIO("PID Test with PWM actuator", "[pid]")
 
         setpoint->setting(20);
         sensor->value(25);
-
-        temp_t mockVal;
 
         auto start = now;
         while (now <= start + 1000'000) {

--- a/wrapped_make.sh
+++ b/wrapped_make.sh
@@ -8,5 +8,6 @@ rm "$MY_DIR/compile_commands.json"
 pushd "$MY_DIR" > /dev/null
 cat ./**/compile_commands.json > compile_commands.json \
   && sed -i -e ':a;N;$!ba;s/\]\n\n\[/,/g' compile_commands.json
+chmod 777 compile_commands.json
 popd > /dev/null
 rm "compile_commands.json"


### PR DESCRIPTION
When pins were written from an external message, the latest known time would be used. This could cause the lastActive time (set by a different actuator) to be newer than the 'now' time in the currently written actuator, resulting in an overflowing calculation and the wait time not being applied.