### PR TITLE
Only re-init OneWire sensors when required an possible

### DIFF
--- a/lib/inc/DallasTemperature.h
+++ b/lib/inc/DallasTemperature.h
@@ -108,6 +108,7 @@
 #define DEVICE_DISCONNECTED_F -196.6
 #endif
 #define DEVICE_DISCONNECTED_RAW -2032
+#define RESET_DETECTED_RAW -2031
 
 class DallasTemperature {
 public:

--- a/lib/src/DallasTemperature.cpp
+++ b/lib/src/DallasTemperature.cpp
@@ -616,7 +616,7 @@ DallasTemperature::getTempRaw(const uint8_t* deviceAddress)
     }
     // return DEVICE_DISCONNECTED when a reset has been detected to force it to be reconfigured
     if (detectedReset(scratchPad)) {
-        return DEVICE_DISCONNECTED_RAW;
+        return RESET_DETECTED_RAW;
     }
     return calculateTemperature(deviceAddress, scratchPad);
 }


### PR DESCRIPTION
The firmware tried to re-init a OneWire sensor any time it was unable to read the sensor successfully. 
When the sensor is disconnected, this behavior is:
- Useless: can't find a disconnected sensor
- Very time consuming.

A few disconnected sensors could slow down the control loop from a few ms to over a second.

This PR fixes the behavior to only re-initialize a OneWire sensor when:
- It actually found
- Our mechanism to use the HIGH_ALARM temperature to detect that the DS18B20 registers have their default boot state indicates that the sensor has been reset (most likely lost power).

After this fix, a disconnected sensor has no significant impact on the control loop duration.