### PR TITLE
add timeout for disconnected wifi to reconnect

### DIFF
--- a/app/brewblox/connectivity.cpp
+++ b/app/brewblox/connectivity.cpp
@@ -97,7 +97,9 @@ listeningModeEnabled()
 void
 manageConnections()
 {
+    static uint16_t wifiTimeOut = 0;
     if (wifiIsConnected) {
+        wifiTimeOut = 0;
         if (!mdns_started) {
             mdns_started = mdns.begin(true);
         } else {
@@ -114,6 +116,14 @@ manageConnections()
             delay(5);
             client.stop();
         }
+    } else {
+        ++wifiTimeOut;
+    }
+    if (wifiTimeOut > 1000) {
+        // after 1000 loops without WiFi, trigger reconnect
+        // wifi is expected to reconnect automatically. This is a failsafe in case it does not
+        spark::WiFi.connect(WIFI_CONNECT_SKIP_LISTEN);
+        wifiTimeOut = 0;
     }
 }
 


### PR DESCRIPTION
Latest firmware with event based WiFi management seems to sometimes miss that it is disconnected.
This is a failsafe to trigger a reconnect when WiFi has been disconnected for a while.