### PR TITLE
Workaround for hard fault caused by Particle device-os WiFi threading behavior

### DIFF
--- a/app/brewblox/connectivity.cpp
+++ b/app/brewblox/connectivity.cpp
@@ -18,27 +18,45 @@
  */
 
 #include "connectivity.h"
+#include "Board.h"
+#include "MDNS.h"
+#include "spark_wiring_system.h"
+#include "spark_wiring_tcpclient.h"
+#include "spark_wiring_tcpserver.h"
 #include "spark_wiring_usbserial.h"
 #include "spark_wiring_wifi.h"
 #include <cstdio>
+volatile uint32_t localIp = 0;
+volatile bool wifiIsConnected = false;
+
+auto mdns = MDNS();
+volatile bool mdns_started = false;
+#if PLATFORM_ID == PLATFORM_GCC
+auto httpserver = TCPServer(8380); // listen on 8380 to serve a simple page with instructions
+#else
+auto httpserver = TCPServer(80); // listen on 80 to serve a simple page with instructions
+#endif
 
 void
 printWiFiIp(char dest[16])
 {
-    IPAddress ip = spark::WiFi.localIP();
+    IPAddress ip = localIp;
     snprintf(dest, 16, "%d.%d.%d.%d", ip[0], ip[1], ip[2], ip[3]);
 }
 
 int8_t
 wifiSignal()
 {
-    if (!spark::WiFi.ready()) {
+    if (!wifiIsConnected) {
         return 2;
     }
-    auto rssi = wlan_connected_rssi();
 
-    return rssi != std::numeric_limits<decltype(rssi)>::min() ? rssi / 100 : 2;
-
+    wlan_connected_info_t info = {0};
+    info.size = sizeof(info);
+    int r = wlan_connected_info(nullptr, &info, nullptr);
+    if (r == 0) {
+        return info.rssi != std::numeric_limits<int32_t>::min() ? info.rssi / 100 : 2;
+    }
     return 2;
 }
 
@@ -57,9 +75,101 @@ setWifiCredentials(const char* ssid, const char* password, uint8_t security, uin
 void
 printWifiSSID(char* dest, const uint8_t& maxLen)
 {
-    if (spark::WiFi.ready()) {
+    if (wifiIsConnected) {
         strncpy(dest, spark::WiFi.SSID(), maxLen);
     } else {
         dest[0] = 0;
     }
+}
+
+bool
+wifiConnected()
+{
+    return wifiIsConnected;
+}
+
+bool
+listeningModeEnabled()
+{
+    return spark::WiFi.listening();
+}
+
+void
+manageConnections()
+{
+    if (wifiIsConnected) {
+        if (!mdns_started) {
+            mdns_started = mdns.begin(true);
+        } else {
+            mdns.processQueries();
+        }
+        TCPClient client = httpserver.available();
+        if (client) {
+            while (client.read() != -1) {
+            }
+
+            client.write("HTTP/1.1 200 Ok\n\n<html><body>Your BrewBlox Spark is online but it does not run its own web server.\n"
+                         "Please install a BrewBlox server to connect to it using the BrewBlox protocol.</body></html>\n\n");
+            client.flush();
+            delay(5);
+            client.stop();
+        }
+    }
+}
+
+void
+initMdns()
+{
+    bool success = mdns.setHostname(System.deviceID());
+    success = success && mdns.addService("tcp", "http", 80, System.deviceID());
+    success = success && mdns.addService("tcp", "brewblox", 8332, System.deviceID());
+    if (success) {
+        auto hw = String("Spark ");
+        switch (getSparkVersion()) {
+        case SparkVersion::V1:
+            hw += "1";
+            break;
+        case SparkVersion::V2:
+            hw += "2";
+            break;
+        case SparkVersion::V3:
+            hw += "3";
+            break;
+        }
+        mdns.addTXTEntry("VERSION", stringify(GIT_VERSION));
+        mdns.addTXTEntry("ID", System.deviceID());
+        mdns.addTXTEntry("PLATFORM", stringify(PLATFORM_ID));
+        mdns.addTXTEntry("HW", hw);
+    }
+}
+
+void
+handleNetworkEvent(system_event_t event, int param)
+{
+    switch (param) {
+    case network_status_connected: {
+        IPAddress ip = spark::WiFi.localIP();
+        localIp = ip.raw().ipv4;
+        wifiIsConnected = true;
+#if PLATFORM_ID != PLATFORM_GCC
+        Particle.connect();
+
+#endif
+    } break;
+    default:
+        localIp = uint32_t(0);
+        wifiIsConnected = false;
+        Particle.disconnect();
+        break;
+    }
+}
+
+void
+wifiInit()
+{
+    System.disable(SYSTEM_FLAG_RESET_NETWORK_ON_CLOUD_ERRORS);
+    spark::WiFi.setListenTimeout(30);
+    spark::WiFi.connect(WIFI_CONNECT_SKIP_LISTEN);
+    System.on(network_status, handleNetworkEvent);
+    initMdns();
 }

--- a/app/brewblox/connectivity.cpp
+++ b/app/brewblox/connectivity.cpp
@@ -18,28 +18,26 @@
  */
 
 #include "connectivity.h"
-#include "application.h"
+#include "spark_wiring_usbserial.h"
+#include "spark_wiring_wifi.h"
+#include <cstdio>
 
 void
 printWiFiIp(char dest[16])
 {
-    IPAddress ip = WiFi.localIP();
+    IPAddress ip = spark::WiFi.localIP();
     snprintf(dest, 16, "%d.%d.%d.%d", ip[0], ip[1], ip[2], ip[3]);
 }
 
 int8_t
 wifiSignal()
 {
-    if (!WiFi.ready()) {
+    if (!spark::WiFi.ready()) {
         return 2;
     }
+    auto rssi = wlan_connected_rssi();
 
-    wlan_connected_info_t info = {0};
-    info.size = sizeof(info);
-    int r = wlan_connected_info(nullptr, &info, nullptr);
-    if (r == 0) {
-        return info.rssi != std::numeric_limits<int32_t>::min() ? info.rssi / 100 : 2;
-    }
+    return rssi != std::numeric_limits<decltype(rssi)>::min() ? rssi / 100 : 2;
 
     return 2;
 }
@@ -47,17 +45,21 @@ wifiSignal()
 bool
 serialConnected()
 {
-    return Serial.isConnected();
+    return _fetch_usbserial().isConnected();
 }
 
 bool
 setWifiCredentials(const char* ssid, const char* password, uint8_t security, uint8_t cipher)
 {
-    return WiFi.setCredentials(ssid, password, security, cipher);
+    return spark::WiFi.setCredentials(ssid, password, security, cipher);
 };
 
 void
 printWifiSSID(char* dest, const uint8_t& maxLen)
 {
-    strncpy(dest, WiFi.SSID(), maxLen);
+    if (spark::WiFi.ready()) {
+        strncpy(dest, spark::WiFi.SSID(), maxLen);
+    } else {
+        dest[0] = 0;
+    }
 }

--- a/app/brewblox/connectivity.h
+++ b/app/brewblox/connectivity.h
@@ -18,6 +18,7 @@
  */
 
 #pragma once
+#include "system_event.h"
 #include <cstdint>
 
 void
@@ -34,3 +35,15 @@ serialConnected();
 
 bool
 setWifiCredentials(const char* ssid, const char* password, uint8_t security, uint8_t cipher);
+
+void
+handleNetworkEvent(system_event_t event, int param);
+
+void
+wifiInit();
+
+bool
+listeningModeEnabled();
+
+void
+manageConnections();

--- a/app/brewblox/display/screens/WidgetsScreen.cpp
+++ b/app/brewblox/display/screens/WidgetsScreen.cpp
@@ -160,21 +160,19 @@ WidgetsScreen::updateWiFi()
     auto signal = wifiSignal();
     printWiFiIp(wifi_ip);
 
+    bool connected = true;
     if (signal >= 0) {
         wifi_icon[0] = 0x22;
-        D4D_EnableObject(&scrWidgets_wifi_icon, false);
-        D4D_EnableObject(&scrWidgets_wifi_ip, false);
-        return;
-    }
-    if (signal >= -65) {
+        connected = false;
+    } else if (signal >= -65) {
         wifi_icon[0] = 0x25;
     } else if (signal >= -70) {
         wifi_icon[0] = 0x24;
     } else {
         wifi_icon[0] = 0x23;
     }
-    D4D_EnableObject(&scrWidgets_wifi_icon, true);
-    D4D_EnableObject(&scrWidgets_wifi_ip, true);
+    D4D_EnableObject(&scrWidgets_wifi_icon, connected);
+    D4D_EnableObject(&scrWidgets_wifi_ip, connected);
 }
 
 void

--- a/app/brewblox/main.cpp
+++ b/app/brewblox/main.cpp
@@ -23,12 +23,12 @@
 #include "Buzzer.h"
 #include "MDNS.h"
 #include "TimerInterrupts.h"
-#include "application.h" // particle stuff
 #include "blox/stringify.h"
 #include "cbox/Object.h"
 #include "d4d.hpp"
 #include "display/screens/WidgetsScreen.h"
 #include "display/screens/startup_screen.h"
+#include "spark_wiring_system.h"
 #include "spark_wiring_timer.h"
 
 SYSTEM_THREAD(ENABLED);

--- a/app/brewblox/main.cpp
+++ b/app/brewblox/main.cpp
@@ -21,10 +21,10 @@
 #include "Board.h"
 #include "BrewBlox.h"
 #include "Buzzer.h"
-#include "MDNS.h"
 #include "TimerInterrupts.h"
 #include "blox/stringify.h"
 #include "cbox/Object.h"
+#include "connectivity.h"
 #include "d4d.hpp"
 #include "display/screens/WidgetsScreen.h"
 #include "display/screens/startup_screen.h"
@@ -36,14 +36,6 @@
 SYSTEM_THREAD(ENABLED);
 SYSTEM_MODE(SEMI_AUTOMATIC);
 STARTUP(System.enableFeature(FEATURE_RESET_INFO));
-
-auto mdns = MDNS();
-auto mdns_started = bool(false);
-#if PLATFORM_ID == PLATFORM_GCC
-auto httpserver = TCPServer(8380); // listen on 8380 to serve a simple page with instructions
-#else
-auto httpserver = TCPServer(80); // listen on 80 to serve a simple page with instructions
-#endif
 
 #if PLATFORM_ID == PLATFORM_GCC
 #include <csignal>
@@ -84,60 +76,6 @@ displayTick()
 }
 
 void
-manageConnections()
-{
-    if (spark::WiFi.ready() && !spark::WiFi.listening()) {
-#if PLATFORM_ID != PLATFORM_GCC
-        Particle.connect();
-#endif
-        if (!mdns_started) {
-            mdns_started = mdns.begin(true);
-        } else {
-            mdns.processQueries();
-        }
-        TCPClient client = httpserver.available();
-        if (client) {
-            while (client.read() != -1) {
-            }
-
-            client.write("HTTP/1.1 200 Ok\n\n<html><body>Your BrewBlox Spark is online but it does not run its own web server.\n"
-                         "Please install a BrewBlox server to connect to it using the BrewBlox protocol.</body></html>\n\n");
-            client.flush();
-            delay(5);
-            client.stop();
-        }
-    } else if (!spark::WiFi.connecting()) {
-        spark::WiFi.connect(WIFI_CONNECT_SKIP_LISTEN);
-    }
-}
-
-void
-initMdns()
-{
-    bool success = mdns.setHostname(System.deviceID());
-    success = success && mdns.addService("tcp", "http", 80, System.deviceID());
-    success = success && mdns.addService("tcp", "brewblox", 8332, System.deviceID());
-    if (success) {
-        auto hw = String("Spark ");
-        switch (getSparkVersion()) {
-        case SparkVersion::V1:
-            hw += "1";
-            break;
-        case SparkVersion::V2:
-            hw += "2";
-            break;
-        case SparkVersion::V3:
-            hw += "3";
-            break;
-        }
-        mdns.addTXTEntry("VERSION", stringify(GIT_VERSION));
-        mdns.addTXTEntry("ID", System.deviceID());
-        mdns.addTXTEntry("PLATFORM", stringify(PLATFORM_ID));
-        mdns.addTXTEntry("HW", hw);
-    }
-}
-
-void
 setup()
 {
     // Install a signal handler
@@ -147,8 +85,6 @@ setup()
     boardInit();
     Buzzer.beep(2, 50);
 
-    System.disable(SYSTEM_FLAG_RESET_NETWORK_ON_CLOUD_ERRORS);
-    spark::WiFi.setListenTimeout(30);
     System.on(setup_update, watchdogCheckin);
 
 #if PLATFORM_ID == PLATFORM_GCC
@@ -176,11 +112,6 @@ setup()
     StartupScreen::setProgress(80);
     StartupScreen::setStep("Loading objects");
     brewbloxBox().loadObjectsFromStorage(); // init box and load stored objects
-    StartupScreen::setProgress(90);
-
-    StartupScreen::setStep("Init mDNS");
-    initMdns();
-
     StartupScreen::setProgress(100);
 
     // perform pending EEPROM erase while we're waiting. Can take up to 500ms and stalls all code execution
@@ -197,13 +128,15 @@ setup()
 #if PLATFORM_ID != PLATFORM_GCC
     TimerInterrupts::init();
 #endif
+
+    wifiInit();
 }
 
 void
 loop()
 {
     ticks.switchTaskTimer(TicksClass::TaskId::Communication);
-    if (!spark::WiFi.listening()) {
+    if (!listeningModeEnabled()) {
         manageConnections();
         brewbloxBox().hexCommunicate();
     }

--- a/app/minimal/application.cpp
+++ b/app/minimal/application.cpp
@@ -1,61 +1,37 @@
 /* Includes ------------------------------------------------------------------*/
 #include "application.h"
-#include <vector>
 
-SYSTEM_THREAD(ENABLED);
 SYSTEM_MODE(SEMI_AUTOMATIC);
 
+// Define the pins we're going to call pinMode on
+int act1 = A0;
+int act2 = A1;
+int act3 = A6;
+int act4 = A7;
 int buzz = A2;
-
-IPAddress ip = uint32_t(0);
-bool connected = false;
-
-void
-printWiFiIp(char dest[16])
-{
-    snprintf(dest, 16, "%d.%d.%d.%d", ip[0], ip[1], ip[2], ip[3]);
-}
-
-std::vector<system_event_t> events;
-
-void
-handleNetworkEvent(system_event_t event, int param)
-{
-    switch (param) {
-    case network_status_connected:
-        ip = WiFi.localIP();
-        connected = true;
-        Particle.connect();
-        break;
-    default:
-        ip = uint32_t(0);
-        connected = false;
-        break;
-    }
-    events.push_back(param);
-}
+const bool invertBuzzer = false;
 
 void
 setup()
 {
+    pinMode(act1, OUTPUT);
+    pinMode(act2, OUTPUT);
+    pinMode(act3, OUTPUT);
+    pinMode(act4, OUTPUT);
     pinMode(buzz, OUTPUT);
-    digitalWrite(buzz, HIGH);
+    digitalWrite(buzz, !invertBuzzer);
     delay(200);
-    digitalWrite(buzz, LOW);
-    Serial.begin();
+    digitalWrite(buzz, invertBuzzer);
 }
 
 void
 loop()
 {
-    char ipString[16];
-    printWiFiIp(ipString);
-    Serial.println();
-    Serial.print("IP: ");
-    Serial.println(ipString);
-    delay(5000);
-    for (auto& event : events) {
-        Serial.print(uint32_t(event));
-        Serial.print(',');
+    int actuators[4] = {act1, act2, act3, act4};
+    for (int i = 0; i < 4; i++) {
+        digitalWrite(actuators[i], HIGH);
+        delay(500);
+        digitalWrite(actuators[i], LOW);
+        delay(500);
     }
 }

--- a/app/minimal/application.cpp
+++ b/app/minimal/application.cpp
@@ -1,33 +1,61 @@
 /* Includes ------------------------------------------------------------------*/
 #include "application.h"
+#include <vector>
 
+SYSTEM_THREAD(ENABLED);
 SYSTEM_MODE(SEMI_AUTOMATIC);
 
-// Define the pins we're going to call pinMode on
-int act1 = A0;
-int act2 = A1;
-int act3 = A6;
-int act4 = A7;
 int buzz = A2;
-const bool invertBuzzer = false;
 
-void setup() {
-    pinMode(act1, OUTPUT);
-    pinMode(act2, OUTPUT);
-    pinMode(act3, OUTPUT);
-    pinMode(act4, OUTPUT);
-    pinMode(buzz, OUTPUT);
-    digitalWrite(buzz, !invertBuzzer);
-    delay(200);
-    digitalWrite(buzz, invertBuzzer);
+IPAddress ip = uint32_t(0);
+bool connected = false;
+
+void
+printWiFiIp(char dest[16])
+{
+    snprintf(dest, 16, "%d.%d.%d.%d", ip[0], ip[1], ip[2], ip[3]);
 }
 
-void loop(){
-    int actuators[4] = {act1, act2, act3, act4};
-    for(int i=0;i<4;i++){
-        digitalWrite(actuators[i], HIGH);
-        delay(500);
-        digitalWrite(actuators[i], LOW);
-        delay(500);
+std::vector<system_event_t> events;
+
+void
+handleNetworkEvent(system_event_t event, int param)
+{
+    switch (param) {
+    case network_status_connected:
+        ip = WiFi.localIP();
+        connected = true;
+        Particle.connect();
+        break;
+    default:
+        ip = uint32_t(0);
+        connected = false;
+        break;
+    }
+    events.push_back(param);
+}
+
+void
+setup()
+{
+    pinMode(buzz, OUTPUT);
+    digitalWrite(buzz, HIGH);
+    delay(200);
+    digitalWrite(buzz, LOW);
+    Serial.begin();
+}
+
+void
+loop()
+{
+    char ipString[16];
+    printWiFiIp(ipString);
+    Serial.println();
+    Serial.print("IP: ");
+    Serial.println(ipString);
+    delay(5000);
+    for (auto& event : events) {
+        Serial.print(uint32_t(event));
+        Serial.print(',');
     }
 }

--- a/controlbox/src/cbox/spark/ConnectionsTcp.h
+++ b/controlbox/src/cbox/spark/ConnectionsTcp.h
@@ -50,8 +50,7 @@ public:
 
     std::unique_ptr<Connection> newConnection() override final
     {
-        using namespace spark;
-        if (WiFi.ready() && !WiFi.listening()) {
+        if (spark::WiFi.ready() && !spark::WiFi.listening()) {
             TCPClient newClient = server.available();
             if (newClient.connected()) {
                 return std::make_unique<TcpConnection>(std::move(newClient));

--- a/platform/spark/modules/mdns/src/Buffer.cpp
+++ b/platform/spark/modules/mdns/src/Buffer.cpp
@@ -1,73 +1,101 @@
 #include "Buffer.h"
+#include "stdlib.h"
 
-Buffer::Buffer(uint16_t size) {
-  this->data = (uint8_t *) malloc(size);
-  this->size = data != NULL? size : 0;
+Buffer::Buffer(uint16_t size)
+{
+    this->data = (uint8_t*)malloc(size);
+    this->size = data != NULL ? size : 0;
 }
 
-uint16_t Buffer::available() {
-  return offset < limit? limit - offset : offset - limit;
+uint16_t
+Buffer::available()
+{
+    return offset < limit ? limit - offset : offset - limit;
 }
 
-void Buffer::mark() {
-  if (markOffset == INVALID_MARK_OFFSET) {
-    markOffset = offset;
-  }
+void
+Buffer::mark()
+{
+    if (markOffset == INVALID_MARK_OFFSET) {
+        markOffset = offset;
+    }
 }
 
-void Buffer::reset() {
-  if (markOffset != INVALID_MARK_OFFSET) {
-    offset = markOffset;
-    markOffset = INVALID_MARK_OFFSET;
-  }
+void
+Buffer::reset()
+{
+    if (markOffset != INVALID_MARK_OFFSET) {
+        offset = markOffset;
+        markOffset = INVALID_MARK_OFFSET;
+    }
 }
 
-void Buffer::setOffset(uint16_t offset) {
-  this->offset = offset;
+void
+Buffer::setOffset(uint16_t offset)
+{
+    this->offset = offset;
 }
 
-uint16_t Buffer::getOffset() {
-  return offset;
+uint16_t
+Buffer::getOffset()
+{
+    return offset;
 }
 
-void Buffer::read(UDP * udp) {
-  offset = 0;
-  limit = udp->read(data, size);
+void
+Buffer::read(UDP* udp)
+{
+    offset = 0;
+    limit = udp->read(data, size);
 }
 
-uint8_t Buffer::readUInt8() {
-  return data[offset++];
+uint8_t
+Buffer::readUInt8()
+{
+    return data[offset++];
 }
 
-uint16_t Buffer::readUInt16() {
-  return readUInt8() << 8 | readUInt8();
+uint16_t
+Buffer::readUInt16()
+{
+    return readUInt8() << 8 | readUInt8();
 }
 
-void Buffer::writeUInt8(uint8_t value) {
-  if (offset < size) {
-    data[offset++] = value;
-  }
+void
+Buffer::writeUInt8(uint8_t value)
+{
+    if (offset < size) {
+        data[offset++] = value;
+    }
 }
 
-void Buffer::writeUInt16(uint16_t value) {
-  writeUInt8(value >> 8);
-  writeUInt8(value);
+void
+Buffer::writeUInt16(uint16_t value)
+{
+    writeUInt8(value >> 8);
+    writeUInt8(value);
 }
 
-void Buffer::writeUInt32(uint32_t value) {
-  writeUInt8(value >> 24);
-  writeUInt8(value >> 16);
-  writeUInt8(value >> 8);
-  writeUInt8(value);
+void
+Buffer::writeUInt32(uint32_t value)
+{
+    writeUInt8(value >> 24);
+    writeUInt8(value >> 16);
+    writeUInt8(value >> 8);
+    writeUInt8(value);
 }
 
-void Buffer::write(UDP * udp) {
-  udp->write(data, offset);
+void
+Buffer::write(UDP* udp)
+{
+    udp->write(data, offset);
 
-  offset = 0;
+    offset = 0;
 }
 
-void Buffer::clear() {
-  offset = 0;
-  limit = 0;
+void
+Buffer::clear()
+{
+    offset = 0;
+    limit = 0;
 }

--- a/platform/spark/modules/mdns/src/Buffer.h
+++ b/platform/spark/modules/mdns/src/Buffer.h
@@ -1,42 +1,42 @@
-#include "application.h"
-
 #ifndef _INCL_BUFFER
 #define _INCL_BUFFER
+
+#include "spark_wiring_udp.h"
+#include <cstdint>
 
 #define INVALID_MARK_OFFSET 0xffff
 
 class Buffer {
 public:
-  Buffer(uint16_t size);
+    Buffer(uint16_t size);
 
-  uint16_t available();
-  
-  void mark();
-  void reset();
-  void setOffset(uint16_t offset);
-  uint16_t getOffset();
+    uint16_t available();
 
-  void read(UDP * udp);
+    void mark();
+    void reset();
+    void setOffset(uint16_t offset);
+    uint16_t getOffset();
 
-  uint8_t readUInt8();
-  uint16_t readUInt16();
+    void read(UDP* udp);
 
-  void write(UDP * udp);
+    uint8_t readUInt8();
+    uint16_t readUInt16();
 
-  void writeUInt8(uint8_t value);
-  void writeUInt16(uint16_t value);
-  void writeUInt32(uint32_t value);
+    void write(UDP* udp);
 
-  void clear();
+    void writeUInt8(uint8_t value);
+    void writeUInt16(uint16_t value);
+    void writeUInt32(uint32_t value);
+
+    void clear();
 
 private:
+    uint8_t* data;
+    uint16_t size;
 
-  uint8_t * data;
-  uint16_t size;
-
-  uint16_t limit = 0;
-  uint16_t offset = 0;
-  uint16_t markOffset = INVALID_MARK_OFFSET;
+    uint16_t limit = 0;
+    uint16_t offset = 0;
+    uint16_t markOffset = INVALID_MARK_OFFSET;
 };
 
 #endif

--- a/platform/spark/modules/mdns/src/Label.cpp
+++ b/platform/spark/modules/mdns/src/Label.cpp
@@ -1,298 +1,347 @@
 #include "Label.h"
+#include "stdlib.h"
 
-Label::Label(String name, Label * nextLabel, bool caseSensitive) {
-  data = (uint8_t *) malloc(name.length() + 1);
+Label::Label(String name, Label* nextLabel, bool caseSensitive)
+{
+    data = (uint8_t*)malloc(name.length() + 1);
 
-  if (data) {
-    data[0] = name.length();
-    for (uint8_t i = 0; i < name.length(); i++) {
-      data[i + 1] = name.charAt(i);
-    }
-  } else {
-    data = EMPTY_DATA;
-  }
-
-  this->nextLabel = nextLabel;
-  this->caseSensitive = caseSensitive;
-}
-
-uint8_t Label::getSize() {
-  return data[0];
-}
-
-uint8_t Label::getWriteSize() {
-  Label * label = this;
-  uint8_t size = 0;
-
-  while (label != NULL) {
-    if (label->writeOffset == INVALID_OFFSET) {
-      size += label->data[0] + 1;
-      label = label->nextLabel;
+    if (data) {
+        data[0] = name.length();
+        for (uint8_t i = 0; i < name.length(); i++) {
+            data[i + 1] = name.charAt(i);
+        }
     } else {
-      size += 2;
-      label = NULL;
-    }
-  }
-
-  return size;
-}
-
-void Label::write(Buffer * buffer) {
-  Label * label = this;
-
-  while (label) {
-    if (label->writeOffset == INVALID_OFFSET) {
-      label->writeOffset = buffer->getOffset();
-
-      uint8_t size = label->data[0] + 1;
-
-      for (uint8_t i = 0; i < size; i++) {
-        buffer->writeUInt8(label->data[i]);
-      }
-
-      label = label->nextLabel;
-    } else {
-      buffer->writeUInt16((LABEL_POINTER << 8) | label->writeOffset);
-      label = NULL;
-    }
-  }
-}
-
-void Label::reset() {
-  Label * label = this;
-
-  while (label != NULL) {
-    label->writeOffset = INVALID_OFFSET;
-
-    label = label->nextLabel;
-  }
-}
-
-Label::Reader::Reader(Buffer * buffer) {
-  this->buffer = buffer;
-}
-
-bool Label::Reader::hasNext() {
-  return c != END_OF_NAME && buffer->available() > 0;
-}
-
-uint8_t Label::Reader::next() {
-  c = buffer->readUInt8();
-
-  while ((c & LABEL_POINTER) == LABEL_POINTER) {
-    if (buffer->available() > 0) {
-      uint8_t c2 = buffer->readUInt8();
-
-      uint16_t pointerOffset = ((c & ~LABEL_POINTER) << 8) | c2;
-
-      buffer->mark();
-
-      buffer->setOffset(pointerOffset);
-
-      c = buffer->readUInt8();
-    }
-  }
-
-  return c;
-}
-
-bool Label::Reader::endOfName() {
-  return c == END_OF_NAME;
-}
-
-Label::Iterator::Iterator(Label * label) {
-  this->label = label;
-  this->startLabel = label;
-  this->size = label->data[0];
-}
-
-bool Label::Iterator::match(uint8_t c) {
-  if (matches) {
-    while (offset > size && label) {
-      label = label->nextLabel;
-      size = label->data[0];
-      offset = 0;
+        data = EMPTY_DATA;
     }
 
-    matches = offset <= size && label && (label->data[offset] == c || (!label->caseSensitive && equalsIgnoreCase(c)));
-
-    offset++;
-  }
-
-  return matches;
+    this->nextLabel = nextLabel;
+    this->caseSensitive = caseSensitive;
 }
 
-bool Label::Iterator::matched() {
-  return matches;
+uint8_t
+Label::getSize()
+{
+    return data[0];
 }
 
-bool Label::Iterator::equalsIgnoreCase(uint8_t c) {
-  return (c >= 'a' && c <= 'z' && label->data[offset] == c - 32) || (c >= 'A' && c <= 'Z' && label->data[offset] == c + 32);
+uint8_t
+Label::getWriteSize()
+{
+    Label* label = this;
+    uint8_t size = 0;
+
+    while (label != NULL) {
+        if (label->writeOffset == INVALID_OFFSET) {
+            size += label->data[0] + 1;
+            label = label->nextLabel;
+        } else {
+            size += 2;
+            label = NULL;
+        }
+    }
+
+    return size;
 }
 
-Label * Label::Iterator::getStartLabel() {
-  return startLabel;
+void
+Label::write(Buffer* buffer)
+{
+    Label* label = this;
+
+    while (label) {
+        if (label->writeOffset == INVALID_OFFSET) {
+            label->writeOffset = buffer->getOffset();
+
+            uint8_t size = label->data[0] + 1;
+
+            for (uint8_t i = 0; i < size; i++) {
+                buffer->writeUInt8(label->data[i]);
+            }
+
+            label = label->nextLabel;
+        } else {
+            buffer->writeUInt16((LABEL_POINTER << 8) | label->writeOffset);
+            label = NULL;
+        }
+    }
 }
 
-Label * Label::Matcher::match(std::map<String, Label *> labels, Buffer * buffer) {
+void
+Label::reset()
+{
+    Label* label = this;
 
-  Iterator * iterators[labels.size()];
+    while (label != NULL) {
+        label->writeOffset = INVALID_OFFSET;
 
-  std::map<String, Label *>::const_iterator i;
+        label = label->nextLabel;
+    }
+}
 
-  uint8_t idx = 0;
+Label::Reader::Reader(Buffer* buffer)
+{
+    this->buffer = buffer;
+}
 
-  for (i = labels.begin(); i != labels.end(); ++i) {
-    iterators[idx++] = new Iterator(i->second);
-  }
+bool
+Label::Reader::hasNext()
+{
+    return c != END_OF_NAME && buffer->available() > 0;
+}
 
-  Reader * reader = new Reader(buffer);
+uint8_t
+Label::Reader::next()
+{
+    c = buffer->readUInt8();
 
-  while (reader->hasNext()) {
-    uint8_t size = reader->next();
+    while ((c & LABEL_POINTER) == LABEL_POINTER) {
+        if (buffer->available() > 0) {
+            uint8_t c2 = buffer->readUInt8();
+
+            uint16_t pointerOffset = ((c & ~LABEL_POINTER) << 8) | c2;
+
+            buffer->mark();
+
+            buffer->setOffset(pointerOffset);
+
+            c = buffer->readUInt8();
+        }
+    }
+
+    return c;
+}
+
+bool
+Label::Reader::endOfName()
+{
+    return c == END_OF_NAME;
+}
+
+Label::Iterator::Iterator(Label* label)
+{
+    this->label = label;
+    this->startLabel = label;
+    this->size = label->data[0];
+}
+
+bool
+Label::Iterator::match(uint8_t c)
+{
+    if (matches) {
+        while (offset > size && label) {
+            label = label->nextLabel;
+            size = label->data[0];
+            offset = 0;
+        }
+
+        matches = offset <= size && label && (label->data[offset] == c || (!label->caseSensitive && equalsIgnoreCase(c)));
+
+        offset++;
+    }
+
+    return matches;
+}
+
+bool
+Label::Iterator::matched()
+{
+    return matches;
+}
+
+bool
+Label::Iterator::equalsIgnoreCase(uint8_t c)
+{
+    return (c >= 'a' && c <= 'z' && label->data[offset] == c - 32) || (c >= 'A' && c <= 'Z' && label->data[offset] == c + 32);
+}
+
+Label*
+Label::Iterator::getStartLabel()
+{
+    return startLabel;
+}
+
+Label*
+Label::Matcher::match(std::map<String, Label*> labels, Buffer* buffer)
+{
+
+    Iterator* iterators[labels.size()];
+
+    std::map<String, Label*>::const_iterator i;
 
     uint8_t idx = 0;
+
+    for (i = labels.begin(); i != labels.end(); ++i) {
+        iterators[idx++] = new Iterator(i->second);
+    }
+
+    Reader* reader = new Reader(buffer);
+
+    while (reader->hasNext()) {
+        uint8_t size = reader->next();
+
+        uint8_t idx = 0;
+
+        for (uint8_t i = 0; i < labels.size(); i++) {
+            iterators[i]->match(size);
+        }
+
+        while (idx < size && reader->hasNext()) {
+            uint8_t c = reader->next();
+
+            for (uint8_t i = 0; i < labels.size(); i++) {
+                iterators[i]->match(c);
+            }
+
+            idx++;
+        }
+    }
+
+    buffer->reset();
+
+    Label* label = NULL;
+
+    if (reader->endOfName()) {
+        uint8_t idx = 0;
+
+        while (label == NULL && idx < labels.size()) {
+            if (iterators[idx]->matched()) {
+                label = iterators[idx]->getStartLabel();
+            }
+
+            idx++;
+        }
+    }
 
     for (uint8_t i = 0; i < labels.size(); i++) {
-      iterators[i]->match(size);
+        delete iterators[i];
     }
 
-    while(idx < size && reader->hasNext()) {
-      uint8_t c = reader->next();
+    delete reader;
 
-      for (uint8_t i = 0; i < labels.size(); i++) {
-        iterators[i]->match(c);
-      }
-
-      idx++;
-    }
-  }
-
-
-  buffer->reset();
-
-  Label * label = NULL;
-
-  if (reader->endOfName()) {
-    uint8_t idx = 0;
-
-    while (label == NULL && idx < labels.size()) {
-      if (iterators[idx]->matched()) {
-        label = iterators[idx]->getStartLabel();
-      }
-
-      idx++;
-    }
-  }
-
-  for (uint8_t i = 0; i < labels.size(); i++) {
-    delete iterators[i];
-  }
-
-  delete reader;
-
-  return label;
+    return label;
 }
 
-void Label::matched(uint16_t type, uint16_t cls) {
+void
+Label::matched(uint16_t type, uint16_t cls)
+{
 }
 
-HostLabel::HostLabel(Record * aRecord, Record * nsecRecord, String name, Label * nextLabel, bool caseSensitive):Label(name, nextLabel, caseSensitive) {
-  this->aRecord = aRecord;
-  this->nsecRecord = nsecRecord;
+HostLabel::HostLabel(Record* aRecord, Record* nsecRecord, String name, Label* nextLabel, bool caseSensitive)
+    : Label(name, nextLabel, caseSensitive)
+{
+    this->aRecord = aRecord;
+    this->nsecRecord = nsecRecord;
 }
 
-void HostLabel::matched(uint16_t type, uint16_t cls) {
-  switch(type) {
+void
+HostLabel::matched(uint16_t type, uint16_t cls)
+{
+    switch (type) {
     case A_TYPE:
     case ANY_TYPE:
-    aRecord->setAnswerRecord();
-    nsecRecord->setAdditionalRecord();
-    break;
+        aRecord->setAnswerRecord();
+        nsecRecord->setAdditionalRecord();
+        break;
 
     default:
-    nsecRecord->setAnswerRecord();
-  }
+        nsecRecord->setAnswerRecord();
+    }
 }
 
-ServiceLabel::ServiceLabel(Record * aRecord, String name, Label * nextLabel, bool caseSensitive):Label(name, nextLabel, caseSensitive) {
-  this->aRecord = aRecord;
+ServiceLabel::ServiceLabel(Record* aRecord, String name, Label* nextLabel, bool caseSensitive)
+    : Label(name, nextLabel, caseSensitive)
+{
+    this->aRecord = aRecord;
 }
 
-void ServiceLabel::addInstance(Record * ptrRecord, Record * srvRecord, Record * txtRecord) {
+void
+ServiceLabel::addInstance(Record* ptrRecord, Record* srvRecord, Record* txtRecord)
+{
     ptrRecords.push_back(ptrRecord);
     srvRecords.push_back(srvRecord);
     txtRecords.push_back(txtRecord);
 }
 
-void ServiceLabel::matched(uint16_t type, uint16_t cls) {
-  switch(type) {
+void
+ServiceLabel::matched(uint16_t type, uint16_t cls)
+{
+    switch (type) {
     case PTR_TYPE:
     case ANY_TYPE:
-    for (std::vector<Record *>::const_iterator i = ptrRecords.begin(); i != ptrRecords.end(); ++i) {
-      (*i)->setAnswerRecord();
+        for (std::vector<Record*>::const_iterator i = ptrRecords.begin(); i != ptrRecords.end(); ++i) {
+            (*i)->setAnswerRecord();
+        }
+        for (std::vector<Record*>::const_iterator i = srvRecords.begin(); i != srvRecords.end(); ++i) {
+            (*i)->setAdditionalRecord();
+        }
+        for (std::vector<Record*>::const_iterator i = txtRecords.begin(); i != txtRecords.end(); ++i) {
+            (*i)->setAdditionalRecord();
+        }
+        aRecord->setAdditionalRecord();
+        break;
     }
-    for (std::vector<Record *>::const_iterator i = srvRecords.begin(); i != srvRecords.end(); ++i) {
-      (*i)->setAdditionalRecord();
-    }
-    for (std::vector<Record *>::const_iterator i = txtRecords.begin(); i != txtRecords.end(); ++i) {
-      (*i)->setAdditionalRecord();
-    }
-    aRecord->setAdditionalRecord();
-    break;
-  }
 }
 
-InstanceLabel::InstanceLabel(Record * srvRecord, Record * txtRecord, Record * nsecRecord, Record * aRecord, String name, Label * nextLabel, bool caseSensitive):Label(name, nextLabel, caseSensitive) {
-  this->srvRecord = srvRecord;
-  this->txtRecord = txtRecord;
-  this->nsecRecord = nsecRecord;
-  this->aRecord = aRecord;
+InstanceLabel::InstanceLabel(Record* srvRecord, Record* txtRecord, Record* nsecRecord, Record* aRecord, String name, Label* nextLabel, bool caseSensitive)
+    : Label(name, nextLabel, caseSensitive)
+{
+    this->srvRecord = srvRecord;
+    this->txtRecord = txtRecord;
+    this->nsecRecord = nsecRecord;
+    this->aRecord = aRecord;
 }
 
-void InstanceLabel::matched(uint16_t type, uint16_t cls) {
-  switch(type) {
+void
+InstanceLabel::matched(uint16_t type, uint16_t cls)
+{
+    switch (type) {
     case SRV_TYPE:
-    srvRecord->setAnswerRecord();
-    txtRecord->setAdditionalRecord();
-    nsecRecord->setAdditionalRecord();
-    aRecord->setAdditionalRecord();
-    break;
+        srvRecord->setAnswerRecord();
+        txtRecord->setAdditionalRecord();
+        nsecRecord->setAdditionalRecord();
+        aRecord->setAdditionalRecord();
+        break;
 
     case TXT_TYPE:
-    txtRecord->setAnswerRecord();
-    srvRecord->setAdditionalRecord();
-    nsecRecord->setAdditionalRecord();
-    aRecord->setAdditionalRecord();
-    break;
+        txtRecord->setAnswerRecord();
+        srvRecord->setAdditionalRecord();
+        nsecRecord->setAdditionalRecord();
+        aRecord->setAdditionalRecord();
+        break;
 
     case ANY_TYPE:
-    srvRecord->setAnswerRecord();
-    txtRecord->setAnswerRecord();
-    nsecRecord->setAdditionalRecord();
-    aRecord->setAdditionalRecord();
-    break;
+        srvRecord->setAnswerRecord();
+        txtRecord->setAnswerRecord();
+        nsecRecord->setAdditionalRecord();
+        aRecord->setAdditionalRecord();
+        break;
 
     default:
-    nsecRecord->setAnswerRecord();
-  }
+        nsecRecord->setAnswerRecord();
+    }
 }
 
-MetaLabel::MetaLabel(String name, Label * nextLabel):Label(name, nextLabel) {
-  // Do nothing
+MetaLabel::MetaLabel(String name, Label* nextLabel)
+    : Label(name, nextLabel)
+{
+    // Do nothing
 }
 
-void MetaLabel::addService(Record * ptrRecord) {
-  records.push_back(ptrRecord);
+void
+MetaLabel::addService(Record* ptrRecord)
+{
+    records.push_back(ptrRecord);
 }
 
-void MetaLabel::matched(uint16_t type, uint16_t cls) {
-  switch(type) {
+void
+MetaLabel::matched(uint16_t type, uint16_t cls)
+{
+    switch (type) {
     case PTR_TYPE:
     case ANY_TYPE:
-      for (std::vector<Record *>::const_iterator i = this->records.begin(); i != this->records.end(); ++i) {
-        (*i)->setAnswerRecord();
-      }
-      break;
-  }
+        for (std::vector<Record*>::const_iterator i = this->records.begin(); i != this->records.end(); ++i) {
+            (*i)->setAnswerRecord();
+        }
+        break;
+    }
 }

--- a/platform/spark/modules/mdns/src/Label.h
+++ b/platform/spark/modules/mdns/src/Label.h
@@ -1,5 +1,3 @@
-#include "application.h"
-
 #ifndef _INCL_LABEL
 #define _INCL_LABEL
 
@@ -7,6 +5,7 @@
 #include "Record.h"
 #include <map>
 #include <vector>
+#include "spark_wiring_string.h"
 
 #define DOT '.'
 
@@ -20,126 +19,122 @@
 
 class Label {
 private:
-
-  class Iterator;
+    class Iterator;
 
 public:
-  class Matcher {
-  public:
-    Label * match(std::map<String, Label *> labels, Buffer * buffer);
-  };
+    class Matcher {
+    public:
+        Label* match(std::map<String, Label*> labels, Buffer* buffer);
+    };
 
-  Label(String name, Label * nextLabel = NULL, bool caseSensitive = false);
+    Label(String name, Label* nextLabel = NULL, bool caseSensitive = false);
 
-  uint8_t getSize();
+    uint8_t getSize();
 
-  uint8_t getWriteSize();
+    uint8_t getWriteSize();
 
-  void write(Buffer * buffer);
+    void write(Buffer* buffer);
 
-  virtual void matched(uint16_t type, uint16_t cls);
+    virtual void matched(uint16_t type, uint16_t cls);
 
-  void reset();
+    void reset();
 
 private:
-  class Reader {
-  public:
-    Reader(Buffer * buffer);
+    class Reader {
+    public:
+        Reader(Buffer* buffer);
 
-    bool hasNext();
+        bool hasNext();
 
-    uint8_t next();
+        uint8_t next();
 
-    bool endOfName();
-  private:
-    Buffer * buffer;
-    uint8_t c = 1;
-  };
+        bool endOfName();
 
-  class Iterator {
-  public:
-    Iterator(Label * label);
+    private:
+        Buffer* buffer;
+        uint8_t c = 1;
+    };
 
-    bool match(uint8_t c);
+    class Iterator {
+    public:
+        Iterator(Label* label);
 
-    bool matched();
+        bool match(uint8_t c);
 
-    Label * getStartLabel();
+        bool matched();
 
-  private:
-    Label * startLabel;
-    Label * label;
-    uint8_t size;
-    uint8_t offset = 0;
-    bool matches = true;
+        Label* getStartLabel();
 
-    bool equalsIgnoreCase(uint8_t c);
-  };
+    private:
+        Label* startLabel;
+        Label* label;
+        uint8_t size;
+        uint8_t offset = 0;
+        bool matches = true;
 
-  uint8_t * EMPTY_DATA = { END_OF_NAME };
-  uint8_t * data;
-  bool caseSensitive;
-  Label * nextLabel;
-  int16_t writeOffset = INVALID_OFFSET;
+        bool equalsIgnoreCase(uint8_t c);
+    };
+
+    uint8_t* EMPTY_DATA = {END_OF_NAME};
+    uint8_t* data;
+    bool caseSensitive;
+    Label* nextLabel;
+    int16_t writeOffset = INVALID_OFFSET;
 };
 
 class HostLabel : public Label {
 
 public:
+    HostLabel(Record* aRecord, Record* nsecRecord, String name, Label* nextLabel = NULL, bool caseSensitive = false);
 
-  HostLabel(Record * aRecord, Record * nsecRecord, String name, Label * nextLabel = NULL, bool caseSensitive = false);
-
-  virtual void matched(uint16_t type, uint16_t cls);
+    virtual void matched(uint16_t type, uint16_t cls);
 
 private:
-  Record * aRecord;
-  Record * nsecRecord;
+    Record* aRecord;
+    Record* nsecRecord;
 };
 
 class ServiceLabel : public Label {
 
 public:
+    ServiceLabel(Record* aRecord, String name, Label* nextLabel = NULL, bool caseSensitive = false);
 
-  ServiceLabel(Record * aRecord, String name, Label * nextLabel = NULL, bool caseSensitive = false);
+    void addInstance(Record* ptrRecord, Record* srvRecord, Record* txtRecord);
 
-  void addInstance(Record * ptrRecord, Record * srvRecord, Record * txtRecord);
-
-  virtual void matched(uint16_t type, uint16_t cls);
+    virtual void matched(uint16_t type, uint16_t cls);
 
 private:
-  Record * aRecord;
-  std::vector<Record *> ptrRecords;
-  std::vector<Record *> srvRecords;
-  std::vector<Record *> txtRecords;
+    Record* aRecord;
+    std::vector<Record*> ptrRecords;
+    std::vector<Record*> srvRecords;
+    std::vector<Record*> txtRecords;
 };
 
 class InstanceLabel : public Label {
 
 public:
+    InstanceLabel(Record* srvRecord, Record* txtRecord, Record* nsecRecord, Record* aRecord, String name, Label* nextLabel = NULL, bool caseSensitive = false);
 
-  InstanceLabel(Record * srvRecord, Record * txtRecord, Record * nsecRecord, Record * aRecord, String name, Label * nextLabel = NULL, bool caseSensitive = false);
-
-  virtual void matched(uint16_t type, uint16_t cls);
+    virtual void matched(uint16_t type, uint16_t cls);
 
 private:
-  Record * srvRecord;
-  Record * txtRecord;
-  Record * nsecRecord;
-  Record * aRecord;
+    Record* srvRecord;
+    Record* txtRecord;
+    Record* nsecRecord;
+    Record* aRecord;
 };
 
 class MetaLabel : public Label {
 
 public:
+    MetaLabel(String name, Label* nextLabel);
 
-  MetaLabel(String name, Label * nextLabel);
+    void addService(Record* ptrRecord);
 
-  void addService(Record * ptrRecord);
-
-  virtual void matched(uint16_t type, uint16_t cls);
+    virtual void matched(uint16_t type, uint16_t cls);
 
 private:
-  std::vector<Record *> records;
+    std::vector<Record*> records;
 };
 
 #endif

--- a/platform/spark/modules/mdns/src/MDNS.cpp
+++ b/platform/spark/modules/mdns/src/MDNS.cpp
@@ -1,275 +1,295 @@
 #include "MDNS.h"
+#include "spark_wiring_wifi.h"
 
-bool MDNS::setHostname(String hostname) {
-  bool success = true;
-  String status = "Ok";
+bool
+MDNS::setHostname(String hostname)
+{
+    bool success = true;
+    String status = "Ok";
 
-  if (labels[HOSTNAME]) {
-    status = "Hostname already set";
-    success = false;
-  }
-
-  if (success && hostname.length() < MAX_LABEL_SIZE && isAlphaDigitHyphen(hostname)) {
-    aRecord = new ARecord();
-
-    HostNSECRecord * hostNSECRecord = new HostNSECRecord();
-
-    records.push_back(aRecord);
-    records.push_back(hostNSECRecord);
-
-    Label * label = new HostLabel(aRecord, hostNSECRecord, hostname, LOCAL);
-
-    labels[HOSTNAME] = label;
-    labels[META_SERVICE] = META;
-
-    aRecord->setLabel(label);
-    hostNSECRecord->setLabel(label);
-  } else {
-    status = success? "Invalid hostname" : status;
-    success = false;
-  }
-
-  return success;
-}
-
-bool MDNS::addService(String protocol, String service, uint16_t port, String instance, std::vector<String> subServices) {
-  bool success = true;
-  String status = "Ok";
-
-  if (!labels[HOSTNAME]) {
-    status = "Hostname not set";
-    success = false;
-  }
-
-  if (success && protocol.length() < MAX_LABEL_SIZE - 1 && service.length() < MAX_LABEL_SIZE - 1 &&
-  instance.length() < MAX_LABEL_SIZE && isAlphaDigitHyphen(protocol) && isAlphaDigitHyphen(service) && isNetUnicode(instance)) {
-
-    PTRRecord * ptrRecord = new PTRRecord();
-    SRVRecord * srvRecord = new SRVRecord();
-    txtRecord = new TXTRecord();
-    InstanceNSECRecord * instanceNSECRecord = new InstanceNSECRecord();
-    PTRRecord * enumerationRecord = new PTRRecord(true);
-
-    records.push_back(ptrRecord);
-    records.push_back(srvRecord);
-    records.push_back(txtRecord);
-    records.push_back(instanceNSECRecord);
-    records.push_back(enumerationRecord);
-
-    String serviceString = "_" + service + "._" + protocol;
-
-    Label * protocolLabel = new Label("_" + protocol, LOCAL);
-
-    if (labels[serviceString] == NULL) {
-      labels[serviceString] = new ServiceLabel(aRecord, "_" + service, protocolLabel);
+    if (labels[HOSTNAME]) {
+        status = "Hostname already set";
+        success = false;
     }
 
-    ((ServiceLabel *) labels[serviceString])->addInstance(ptrRecord, srvRecord, txtRecord);
+    if (success && hostname.length() < MAX_LABEL_SIZE && isAlphaDigitHyphen(hostname)) {
+        aRecord = new ARecord();
 
-    String instanceString = instance + "._" + service + "._" + protocol;
+        HostNSECRecord* hostNSECRecord = new HostNSECRecord();
 
-    labels[instanceString] = new InstanceLabel(srvRecord, txtRecord, instanceNSECRecord, aRecord, instance, labels[serviceString], true);
-    META->addService(enumerationRecord);
+        records.push_back(aRecord);
+        records.push_back(hostNSECRecord);
 
-    for (std::vector<String>::const_iterator i = subServices.begin(); i != subServices.end(); ++i) {
-      String subServiceString = "_" + *i + "._sub." + serviceString;
+        Label* label = new HostLabel(aRecord, hostNSECRecord, hostname, LOCAL);
 
-      if (labels[subServiceString] == NULL) {
-        labels[subServiceString] = new ServiceLabel(aRecord, "_" + *i, new Label("_sub", labels[serviceString]));
-      }
+        labels[HOSTNAME] = label;
+        labels[META_SERVICE] = META;
 
-      PTRRecord * subPTRRecord = new PTRRecord();
-      PTRRecord * enumerationSubPTRRecord = new PTRRecord(true);
-
-      subPTRRecord->setLabel(labels[subServiceString]);
-      subPTRRecord->setTargetLabel(labels[instanceString]);
-
-      enumerationSubPTRRecord->setLabel(META);
-      enumerationSubPTRRecord->setTargetLabel(labels[subServiceString]);
-
-      records.push_back(subPTRRecord);
-      records.push_back(enumerationSubPTRRecord);
-
-      ((ServiceLabel *) labels[subServiceString])->addInstance(subPTRRecord, srvRecord, txtRecord);
-      META->addService(enumerationSubPTRRecord);
+        aRecord->setLabel(label);
+        hostNSECRecord->setLabel(label);
+    } else {
+        status = success ? "Invalid hostname" : status;
+        success = false;
     }
 
-    ptrRecord->setLabel(labels[serviceString]);
-    ptrRecord->setTargetLabel(labels[instanceString]);
-    srvRecord->setLabel(labels[instanceString]);
-    srvRecord->setPort(port);
-    srvRecord->setHostLabel(labels[HOSTNAME]);
-    txtRecord->setLabel(labels[instanceString]);
-    instanceNSECRecord->setLabel(labels[instanceString]);
-    enumerationRecord->setLabel(META);
-    enumerationRecord->setTargetLabel(labels[serviceString]);
-  } else {
-    status = success? "Invalid name" : status;
-    success = false;
-  }
-
-  return success;
+    return success;
 }
 
-void MDNS::addTXTEntry(String key, String value) {
-  txtRecord->addEntry(key, value);
-}
+bool
+MDNS::addService(String protocol, String service, uint16_t port, String instance, std::vector<String> subServices)
+{
+    bool success = true;
+    String status = "Ok";
 
-bool MDNS::begin(bool announce) {
-  // Wait for WiFi to connect
-  if (!WiFi.ready()) {
-    return false;
-  }
-
-  udp->begin(MDNS_PORT);
-  udp->joinMulticast(MDNS_ADDRESS);
-
-  // TODO: Probing
-
-  if (announce) {
-    for (std::vector<Record *>::const_iterator i = records.begin(); i != records.end(); ++i) {
-      (*i)->announceRecord();
+    if (!labels[HOSTNAME]) {
+        status = "Hostname not set";
+        success = false;
     }
 
-    writeResponses();
-  }
+    if (success && protocol.length() < MAX_LABEL_SIZE - 1 && service.length() < MAX_LABEL_SIZE - 1 && instance.length() < MAX_LABEL_SIZE && isAlphaDigitHyphen(protocol) && isAlphaDigitHyphen(service) && isNetUnicode(instance)) {
 
-  return true;
-}
+        PTRRecord* ptrRecord = new PTRRecord();
+        SRVRecord* srvRecord = new SRVRecord();
+        txtRecord = new TXTRecord();
+        InstanceNSECRecord* instanceNSECRecord = new InstanceNSECRecord();
+        PTRRecord* enumerationRecord = new PTRRecord(true);
 
-bool MDNS::processQueries() {
-  uint16_t n = udp->parsePacket();
+        records.push_back(ptrRecord);
+        records.push_back(srvRecord);
+        records.push_back(txtRecord);
+        records.push_back(instanceNSECRecord);
+        records.push_back(enumerationRecord);
 
-  if (n > 0) {
-    buffer->read(udp);
+        String serviceString = "_" + service + "._" + protocol;
 
-    udp->flush();
+        Label* protocolLabel = new Label("_" + protocol, LOCAL);
 
-    getResponses();
-
-    buffer->clear();
-
-    writeResponses();
-  }
-
-  return n > 0;
-}
-
-void MDNS::getResponses() {
-  QueryHeader header = readHeader(buffer);
-
-  if ((header.flags & 0x8000) == 0 && header.qdcount > 0) {
-    uint8_t count = 0;
-
-    while (count++ < header.qdcount && buffer->available() > 0) {
-      Label * label = matcher->match(labels, buffer);
-
-      if (buffer->available() >= 4) {
-        uint16_t type = buffer->readUInt16();
-        uint16_t cls = buffer->readUInt16();
-
-        if (label != NULL) {
-
-          label->matched(type, cls);
+        if (labels[serviceString] == NULL) {
+            labels[serviceString] = new ServiceLabel(aRecord, "_" + service, protocolLabel);
         }
-      } else {
-        status = "Buffer underflow at index " + buffer->getOffset();
-      }
+
+        ((ServiceLabel*)labels[serviceString])->addInstance(ptrRecord, srvRecord, txtRecord);
+
+        String instanceString = instance + "._" + service + "._" + protocol;
+
+        labels[instanceString] = new InstanceLabel(srvRecord, txtRecord, instanceNSECRecord, aRecord, instance, labels[serviceString], true);
+        META->addService(enumerationRecord);
+
+        for (std::vector<String>::const_iterator i = subServices.begin(); i != subServices.end(); ++i) {
+            String subServiceString = "_" + *i + "._sub." + serviceString;
+
+            if (labels[subServiceString] == NULL) {
+                labels[subServiceString] = new ServiceLabel(aRecord, "_" + *i, new Label("_sub", labels[serviceString]));
+            }
+
+            PTRRecord* subPTRRecord = new PTRRecord();
+            PTRRecord* enumerationSubPTRRecord = new PTRRecord(true);
+
+            subPTRRecord->setLabel(labels[subServiceString]);
+            subPTRRecord->setTargetLabel(labels[instanceString]);
+
+            enumerationSubPTRRecord->setLabel(META);
+            enumerationSubPTRRecord->setTargetLabel(labels[subServiceString]);
+
+            records.push_back(subPTRRecord);
+            records.push_back(enumerationSubPTRRecord);
+
+            ((ServiceLabel*)labels[subServiceString])->addInstance(subPTRRecord, srvRecord, txtRecord);
+            META->addService(enumerationSubPTRRecord);
+        }
+
+        ptrRecord->setLabel(labels[serviceString]);
+        ptrRecord->setTargetLabel(labels[instanceString]);
+        srvRecord->setLabel(labels[instanceString]);
+        srvRecord->setPort(port);
+        srvRecord->setHostLabel(labels[HOSTNAME]);
+        txtRecord->setLabel(labels[instanceString]);
+        instanceNSECRecord->setLabel(labels[instanceString]);
+        enumerationRecord->setLabel(META);
+        enumerationRecord->setTargetLabel(labels[serviceString]);
+    } else {
+        status = success ? "Invalid name" : status;
+        success = false;
     }
-  }
+
+    return success;
 }
 
-MDNS::QueryHeader MDNS::readHeader(Buffer * buffer) {
-  QueryHeader header;
-
-  if (buffer->available() >= 12) {
-    header.id = buffer->readUInt16();
-    header.flags = buffer->readUInt16();
-    header.qdcount = buffer->readUInt16();
-    header.ancount = buffer->readUInt16();
-    header.nscount = buffer->readUInt16();
-    header.arcount = buffer->readUInt16();
-  }
-
-  return header;
+void
+MDNS::addTXTEntry(String key, String value)
+{
+    txtRecord->addEntry(key, value);
 }
 
-void MDNS::writeResponses() {
-
-  uint8_t answerCount = 0;
-  uint8_t additionalCount = 0;
-
-  for (std::vector<Record *>::const_iterator i = records.begin(); i != records.end(); ++i) {
-    if ((*i)->isAnswerRecord()) {
-      answerCount++;
-    }
-    if ((*i)->isAdditionalRecord()) {
-      additionalCount++;
-    }
-  }
-
-  if (answerCount > 0) {
-    buffer->writeUInt16(0x0);
-    buffer->writeUInt16(0x8400);
-    buffer->writeUInt16(0x0);
-    buffer->writeUInt16(answerCount);
-    buffer->writeUInt16(0x0);
-    buffer->writeUInt16(additionalCount);
-
-    for (std::vector<Record *>::const_iterator i = records.begin(); i != records.end(); ++i) {
-      if ((*i)->isAnswerRecord()) {
-        (*i)->write(buffer);
-      }
+bool
+MDNS::begin(bool announce)
+{
+    // Wait for spark::WiFi to connect
+    if (!spark::WiFi.ready()) {
+        return false;
     }
 
-    for (std::vector<Record *>::const_iterator i = records.begin(); i != records.end(); ++i) {
-      if ((*i)->isAdditionalRecord()) {
-        (*i)->write(buffer);
-      }
+    udp->begin(MDNS_PORT);
+    udp->joinMulticast(MDNS_ADDRESS);
+
+    // TODO: Probing
+
+    if (announce) {
+        for (std::vector<Record*>::const_iterator i = records.begin(); i != records.end(); ++i) {
+            (*i)->announceRecord();
+        }
+
+        writeResponses();
     }
-  }
 
-  if (buffer->available() > 0) {
-    udp->beginPacket(MDNS_ADDRESS, MDNS_PORT);
-
-    buffer->write(udp);
-
-    udp->endPacket();
-  }
-
-  for (std::map<String, Label *>::const_iterator i = labels.begin(); i != labels.end(); ++i) {
-    i->second->reset();
-  }
-
-  for (std::vector<Record *>::const_iterator i = records.begin(); i != records.end(); ++i) {
-    (*i)->reset();
-  }
+    return true;
 }
 
-bool MDNS::isAlphaDigitHyphen(String string) {
-  bool result = true;
+bool
+MDNS::processQueries()
+{
+    uint16_t n = udp->parsePacket();
 
-  uint8_t idx = 0;
+    if (n > 0) {
+        buffer->read(udp);
 
-  while (result && idx < string.length()) {
-    uint8_t c = string.charAt(idx++);
+        udp->flush();
 
-    result = (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || c == '-';
-  }
+        getResponses();
 
-  return result;
+        buffer->clear();
+
+        writeResponses();
+    }
+
+    return n > 0;
 }
 
-bool MDNS::isNetUnicode(String string) {
-  bool result = true;
+void
+MDNS::getResponses()
+{
+    QueryHeader header = readHeader(buffer);
 
-  uint8_t idx = 0;
+    if ((header.flags & 0x8000) == 0 && header.qdcount > 0) {
+        uint8_t count = 0;
 
-  while (result && idx < string.length()) {
-    uint8_t c = string.charAt(idx++);
+        while (count++ < header.qdcount && buffer->available() > 0) {
+            Label* label = matcher->match(labels, buffer);
 
-    result = c >= 0x1f && c != 0x7f;
-  }
+            if (buffer->available() >= 4) {
+                uint16_t type = buffer->readUInt16();
+                uint16_t cls = buffer->readUInt16();
 
-  return result;
+                if (label != NULL) {
+
+                    label->matched(type, cls);
+                }
+            } else {
+                status = "Buffer underflow at index " + buffer->getOffset();
+            }
+        }
+    }
+}
+
+MDNS::QueryHeader
+MDNS::readHeader(Buffer* buffer)
+{
+    QueryHeader header;
+
+    if (buffer->available() >= 12) {
+        header.id = buffer->readUInt16();
+        header.flags = buffer->readUInt16();
+        header.qdcount = buffer->readUInt16();
+        header.ancount = buffer->readUInt16();
+        header.nscount = buffer->readUInt16();
+        header.arcount = buffer->readUInt16();
+    }
+
+    return header;
+}
+
+void
+MDNS::writeResponses()
+{
+
+    uint8_t answerCount = 0;
+    uint8_t additionalCount = 0;
+
+    for (std::vector<Record*>::const_iterator i = records.begin(); i != records.end(); ++i) {
+        if ((*i)->isAnswerRecord()) {
+            answerCount++;
+        }
+        if ((*i)->isAdditionalRecord()) {
+            additionalCount++;
+        }
+    }
+
+    if (answerCount > 0) {
+        buffer->writeUInt16(0x0);
+        buffer->writeUInt16(0x8400);
+        buffer->writeUInt16(0x0);
+        buffer->writeUInt16(answerCount);
+        buffer->writeUInt16(0x0);
+        buffer->writeUInt16(additionalCount);
+
+        for (std::vector<Record*>::const_iterator i = records.begin(); i != records.end(); ++i) {
+            if ((*i)->isAnswerRecord()) {
+                (*i)->write(buffer);
+            }
+        }
+
+        for (std::vector<Record*>::const_iterator i = records.begin(); i != records.end(); ++i) {
+            if ((*i)->isAdditionalRecord()) {
+                (*i)->write(buffer);
+            }
+        }
+    }
+
+    if (buffer->available() > 0) {
+        udp->beginPacket(MDNS_ADDRESS, MDNS_PORT);
+
+        buffer->write(udp);
+
+        udp->endPacket();
+    }
+
+    for (std::map<String, Label*>::const_iterator i = labels.begin(); i != labels.end(); ++i) {
+        i->second->reset();
+    }
+
+    for (std::vector<Record*>::const_iterator i = records.begin(); i != records.end(); ++i) {
+        (*i)->reset();
+    }
+}
+
+bool
+MDNS::isAlphaDigitHyphen(String string)
+{
+    bool result = true;
+
+    uint8_t idx = 0;
+
+    while (result && idx < string.length()) {
+        uint8_t c = string.charAt(idx++);
+
+        result = (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || c == '-';
+    }
+
+    return result;
+}
+
+bool
+MDNS::isNetUnicode(String string)
+{
+    bool result = true;
+
+    uint8_t idx = 0;
+
+    while (result && idx < string.length()) {
+        uint8_t c = string.charAt(idx++);
+
+        result = c >= 0x1f && c != 0x7f;
+    }
+
+    return result;
 }

--- a/platform/spark/modules/mdns/src/Record.cpp
+++ b/platform/spark/modules/mdns/src/Record.cpp
@@ -1,165 +1,221 @@
 #include "Record.h"
 
 #include "Label.h"
+#include "spark_wiring_wifi.h"
 
-Record::Record(uint16_t type, uint16_t cls, uint32_t ttl, bool announce) {
-  this->type = type;
-  this->cls = cls;
-  this->ttl = ttl;
-  this->announce = announce;
+Record::Record(uint16_t type, uint16_t cls, uint32_t ttl, bool announce)
+{
+    this->type = type;
+    this->cls = cls;
+    this->ttl = ttl;
+    this->announce = announce;
 }
 
-void Record::setLabel(Label * label) {
-  this->label = label;
+void
+Record::setLabel(Label* label)
+{
+    this->label = label;
 }
 
-void Record::announceRecord() {
-  if (this->announce) {
-    this->answerRecord = true;
-  }
-}
-
-void Record::setAnswerRecord() {
-  this->answerRecord = true;
-}
-
-bool Record::isAnswerRecord() {
-  return answerRecord && !knownRecord;
-}
-
-void Record::setAdditionalRecord() {
-  this->additionalRecord = true;
-}
-
-bool Record::isAdditionalRecord() {
-  return additionalRecord && !answerRecord && !knownRecord;
-}
-
-void Record::setKnownRecord() {
-  this->knownRecord = true;
-}
-
-void Record::write(Buffer * buffer) {
-  label->write(buffer);
-  buffer->writeUInt16(type);
-  buffer->writeUInt16(cls);
-  buffer->writeUInt32(ttl);
-  writeSpecific(buffer);
-}
-
-void Record::reset() {
-  this->answerRecord = false;
-  this->additionalRecord = false;
-  this->knownRecord = false;
-}
-
-Label * Record::getLabel() {
-  return label;
-}
-
-ARecord::ARecord():Record(A_TYPE, IN_CLASS | CACHE_FLUSH, TTL_2MIN) {
-}
-
-void ARecord::writeSpecific(Buffer * buffer) {
-  buffer->writeUInt16(4);
-  IPAddress ip = WiFi.localIP();
-  for (int i = 0; i < IP_SIZE; i++) {
-    buffer->writeUInt8(ip[i]);
-  }
-}
-
-NSECRecord::NSECRecord():Record(NSEC_TYPE, IN_CLASS | CACHE_FLUSH, TTL_2MIN) {
-}
-
-HostNSECRecord::HostNSECRecord():NSECRecord() {
-}
-
-void HostNSECRecord::writeSpecific(Buffer * buffer) {
-  buffer->writeUInt16(5);
-  getLabel()->write(buffer);
-  buffer->writeUInt8(0);
-  buffer->writeUInt8(1);
-  buffer->writeUInt8(0x40);
-}
-
-InstanceNSECRecord::InstanceNSECRecord():NSECRecord() {
-}
-
-void InstanceNSECRecord::writeSpecific(Buffer * buffer) {
-  buffer->writeUInt16(9);
-  getLabel()->write(buffer);
-  buffer->writeUInt8(0);
-  buffer->writeUInt8(5);
-  buffer->writeUInt8(0);
-  buffer->writeUInt8(0);
-  buffer->writeUInt8(0x80);
-  buffer->writeUInt8(0);
-  buffer->writeUInt8(0x40);
-}
-
-PTRRecord::PTRRecord(bool meta):Record(PTR_TYPE, IN_CLASS, TTL_75MIN, !meta) {
-}
-
-void PTRRecord::writeSpecific(Buffer * buffer) {
-  buffer->writeUInt16(targetLabel->getWriteSize());
-  targetLabel->write(buffer);
-}
-
-void PTRRecord::setTargetLabel(Label * label) {
-  targetLabel = label;
-}
-
-SRVRecord::SRVRecord():Record(SRV_TYPE, IN_CLASS | CACHE_FLUSH, TTL_2MIN) {
-}
-
-void SRVRecord::writeSpecific(Buffer * buffer) {
-  buffer->writeUInt16(6 + hostLabel->getWriteSize());
-  buffer->writeUInt16(0);
-  buffer->writeUInt16(0);
-  buffer->writeUInt16(port);
-  hostLabel->write(buffer);
-}
-
-void SRVRecord::setHostLabel(Label * label) {
-  hostLabel = label;
-}
-
-void SRVRecord::setPort(uint16_t port) {
-  this->port = port;
-}
-
-TXTRecord::TXTRecord():Record(TXT_TYPE, IN_CLASS | CACHE_FLUSH, TTL_75MIN) {
-}
-
-void TXTRecord::addEntry(String key, String value) {
-  String entry = key;
-
-  if (value == NULL || value.length() > 0) {
-    entry += '=';
-    entry += value;
-  }
-
-  data.push_back(entry);
-}
-
-void TXTRecord::writeSpecific(Buffer * buffer) {
-  uint16_t size = 0;
-
-  std::vector<String>::const_iterator i;
-
-  for(i = data.begin(); i != data.end(); ++i) {
-    size += i->length() + 1;
-  }
-
-  buffer->writeUInt16(size);
-
-  for(i = data.begin(); i != data.end(); ++i) {
-    uint8_t length = i->length();
-
-    buffer->writeUInt8(length);
-
-    for (uint8_t idx = 0; idx < length; idx++) {
-      buffer->writeUInt8(i->charAt(idx));
+void
+Record::announceRecord()
+{
+    if (this->announce) {
+        this->answerRecord = true;
     }
-  }
+}
+
+void
+Record::setAnswerRecord()
+{
+    this->answerRecord = true;
+}
+
+bool
+Record::isAnswerRecord()
+{
+    return answerRecord && !knownRecord;
+}
+
+void
+Record::setAdditionalRecord()
+{
+    this->additionalRecord = true;
+}
+
+bool
+Record::isAdditionalRecord()
+{
+    return additionalRecord && !answerRecord && !knownRecord;
+}
+
+void
+Record::setKnownRecord()
+{
+    this->knownRecord = true;
+}
+
+void
+Record::write(Buffer* buffer)
+{
+    label->write(buffer);
+    buffer->writeUInt16(type);
+    buffer->writeUInt16(cls);
+    buffer->writeUInt32(ttl);
+    writeSpecific(buffer);
+}
+
+void
+Record::reset()
+{
+    this->answerRecord = false;
+    this->additionalRecord = false;
+    this->knownRecord = false;
+}
+
+Label*
+Record::getLabel()
+{
+    return label;
+}
+
+ARecord::ARecord()
+    : Record(A_TYPE, IN_CLASS | CACHE_FLUSH, TTL_2MIN)
+{
+}
+
+void
+ARecord::writeSpecific(Buffer* buffer)
+{
+    buffer->writeUInt16(4);
+    IPAddress ip = spark::WiFi.localIP();
+    for (int i = 0; i < IP_SIZE; i++) {
+        buffer->writeUInt8(ip[i]);
+    }
+}
+
+NSECRecord::NSECRecord()
+    : Record(NSEC_TYPE, IN_CLASS | CACHE_FLUSH, TTL_2MIN)
+{
+}
+
+HostNSECRecord::HostNSECRecord()
+    : NSECRecord()
+{
+}
+
+void
+HostNSECRecord::writeSpecific(Buffer* buffer)
+{
+    buffer->writeUInt16(5);
+    getLabel()->write(buffer);
+    buffer->writeUInt8(0);
+    buffer->writeUInt8(1);
+    buffer->writeUInt8(0x40);
+}
+
+InstanceNSECRecord::InstanceNSECRecord()
+    : NSECRecord()
+{
+}
+
+void
+InstanceNSECRecord::writeSpecific(Buffer* buffer)
+{
+    buffer->writeUInt16(9);
+    getLabel()->write(buffer);
+    buffer->writeUInt8(0);
+    buffer->writeUInt8(5);
+    buffer->writeUInt8(0);
+    buffer->writeUInt8(0);
+    buffer->writeUInt8(0x80);
+    buffer->writeUInt8(0);
+    buffer->writeUInt8(0x40);
+}
+
+PTRRecord::PTRRecord(bool meta)
+    : Record(PTR_TYPE, IN_CLASS, TTL_75MIN, !meta)
+{
+}
+
+void
+PTRRecord::writeSpecific(Buffer* buffer)
+{
+    buffer->writeUInt16(targetLabel->getWriteSize());
+    targetLabel->write(buffer);
+}
+
+void
+PTRRecord::setTargetLabel(Label* label)
+{
+    targetLabel = label;
+}
+
+SRVRecord::SRVRecord()
+    : Record(SRV_TYPE, IN_CLASS | CACHE_FLUSH, TTL_2MIN)
+{
+}
+
+void
+SRVRecord::writeSpecific(Buffer* buffer)
+{
+    buffer->writeUInt16(6 + hostLabel->getWriteSize());
+    buffer->writeUInt16(0);
+    buffer->writeUInt16(0);
+    buffer->writeUInt16(port);
+    hostLabel->write(buffer);
+}
+
+void
+SRVRecord::setHostLabel(Label* label)
+{
+    hostLabel = label;
+}
+
+void
+SRVRecord::setPort(uint16_t port)
+{
+    this->port = port;
+}
+
+TXTRecord::TXTRecord()
+    : Record(TXT_TYPE, IN_CLASS | CACHE_FLUSH, TTL_75MIN)
+{
+}
+
+void
+TXTRecord::addEntry(String key, String value)
+{
+    String entry = key;
+
+    if (value == NULL || value.length() > 0) {
+        entry += '=';
+        entry += value;
+    }
+
+    data.push_back(entry);
+}
+
+void
+TXTRecord::writeSpecific(Buffer* buffer)
+{
+    uint16_t size = 0;
+
+    std::vector<String>::const_iterator i;
+
+    for (i = data.begin(); i != data.end(); ++i) {
+        size += i->length() + 1;
+    }
+
+    buffer->writeUInt16(size);
+
+    for (i = data.begin(); i != data.end(); ++i) {
+        uint8_t length = i->length();
+
+        buffer->writeUInt8(length);
+
+        for (uint8_t idx = 0; idx < length; idx++) {
+            buffer->writeUInt8(i->charAt(idx));
+        }
+    }
 }

--- a/platform/spark/modules/mdns/src/Record.h
+++ b/platform/spark/modules/mdns/src/Record.h
@@ -1,9 +1,8 @@
-#include "application.h"
-
 #ifndef _INCL_RECORD
 #define _INCL_RECORD
 
 #include "Buffer.h"
+#include "spark_wiring_string.h"
 #include <vector>
 
 #define IN_CLASS 1
@@ -28,128 +27,114 @@ class Label;
 class Record {
 
 public:
+    void setLabel(Label* label);
 
-  void setLabel(Label * label);
+    void announceRecord();
 
-  void announceRecord();
+    void setAnswerRecord();
 
-  void setAnswerRecord();
+    bool isAnswerRecord();
 
-  bool isAnswerRecord();
+    void setAdditionalRecord();
 
-  void setAdditionalRecord();
+    bool isAdditionalRecord();
 
-  bool isAdditionalRecord();
+    void setKnownRecord();
 
-  void setKnownRecord();
+    void write(Buffer* buffer);
 
-  void write(Buffer * buffer);
-
-  void reset();
+    void reset();
 
 protected:
+    Record(uint16_t type, uint16_t cls, uint32_t ttl, bool announce = true);
 
-  Record(uint16_t type, uint16_t cls, uint32_t ttl, bool announce = true);
+    Label* getLabel();
 
-  Label * getLabel();
-
-  virtual void writeSpecific(Buffer * buffer) = 0;
+    virtual void writeSpecific(Buffer* buffer) = 0;
 
 private:
-
-  Label * label;
-  uint16_t type;
-  uint16_t cls;
-  uint32_t ttl;
-  bool announce;
-  bool answerRecord = false;
-  bool additionalRecord = false;
-  bool knownRecord = false;
+    Label* label;
+    uint16_t type;
+    uint16_t cls;
+    uint32_t ttl;
+    bool announce;
+    bool answerRecord = false;
+    bool additionalRecord = false;
+    bool knownRecord = false;
 };
 
 class ARecord : public Record {
 
 public:
+    ARecord();
 
-  ARecord();
-
-  virtual void writeSpecific(Buffer * buffer);
+    virtual void writeSpecific(Buffer* buffer);
 };
 
 class NSECRecord : public Record {
 
 public:
+    NSECRecord();
 
-  NSECRecord();
-
-  virtual void writeSpecific(Buffer * buffer) = 0;
+    virtual void writeSpecific(Buffer* buffer) = 0;
 };
 
 class HostNSECRecord : public NSECRecord {
 
 public:
+    HostNSECRecord();
 
-  HostNSECRecord();
-
-  virtual void writeSpecific(Buffer * buffer);
+    virtual void writeSpecific(Buffer* buffer);
 };
 
 class InstanceNSECRecord : public NSECRecord {
 
 public:
+    InstanceNSECRecord();
 
-  InstanceNSECRecord();
-
-  virtual void writeSpecific(Buffer * buffer);
+    virtual void writeSpecific(Buffer* buffer);
 };
 
 class PTRRecord : public Record {
 
 public:
+    PTRRecord(bool meta = false);
 
-  PTRRecord(bool meta = false);
+    virtual void writeSpecific(Buffer* buffer);
 
-  virtual void writeSpecific(Buffer * buffer);
-
-  void setTargetLabel(Label * label);
+    void setTargetLabel(Label* label);
 
 private:
-
-  Label * targetLabel;
-
+    Label* targetLabel;
 };
 
 class SRVRecord : public Record {
 
 public:
+    SRVRecord();
 
-  SRVRecord();
+    virtual void writeSpecific(Buffer* buffer);
 
-  virtual void writeSpecific(Buffer * buffer);
+    void setHostLabel(Label* label);
 
-  void setHostLabel(Label * label);
-
-  void setPort(uint16_t port);
+    void setPort(uint16_t port);
 
 private:
-
-  Label * hostLabel;
-  uint16_t port;
+    Label* hostLabel;
+    uint16_t port;
 };
 
 class TXTRecord : public Record {
 
 public:
+    TXTRecord();
 
-  TXTRecord();
+    virtual void writeSpecific(Buffer* buffer);
 
-  virtual void writeSpecific(Buffer * buffer);
-
-  void addEntry(String key, String value = "");
+    void addEntry(String key, String value = "");
 
 private:
-
-  std::vector<String> data;
+    std::vector<String> data;
 };
 
 #endif

--- a/platform/wiring/TicksWiring.cpp
+++ b/platform/wiring/TicksWiring.cpp
@@ -1,25 +1,26 @@
 #include "TicksWiring.h"
 #include "Ticks.h"
-#include "application.h"
+#include "delay_hal.h"
+#include "timer_hal.h"
 
 ticks_seconds_t
 TicksWiring::seconds()
 {
-    return ::millis() / 1000;
+    return HAL_Timer_Get_Micro_Seconds() / 1000;
 }
 ticks_millis_t
 TicksWiring::millis()
 {
-    return ::millis();
+    return HAL_Timer_Get_Milli_Seconds();
 }
 ticks_micros_t
 TicksWiring::micros()
 {
-    return ::micros();
+    return HAL_Timer_Get_Micro_Seconds();
 }
 
 void
 TicksWiring::delayMillis(const duration_millis_t& duration)
 {
-    ::delay(duration);
+    HAL_Delay_Milliseconds(duration);
 }


### PR DESCRIPTION
The system stack device-os from Particle seems to not be thread safe regarding WiFi function calls.
Bug reported here:
https://github.com/particle-iot/device-os/issues/1805

As a workaround, this PR updates the network status (IP address and connected status) in a system event handler so the WiFi function calls run on the system thread.