### PR TITLE
When reference for setpoint driver is invalid, only invalidate target once

### DIFF
--- a/lib/inc/ActuatorOffset.h
+++ b/lib/inc/ActuatorOffset.h
@@ -107,40 +107,41 @@ public:
 
     void update()
     {
-        m_settingValid = false;
-        if (!m_enabled) {
-            return;
-        }
-
         m_valueValid = false;
+        m_value = 0;
+        bool newTargetSettingValid = false;
+        auto newTargetSetting = value_t(0);
+
         if (auto targetPtr = m_target()) {
             if (auto refPtr = m_reference()) {
                 if (m_selectedReference == SettingOrValue::SETTING) {
                     if (refPtr->settingValid()) {
-                        targetPtr->settingValid(true); // try to make target valid
-                        targetPtr->setting(refPtr->setting() + m_setting);
-                        m_settingValid = true;
+                        newTargetSetting = refPtr->setting() + m_setting;
+                        newTargetSettingValid = true;
                         if (targetPtr->valueValid()) {
                             m_value = targetPtr->value() - refPtr->setting();
                             m_valueValid = true;
                         }
-                        return;
                     }
                 } else {
                     if (refPtr->valueValid()) {
-                        targetPtr->settingValid(true); // try to make target valid
-                        targetPtr->setting(refPtr->value() + m_setting);
-                        m_settingValid = true;
+                        newTargetSetting = refPtr->value() + m_setting;
+                        newTargetSettingValid = true;
                         if (targetPtr->valueValid()) {
                             m_value = targetPtr->value() - refPtr->value();
                             m_valueValid = true;
                         }
-                        return;
                     }
                 }
             }
-            targetPtr->settingValid(false);
-            m_value = 0;
+            if (newTargetSettingValid && m_enabled) {
+                targetPtr->settingValid(true); // try to make target valid
+                targetPtr->setting(newTargetSetting);
+                m_settingValid = true;
+            } else if (m_settingValid) {
+                targetPtr->settingValid(false); // invalidate target once
+                m_settingValid = false;
+            }
         }
     }
 

--- a/lib/test/ActuatorOffset_test.cpp
+++ b/lib/test/ActuatorOffset_test.cpp
@@ -131,9 +131,8 @@ SCENARIO("ActuatorOffset offsets one setpoint from another", "[ActuatorOffset]")
     {
         act->selectedReference(ActuatorOffset::SettingOrValue::SETTING);
         referenceSensor->connected(true);
-        act->setting(12.0);
-
         reference->settingValid(false);
+        act->setting(12.0);
 
         CHECK(target->setting() == 20.0); // unchanged
         CHECK(act->valueValid() == false);


### PR DESCRIPTION
Fixes the issue that when the reference setpoint of a setpoint driver is disabled, the target setpoint cannot be set manually.

Example situation:
Fridge setpoint is driven by beer temperature/setpoint. Beer setpoint is disabled. User tries to set fridge setpoint manually, but it keeps getting disabled.

With this fix, when the reference becomes invalid, the target is only set to invalid/disabled once. The user can change it manually afterwards.