### PR TITLE
Fix derivative having incorrect value due to lower update rate in later filter stages

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -28,6 +28,28 @@
             "problemMatcher": "$gcc"
         },
         {
+            "label": "build_gcc_local",
+            "command": "bash",
+            "args": [
+                "../wrapped_make.sh",
+                "APP=brewblox",
+                "PLATFORM=gcc"
+            ],
+            "group": "build",
+            "options": {
+                "cwd": "${workspaceFolder}/build"
+            },
+            "presentation": {
+                "echo": true,
+                "reveal": "always",
+                "focus": true,
+                "panel": "shared",
+                "showReuseMessage": false,
+                "clear": false
+            },
+            "problemMatcher": "$gcc"
+        },
+        {
             "label": "flash_p1",
             "command": "docker-compose",
             "args": [

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -9,6 +9,7 @@
             "args": [
                 "exec",
                 "compiler",
+                "bash",
                 "../wrapped_make.sh",
                 "APP=brewblox",
                 "PLATFORM=p1"
@@ -55,6 +56,7 @@
             "args": [
                 "exec",
                 "compiler",
+                "bash",
                 "../wrapped_make.sh",
                 "APP=brewblox",
                 "PLATFORM=p1",
@@ -181,6 +183,7 @@
             "args": [
                 "exec",
                 "compiler",
+                "bash",
                 "../wrapped_make.sh",
                 "-C",
                 "../app/brewblox/test"
@@ -206,6 +209,7 @@
             "args": [
                 "exec",
                 "compiler",
+                "bash",
                 "../wrapped_make.sh",
                 "-C",
                 "../lib/test_catch"
@@ -231,6 +235,7 @@
             "args": [
                 "exec",
                 "compiler",
+                "bash",
                 "../wrapped_make.sh",
                 "-C",
                 "../controlbox"

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -82,10 +82,9 @@
         },
         {
             "label": "restart_compiler",
-            "command": "docker-compose",
+            "command": "bash",
             "args": [
-                "restart",
-                "compiler",
+                "start-compiler.sh",
             ],
             "group": "build",
             "options": {

--- a/app/brewblox/blox/WiFiSettingsBlock.cpp
+++ b/app/brewblox/blox/WiFiSettingsBlock.cpp
@@ -29,7 +29,7 @@ WiFiSettingsBlock::streamTo(cbox::DataOut& out) const
     blox_WiFiSettings message = blox_WiFiSettings_init_zero;
 
     printWiFiIp(message.ip);
-
+    printWifiSSID(message.ssid, sizeof(message.ssid));
     message.signal = wifiSignal();
 
     return streamProtoTo(out, &message, blox_WiFiSettings_fields, blox_WiFiSettings_size);

--- a/app/brewblox/connectivity.cpp
+++ b/app/brewblox/connectivity.cpp
@@ -55,3 +55,9 @@ setWifiCredentials(const char* ssid, const char* password, uint8_t security, uin
 {
     return WiFi.setCredentials(ssid, password, security, cipher);
 };
+
+void
+printWifiSSID(char* dest, const uint8_t& maxLen)
+{
+    strncpy(dest, WiFi.SSID(), maxLen);
+}

--- a/app/brewblox/connectivity.h
+++ b/app/brewblox/connectivity.h
@@ -23,6 +23,9 @@
 void
 printWiFiIp(char dest[16]);
 
+void
+printWifiSSID(char* dest, const uint8_t& maxLen);
+
 int8_t
 wifiSignal();
 

--- a/app/brewblox/test/PidBlock_test.cpp
+++ b/app/brewblox/test/PidBlock_test.cpp
@@ -152,7 +152,6 @@ SCENARIO("A Blox Pid object can be created from streamed protobuf data")
                                         "enabled: true active: true "
                                         "kp: 40960 ti: 2000 td: 200 "
                                         "p: 40950 i: 20475 "
-                                        "error: 4095 integral: 4095000 "
+                                        "error: 4095 integral: 4095000 derivative: -1 "
                                         "drivenOutputId: 103");
-
 }

--- a/build/build-tests.sh
+++ b/build/build-tests.sh
@@ -10,6 +10,14 @@ else
 fi
 }
 
+pushd "$MY_DIR/../lib/test_catch" > /dev/null
+echo "Building lib unit tests"
+make $MAKE_ARGS -s runner;
+(( result = $? ))
+status $result
+(( exit_status = exit_status || result ))
+popd > /dev/null
+
 pushd "$MY_DIR/../app/brewblox/test" > /dev/null
 echo "Building BrewBlox app unit tests"
 make $MAKE_ARGS -s runner;

--- a/build/run-tests.sh
+++ b/build/run-tests.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-MY_DIR=$(dirname $(readlink -f $0))
+MY_DIR=$(dirname "$(readlink -f "$0")")
 
 function status()
 {
@@ -10,7 +10,14 @@ else
 fi
 }
 
-# status $?
+echo "Running lib unit tests"
+pushd "$MY_DIR/../lib/test_catch/build" > /dev/null
+./lib_test_runner;
+(( result = $? ))
+status $result
+(( exit_status = exit_status || result ))
+popd > /dev/null
+
 echo "Running ControlBox unit tests"
 pushd "$MY_DIR/../controlbox/build/" > /dev/null
 ./cbox_test_runner;

--- a/docker/start-compiler.sh
+++ b/docker/start-compiler.sh
@@ -1,4 +1,6 @@
 #! /usr/bin/env bash
+
+docker-compose down
 touch .env
 ENV_MOUNTDIR="$(grep MOUNTDIR .env)"
 

--- a/lib/inc/FilterChain.h
+++ b/lib/inc/FilterChain.h
@@ -19,10 +19,11 @@
 
 #pragma once
 #include "IirFilter.h"
+#include <cstdint>
 #include <limits>
 #include <memory>
-#include <cstdint>
 #include <vector>
+
 
 class FilterChain {
 private:
@@ -64,6 +65,6 @@ public:
     int64_t readWithNFractionBits(uint8_t filterNr, uint8_t bits) const;
     int64_t readWithNFractionBits(uint8_t bits) const;
     int32_t readLastInput() const;
-    IirFilter::DerivativeResult readDerivative(uint8_t filterIdx = 0) const;
+    IirFilter::DerivativeResult readDerivative() const;
     void reset(const int32_t& value);
 };

--- a/lib/inc/FpFilterChain.h
+++ b/lib/inc/FpFilterChain.h
@@ -124,9 +124,9 @@ public:
 
     // get the derivative from the chain with max precision and convert to the requested FP precision
     template <typename U>
-    U readDerivative(uint8_t filterIdx = 0) const
+    U readDerivative() const
     {
-        auto derivative = chain.readDerivative(filterIdx);
+        auto derivative = chain.readDerivative();
         uint8_t destFractionBits = -U::exponent;
         uint8_t filterFactionBits = -T::exponent + derivative.fractionBits;
         int64_t result;

--- a/lib/inc/Pid.h
+++ b/lib/inc/Pid.h
@@ -150,8 +150,12 @@ public:
 
     void configureFilter(const uint8_t& choice, const in_t& threshold)
     {
-        m_filterChoice = choice;
-        m_filter.setParams(choice, threshold);
+        if (m_filterChoice != choice) {
+            m_filterChoice = choice;
+            m_filter.setParams(choice, threshold);
+        } else {
+            m_filter.setStepThreshold(threshold);
+        }
     }
 
     void enabled(bool state)

--- a/lib/src/FilterChain.cpp
+++ b/lib/src/FilterChain.cpp
@@ -74,7 +74,7 @@ FilterChain::setParams(const std::vector<uint8_t>& params, const std::vector<uin
     auto itP = params.begin();
     auto itS = stages.begin();
     auto itI = intervals.begin();
-    auto newFilterInitVal = int32_t(0);
+    auto newFilterInitVal = read();
     // reconfigure already existing filters
     for (; itS != stages.end() && itP != params.end(); ++itP, ++itS) {
         if (*itP != itS->filter.getParamsIdx()) {
@@ -88,7 +88,6 @@ FilterChain::setParams(const std::vector<uint8_t>& params, const std::vector<uin
         } else {
             itS->interval = IirFilter::FilterDefinition(*itP).downsample;
         }
-        newFilterInitVal = itS->filter.read();
     }
     // append new filters
     for (; itP != params.end(); ++itP) {
@@ -99,11 +98,10 @@ FilterChain::setParams(const std::vector<uint8_t>& params, const std::vector<uin
         } else {
             interval = IirFilter::FilterDefinition(*itP).downsample;
         }
-        auto newFilter = IirFilter(*itP, stepThreshold);
-        newFilter.reset(newFilterInitVal);
-        stages.emplace_back(Stage{std::move(newFilter), std::move(interval)});
+        stages.emplace_back(Stage{IirFilter(*itP, stepThreshold), std::move(interval)});
     }
     stages.shrink_to_fit(); // remove filters if params is shorter than before
+    reset(newFilterInitVal);
 }
 
 void

--- a/lib/src/FilterChain.cpp
+++ b/lib/src/FilterChain.cpp
@@ -196,7 +196,11 @@ FilterChain::readLastInput() const
 }
 
 IirFilter::DerivativeResult
-FilterChain::readDerivative(uint8_t filterIdx) const
+FilterChain::readDerivative() const
 {
-    return (filterIdx < length()) ? stages[filterIdx].filter.readDerivative() : IirFilter::DerivativeResult{0, 0};
+    auto retv = stages[stages.size() - 1].filter.readDerivative();
+    // The last filter is updated less frequenctly, so the derivative needs to be scaled back to the input sample interval
+    auto inputSamplesPerOutputChange = minSampleInterval();
+    retv.result = retv.result / inputSamplesPerOutputChange;
+    return retv;
 }

--- a/lib/test_catch/ActuatorDigitalConstrained_test.cpp
+++ b/lib/test_catch/ActuatorDigitalConstrained_test.cpp
@@ -141,24 +141,29 @@ SCENARIO("Mutex contraint", "[constraints]")
     WHEN("A minimum switch time of 1000 is set on the mutex and actuator 1 was active before")
     {
         mut->differentActuatorWait(1000);
+        mut->update(now);
         constrained1.state(State::Active, ++now);
         CHECK(constrained1.state() == State::Active);
 
+        mut->update(now);
         constrained1.state(State::Inactive, ++now);
         CHECK(constrained1.state() == State::Inactive);
 
         THEN("Actuator 1 can go active again immediately")
         {
+            mut->update(now);
             constrained1.state(State::Active, ++now);
             CHECK(constrained1.state() == State::Active);
         }
 
         THEN("Actuator 2 has to wait until no actuator has been active for 1000ms")
         {
+            mut->update(now);
             constrained2.state(State::Active, ++now);
             CHECK(constrained2.state() == State::Inactive);
 
             while (constrained2.state() != State::Active && now < 2000) {
+                mut->update(now);
                 constrained2.state(State::Active, ++now);
             }
             CHECK(now == 1002);
@@ -166,17 +171,21 @@ SCENARIO("Mutex contraint", "[constraints]")
 
         THEN("Toggling actuator 1 again resets the wait time")
         {
+            mut->update(now);
             constrained2.state(State::Active, ++now);
             CHECK(constrained2.state() == State::Inactive);
 
             while (constrained2.state() != State::Active && now < 500) {
+                mut->update(now);
                 constrained2.state(State::Active, ++now);
             }
 
+            mut->update(now);
             constrained1.state(State::Active, ++now);
             constrained1.state(State::Inactive, ++now);
 
             while (constrained2.state() != State::Active && now < 2000) {
+                mut->update(now);
                 constrained2.state(State::Active, ++now);
                 constrained2.state(State::Active, ++now);
             }

--- a/lib/test_catch/FpFilterChainTest.cpp
+++ b/lib/test_catch/FpFilterChainTest.cpp
@@ -211,26 +211,24 @@ SCENARIO("Fixed point filterchain using temp_t")
 
     WHEN("A different filterchain spec is chosen that is longer")
     {
-        auto chain = FpFilterChain<temp_t>(0);
+        auto chain = FpFilterChain<temp_t>(3); // 5 min
 
-        chain.setParams(3, temp_t(10)); // 5min
-        // generate noisy input with average value 2
+        // generate noisy input with average value 10
         uint32_t count = 0;
-        while (count++ < 210) {
-            chain.add(temp_t(count % 2) + temp_t(count % 3) / 2 + temp_t(count % 5) / 4 + temp_t(count % 7) / 6);
+        while (count++ < 600) {
+            chain.add(temp_t(8) + temp_t(count % 2) + temp_t(count % 3) / 2 + temp_t(count % 5) / 4 + temp_t(count % 7) / 6);
         }
-        REQUIRE(chain.read() == Approx(temp_t(1)).margin(0.01));
+        REQUIRE(chain.read() == Approx(temp_t(10)).epsilon(0.01));
 
-        chain.setParams(5, temp_t(10)); // 20min
-        REQUIRE(chain.read() == Approx(temp_t(1)).margin(1));
+        chain.setParams(5, temp_t(100)); // 20min
+        REQUIRE(chain.read() == Approx(temp_t(10)).epsilon(0.01));
 
         THEN("The filter output stays between expected boundaries")
         {
             uint32_t count = 0;
             while (count++ < 2000) {
-                chain.add(temp_t(2));
-                CHECK(chain.read() <= temp_t(2.01));
-                CHECK(chain.read() >= temp_t(0.99));
+                chain.add(temp_t(8) + temp_t(count % 2) + temp_t(count % 3) / 2 + temp_t(count % 5) / 4 + temp_t(count % 7) / 6);
+                CHECK(chain.read() == Approx(temp_t(10)).epsilon(0.01));
             }
         }
     }

--- a/lib/test_catch/FpFilterChainTest.cpp
+++ b/lib/test_catch/FpFilterChainTest.cpp
@@ -196,16 +196,17 @@ SCENARIO("Fixed point filterchain using temp_t")
         }
     }
 
-    WHEN("A different filterchain spec is chosen when the filter is in steady state")
+    WHEN("A different filterchain spec is chosen that is longer")
     {
         auto chain = FpFilterChain<temp_t>(0);
 
         chain.setParams(3, temp_t(10)); // 5min
+        // generate noisy input with average value 2
         uint32_t count = 0;
         while (count++ < 210) {
-            chain.add(temp_t(2));
+            chain.add(temp_t(count % 2) + temp_t(count % 3) / 2 + temp_t(count % 5) / 4 + temp_t(count % 7) / 6);
         }
-        REQUIRE(chain.read() == Approx(temp_t(1)).margin(1));
+        REQUIRE(chain.read() == Approx(temp_t(1)).margin(0.01));
 
         chain.setParams(5, temp_t(10)); // 20min
         REQUIRE(chain.read() == Approx(temp_t(1)).margin(1));
@@ -213,9 +214,9 @@ SCENARIO("Fixed point filterchain using temp_t")
         THEN("The filter output stays between expected boundaries")
         {
             uint32_t count = 0;
-            while (count++ < 100) {
+            while (count++ < 2000) {
                 chain.add(temp_t(2));
-                CHECK(chain.read() <= temp_t(2));
+                CHECK(chain.read() <= temp_t(2.01));
                 CHECK(chain.read() >= temp_t(0.99));
             }
         }

--- a/lib/test_catch/PidTest.cpp
+++ b/lib/test_catch/PidTest.cpp
@@ -532,7 +532,7 @@ SCENARIO("PID Test with PWM actuator", "[pid]")
         CHECK(mockVal == 29);
         CHECK(pid.error() == Approx(1.23).epsilon(0.01)); // the filter introduces some delay, which is why this is not 1.0
         CHECK(pid.p() == Approx(12.3).epsilon(0.01));
-        CHECK(pid.i() == Approx(accumulatedError * (10.0 / 2000)).epsilon(0.01));
+        CHECK(pid.i() == Approx(accumulatedError * (10.0 / 2000)).epsilon(0.05)); // some integral anti-windup will occur at the start
         CHECK(pid.d() == Approx(-10 * 9.0 / 900 * 200).epsilon(0.01));
 
         CHECK(actuator->setting() == pid.p() + pid.i() + pid.d());
@@ -569,7 +569,7 @@ SCENARIO("PID Test with PWM actuator", "[pid]")
         CHECK(mockVal == 21);
         CHECK(pid.error() == Approx(-1.23).epsilon(0.01)); // the filter introduces some delay, which is why this is not 1.0
         CHECK(pid.p() == Approx(12.3).epsilon(0.01));
-        CHECK(pid.i() == Approx(accumulatedError * (-10.0 / 2000)).epsilon(0.01));
+        CHECK(pid.i() == Approx(accumulatedError * (-10.0 / 2000)).epsilon(0.05)); // some integral anti-windup will occur at the start
         CHECK(pid.d() == Approx(-10 * 9.0 / 900 * 200).epsilon(0.01));
 
         CHECK(actuator->setting() == pid.p() + pid.i() + pid.d());


### PR DESCRIPTION
**PID derivative fix**
In the cascaded filter chains, not all filters run at the same sample interval.
Filters later in the chain will downsample the previous stages.

The derivative was calculated as the difference between the last 2 output samples of the last stage.
To return a correct derivative, the result needed to be scaled with the output rate of the last stage.

**Prevent unnecessarily resetting the filter**
While debugging this I noticed that the filter is re-initialized at every PID settings change (due to not supporting partial updates), so I added a check for an actual filter config change to skip re-init.

**Lib tests in ci**
Lib tests were not run in CI, an oversight fixed in this PR.

**WiFi SSID**
WiFi SSID was missing from serial output and has been added.
