### PR TITLE
Support for displaying Fahrenheit values on TFT screen

### DIFF
--- a/app/brewblox/display/screens/ActuatorAnalogWidget.cpp
+++ b/app/brewblox/display/screens/ActuatorAnalogWidget.cpp
@@ -29,7 +29,7 @@ ActuatorAnalogWidget::ActuatorAnalogWidget(WidgetWrapper& myWrapper, const cbox:
 }
 
 void
-ActuatorAnalogWidget::update()
+ActuatorAnalogWidget::update(const WidgetSettings& settings)
 {
     if (auto pAct = lookup.const_lock()) {
         setConnected();

--- a/app/brewblox/display/screens/ActuatorAnalogWidget.h
+++ b/app/brewblox/display/screens/ActuatorAnalogWidget.h
@@ -30,7 +30,7 @@ public:
     ActuatorAnalogWidget(WidgetWrapper& myWrapper, const cbox::obj_id_t& id);
     virtual ~ActuatorAnalogWidget() = default;
 
-    virtual void update() override final;
+    virtual void update(const WidgetSettings& settings) override final;
 
     static void
     onClickStatic(void* thisPtr)

--- a/app/brewblox/display/screens/PidWidget.cpp
+++ b/app/brewblox/display/screens/PidWidget.cpp
@@ -131,7 +131,7 @@ PidWidget::drawPidRects(const Pid& pid)
 }
 
 void
-PidWidget::update()
+PidWidget::update(const WidgetSettings& settings)
 {
     if (auto ptr = lookup.const_lock()) {
         auto pid = ptr->get();
@@ -140,24 +140,24 @@ PidWidget::update()
         setConnected();
         auto input = inputLookup.const_lock();
         if (input && input->valueValid()) {
-            setAndEnable(&inputValue, temp_to_string(input->value(), 1).c_str());
+            setAndEnable(&inputValue, temp_to_string(input->value(), 1, settings.tempUnit).c_str());
         } else {
             setAndEnable(&inputValue, nullptr);
         }
         if (input && input->settingValid()) {
-            setAndEnable(&inputTarget, temp_to_string(input->setting(), 1).c_str());
+            setAndEnable(&inputTarget, temp_to_string(input->setting(), 1, settings.tempUnit).c_str());
         } else {
             setAndEnable(&inputTarget, nullptr);
         }
 
         auto output = outputLookup.const_lock();
         if (output && output->valueValid()) {
-            setAndEnable(&outputValue, temp_to_string(output->value(), 1).c_str());
+            setAndEnable(&outputValue, to_string_dec(output->value(), 1).c_str());
         } else {
             setAndEnable(&outputValue, nullptr);
         }
         if (output && output->settingValid()) {
-            setAndEnable(&outputTarget, temp_to_string(output->setting(), 1).c_str());
+            setAndEnable(&outputTarget, to_string_dec(output->setting(), 1).c_str());
         } else {
             setAndEnable(&outputTarget, nullptr);
         }

--- a/app/brewblox/display/screens/PidWidget.h
+++ b/app/brewblox/display/screens/PidWidget.h
@@ -87,7 +87,7 @@ public:
         wrapper.colorScheme.bckgDis = wrapper.colorScheme.bckg;
     }
 
-    virtual void update() override final;
+    virtual void update(const WidgetSettings& settings) override final;
 
     static void
     onClickStatic(void* thisPtr)

--- a/app/brewblox/display/screens/ProcessValueWidgetBase.h
+++ b/app/brewblox/display/screens/ProcessValueWidgetBase.h
@@ -19,7 +19,6 @@
 
 #pragma once
 #include "ProcessValue.h"
-#include "Temperature.h"
 #include "WidgetBase.h"
 #include "cbox/CboxPtr.h"
 #include "d4d.hpp"

--- a/app/brewblox/display/screens/SetpointSensorWidget.cpp
+++ b/app/brewblox/display/screens/SetpointSensorWidget.cpp
@@ -28,7 +28,7 @@ SetpointSensorWidget::SetpointSensorWidget(WidgetWrapper& myWrapper, const cbox:
 }
 
 void
-SetpointSensorWidget::update()
+SetpointSensorWidget::update(const WidgetSettings& settings)
 {
     if (auto ptr = lookup.const_lock()) {
         setConnected();
@@ -36,14 +36,14 @@ SetpointSensorWidget::update()
 
         char icons[3] = {0};
         if (pair.valueValid()) {
-            setValue(temp_to_string(pair.value(), 1).c_str());
+            setValue(temp_to_string(pair.value(), 1, settings.tempUnit).c_str());
             icons[0] = '\x29';
         } else {
             setValue(nullptr);
             icons[0] = '\x2B';
         }
         if (pair.settingValid()) {
-            setSetting(temp_to_string(pair.setting(), 1).c_str());
+            setSetting(temp_to_string(pair.setting(), 1, settings.tempUnit).c_str());
             icons[1] = '\x2A';
         } else {
             setSetting(nullptr);

--- a/app/brewblox/display/screens/SetpointSensorWidget.h
+++ b/app/brewblox/display/screens/SetpointSensorWidget.h
@@ -30,7 +30,7 @@ public:
     SetpointSensorWidget(WidgetWrapper& myWrapper, const cbox::obj_id_t& id);
     virtual ~SetpointSensorWidget() = default;
 
-    virtual void update() override final;
+    virtual void update(const WidgetSettings& settings) override final;
 
     static void
     onClickStatic(void* thisPtr)

--- a/app/brewblox/display/screens/TempSensorWidget.cpp
+++ b/app/brewblox/display/screens/TempSensorWidget.cpp
@@ -27,13 +27,13 @@ TempSensorWidget::TempSensorWidget(WidgetWrapper& myWrapper, const cbox::obj_id_
 }
 
 void
-TempSensorWidget::update()
+TempSensorWidget::update(const WidgetSettings& settings)
 {
     if (auto ptr = lookup.const_lock()) {
         setConnected();
         char icons[2] = {0};
         if (ptr->valid()) {
-            setValue(temp_to_string(ptr->value(), 1).c_str());
+            setValue(temp_to_string(ptr->value(), 1, settings.tempUnit).c_str());
             icons[0] = 0x29;
         } else {
             setValue(nullptr);

--- a/app/brewblox/display/screens/TempSensorWidget.h
+++ b/app/brewblox/display/screens/TempSensorWidget.h
@@ -30,5 +30,5 @@ public:
     TempSensorWidget(WidgetWrapper& myWrapper, const cbox::obj_id_t& id);
     virtual ~TempSensorWidget() = default;
 
-    virtual void update() override final;
+    virtual void update(const WidgetSettings& settings) override final;
 };

--- a/app/brewblox/display/screens/WidgetBase.h
+++ b/app/brewblox/display/screens/WidgetBase.h
@@ -18,7 +18,12 @@
  */
 
 #pragma once
+#include "Temperature.h"
 #include "WidgetWrapper.h"
+
+struct WidgetSettings {
+    TempUnit tempUnit;
+};
 
 class WidgetBase {
 protected:
@@ -57,5 +62,5 @@ public:
         D4D_EnableObject(obj, false);
     }
 
-    virtual void update() = 0;
+    virtual void update(const WidgetSettings& settings) = 0;
 };

--- a/app/brewblox/display/screens/WidgetsScreen.cpp
+++ b/app/brewblox/display/screens/WidgetsScreen.cpp
@@ -92,6 +92,9 @@ D4D_DECLARE_STD_SCREEN_BEGIN(widgets_screen, scrWidgets_)
     D4D_DECLARE_SCREEN_END();
 
 std::vector<std::unique_ptr<WidgetBase>> WidgetsScreen::widgets;
+WidgetSettings WidgetsScreen::widgetSettings = {
+    TempUnit::Celsius,
+};
 
 void
 WidgetsScreen::loadSettings()
@@ -100,6 +103,7 @@ WidgetsScreen::loadSettings()
     if (settings.name[0] != 0) {
         D4D_SetText(&scrWidgets_title, settings.name);
     }
+    widgetSettings.tempUnit = TempUnit(settings.tempUnit);
 
     widgets.clear();
     pb_size_t numWidgets = std::min(settings.widgets_count, pb_size_t(sizeof(settings.widgets) / sizeof(settings.widgets[0])));
@@ -178,7 +182,7 @@ WidgetsScreen::updateWidgets()
 {
     for (auto& w : widgets) {
         if (w) {
-            w->update();
+            w->update(widgetSettings);
         }
     }
 }

--- a/app/brewblox/display/screens/WidgetsScreen.h
+++ b/app/brewblox/display/screens/WidgetsScreen.h
@@ -17,11 +17,13 @@
  * along with BrewPi.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include "Temperature.h"
 #include "WidgetBase.h"
 
 class WidgetsScreen {
 private:
     static std::vector<std::unique_ptr<WidgetBase>> widgets;
+    static WidgetSettings widgetSettings;
 
 public:
     WidgetsScreen() = default;

--- a/app/brewblox/proto/DisplaySettings.proto
+++ b/app/brewblox/proto/DisplaySettings.proto
@@ -20,6 +20,12 @@ message DisplaySettings {
     };
   }
 
+  enum TemperatureUnit {
+    CELSIUS = 0;
+    FAHRENHEIT = 1;
+  };
+
   repeated Widget widgets = 1 [ (nanopb).max_count = 6 ];
   string name = 2 [ (nanopb).max_size = 40 ];
+  TemperatureUnit tempUnit = 3;
 }

--- a/lib/inc/Temperature.h
+++ b/lib/inc/Temperature.h
@@ -25,15 +25,13 @@
 
 using temp_t = fp12_t;
 
-enum TempFormat {
-    Celsius,
-    Fahrenheit
+enum class TempUnit : uint8_t {
+    Celsius = 0,
+    Fahrenheit = 1,
 };
 
-extern TempFormat tempFormat;
+std::string
+tempDiff_to_string(const temp_t& t, uint8_t decimals, const TempUnit& unit);
 
 std::string
-tempDiff_to_string(const temp_t& t, uint8_t decimals);
-
-std::string
-temp_to_string(const temp_t& t, uint8_t decimals);
+temp_to_string(const temp_t& t, uint8_t decimals, const TempUnit& unit);

--- a/lib/src/Temperature.cpp
+++ b/lib/src/Temperature.cpp
@@ -19,23 +19,21 @@
 
 #include "Temperature.h"
 
-TempFormat tempFormat = TempFormat::Celsius;
-
 std::string
-tempDiff_to_string(const temp_t& t, uint8_t decimals)
+tempDiff_to_string(const temp_t& t, uint8_t decimals, const TempUnit& unit)
 {
     fp12_t val = t;
-    if (tempFormat == Fahrenheit) {
+    if (unit == TempUnit::Fahrenheit) {
         val = (t * 9) / 5;
     }
     return to_string_dec(val, decimals);
 }
 
 std::string
-temp_to_string(const temp_t& t, uint8_t decimals)
+temp_to_string(const temp_t& t, uint8_t decimals, const TempUnit& unit)
 {
     fp12_t val = t;
-    if (tempFormat == Fahrenheit) {
+    if (unit == TempUnit::Fahrenheit) {
         val = (t * 9) / 5 + fp12_t(32);
     }
     return to_string_dec(val, decimals);


### PR DESCRIPTION
Supporting Fahrenheit values on the TFT screen was still missing. This adds a setting to the DisplaySettings block to change it.