### PR TITLE
Add some simple task timers to get a grasp on system load

### DIFF
--- a/app/brewblox/blox/SysInfoBlock.cpp
+++ b/app/brewblox/blox/SysInfoBlock.cpp
@@ -39,7 +39,10 @@ SysInfoBlock::streamTo(cbox::DataOut& out) const
 
     HAL_device_ID(static_cast<uint8_t*>(&message.deviceId[0]), 12);
 
-    strncpy(message.version, stringify(GIT_VERSION), 20);
+    strncpy(message.version, stringify(GIT_VERSION), 12);
+    strncpy(message.protocolVersion, stringify(PROTO_VERSION), 12);
+    strncpy(message.releaseDate, stringify(GIT_DATE), 12);
+    strncpy(message.protocolDate, stringify(PROTO_DATE), 12);
 
     message.platform = blox_SysInfo_Platform(PLATFORM_ID);
 

--- a/app/brewblox/blox/TicksBlock.h
+++ b/app/brewblox/blox/TicksBlock.h
@@ -52,6 +52,11 @@ public:
         message.secondsSinceEpoch = ticks.getNow();
         message.millisSinceBoot = ticks.millis();
 
+        message.avgCommunicationTask = ticks.taskTimers()[0];
+        message.avgBlocksUpdateTask = ticks.taskTimers()[1];
+        message.avgDisplayTask = ticks.taskTimers()[2];
+        message.avgSystemTask = ticks.taskTimers()[3];
+
         return streamProtoTo(out, &message, blox_Ticks_fields, blox_Ticks_size);
     }
 

--- a/app/brewblox/build.mk
+++ b/app/brewblox/build.mk
@@ -113,8 +113,20 @@ CSRC := $(filter-out $(CEXCLUDES),$(CSRC))
 CPPSRC := $(filter-out $(CPPEXCLUDES),$(CPPSRC)) 
 
 GIT_VERSION = $(shell cd $(SOURCE_PATH); git rev-parse --short HEAD)
-$(info using $(GIT_VERSION) as version string)
+$(info using $(GIT_VERSION) as version)
 CFLAGS += -DGIT_VERSION="$(GIT_VERSION)"
+
+GIT_DATE = $(shell cd $(SOURCE_PATH); git log -1 --format=%cd --date=short)
+$(info using $(GIT_DATE) as release date)
+CFLAGS += -DGIT_DATE="$(GIT_DATE)"
+
+PROTO_VERSION = $(shell cd $(SOURCE_PATH)/app/brewblox/proto; git rev-parse --short HEAD)
+$(info using $(PROTO_VERSION) as protocol version)
+CFLAGS += -DPROTO_VERSION="$(PROTO_VERSION)"
+
+PROTO_DATE = $(shell cd $(SOURCE_PATH)/app/brewblox/proto; git log -1 --format=%cd --date=short)
+$(info using $(GIT_DATE) as protocol date)
+CFLAGS += -DPROTO_DATE="$(PROTO_DATE)"
 
 COMPILER_VERSION = $(shell $(CC) --version) 
 $(info using compiler: $(COMPILER_VERSION))

--- a/app/brewblox/main.cpp
+++ b/app/brewblox/main.cpp
@@ -202,15 +202,18 @@ setup()
 void
 loop()
 {
+    ticks.switchTaskTimer(TicksClass::TaskId::Communication);
     if (!WiFi.listening()) {
         manageConnections();
         brewbloxBox().hexCommunicate();
     }
-
+    ticks.switchTaskTimer(TicksClass::TaskId::BlocksUpdate);
     updateBrewbloxBox();
 
+    ticks.switchTaskTimer(TicksClass::TaskId::DisplayUpdate);
     displayTick();
 
+    ticks.switchTaskTimer(TicksClass::TaskId::System);
     watchdogCheckin();
 }
 

--- a/app/brewblox/test/SysinfoBlock_test.cpp
+++ b/app/brewblox/test/SysinfoBlock_test.cpp
@@ -43,12 +43,14 @@ SCENARIO("SysInfo Block")
         testBox.processInputToProto(decoded);
 
         std::string version = stringify(GIT_VERSION);
-        REQUIRE(version != "GIT_VERSION"); // check that it is properly expanded
+        std::string protocolVersion = stringify(PROTO_VERSION);
+        std::string releaseDate = stringify(GIT_DATE);
+        std::string protocolDate = stringify(PROTO_DATE);
 
-        THEN("The VERSION and device ID are correct")
+        THEN("The system info is serialized correctly")
         {
             CHECK(testBox.lastReplyHasStatusOk());
-            CHECK(decoded.ShortDebugString() == std::string("deviceId: \"999999999999\" version: \"") + version + std::string("\" platform: gcc hardware: Spark3"));
+            CHECK(decoded.ShortDebugString() == std::string("deviceId: \"999999999999\"") + std::string(" version: \"") + version + std::string("\" platform: gcc hardware: Spark3") + std::string(" protocolVersion: \"") + protocolVersion + std::string("\" releaseDate: \"") + releaseDate + std::string("\" protocolDate: \"") + protocolDate + std::string("\""));
         }
     }
 }

--- a/app/brewblox/test/makefile
+++ b/app/brewblox/test/makefile
@@ -125,7 +125,21 @@ LDFLAGS += $(shell pkg-config --libs protobuf)
 CFLAGS += -Wno-system-headers
 
 GIT_VERSION = $(shell cd $(SOURCE_PATH); git rev-parse --short HEAD)
+$(info using $(GIT_VERSION) as version)
 CFLAGS += -DGIT_VERSION="$(GIT_VERSION)"
+
+GIT_DATE = $(shell cd $(SOURCE_PATH); git log -1 --format=%cd --date=short)
+$(info using $(GIT_DATE) as release date)
+CFLAGS += -DGIT_DATE="$(GIT_DATE)"
+
+PROTO_VERSION = $(shell cd $(SOURCE_PATH)/app/brewblox/proto; git rev-parse --short HEAD)
+$(info using $(PROTO_VERSION) as protocol version)
+CFLAGS += -DPROTO_VERSION="$(PROTO_VERSION)"
+
+PROTO_DATE = $(shell cd $(SOURCE_PATH)/app/brewblox/proto; git log -1 --format=%cd --date=short)
+$(info using $(GIT_DATE) as protocol date)
+CFLAGS += -DPROTO_DATE="$(PROTO_DATE)"
+
 
 CPPEXCLUDES += app/brewblox/blox/TouchSettingsBlock.cpp
 CPPEXCLUDES += app/brewblox/blox/WiFiSettingsBlock.cpp

--- a/lib/inc/Ticks.h
+++ b/lib/inc/Ticks.h
@@ -82,4 +82,32 @@ public:
     {
         return impl;
     }
+
+    enum class TaskId {
+        Communication,
+        BlocksUpdate,
+        DisplayUpdate,
+        System,
+        NumTasks,
+    };
+
+    void switchTaskTimer(TaskId startedTask)
+    {
+        auto now = millis();
+        auto elapsed = now - lastTimerTick;
+        uint8_t timerIdx = uint8_t(runningTask);
+        timers[timerIdx] = timers[timerIdx] - (timers[timerIdx] >> 5) + elapsed;
+        runningTask = startedTask;
+        lastTimerTick = now;
+    }
+
+    const auto& taskTimers() const
+    {
+        return timers;
+    }
+
+private:
+    ticks_millis_t timers[uint8_t(TaskId::NumTasks)]; // EMA of durations of each task
+    ticks_millis_t lastTimerTick = 0;
+    TaskId runningTask = TaskId::System;
 };


### PR DESCRIPTION
Adds average duration of communication and block updates for the main loop to the time object to help us find performance issues.