### PR TITLE
unregister PWM interrupt on destruction of ActuatorPWM to fix crash caused by dangling copy of this pointer

### DIFF
--- a/lib/inc/ActuatorPwm.h
+++ b/lib/inc/ActuatorPwm.h
@@ -67,7 +67,11 @@ public:
         std::function<std::shared_ptr<ActuatorDigitalChangeLogged>()>&& target,
         duration_millis_t period = 4000);
 
-    ~ActuatorPwm() = default;
+    ~ActuatorPwm()
+    {
+        // ensure that interrupts are removed before destruction.
+        enabled(false);
+    };
 
     /** ActuatorPWM keeps track of the last high and low transition.
      *  This function returns the actually achieved value. This can differ from


### PR DESCRIPTION
A 100Hz PWM block registers a timer interrupt for toggling. This interrupt handler gets a copy of the this pointer. On destruction of the PWM object, the interrupt handler was not removed and the dangling this pointer caused a crash.

This PR adds the unregister in the destructor to fix the bug.