### PR TITLE
Include deprectated objects found in EEPROM with original ID (EEPROM) as data

### DIFF
--- a/controlbox/src/cbox/Box.cpp
+++ b/controlbox/src/cbox/Box.cpp
@@ -24,6 +24,7 @@
 #include "ContainedObject.h"
 #include "DataStream.h"
 #include "DataStreamConverters.h"
+#include "DeprecatedObject.h"
 #include "GroupsObject.h"
 #include "Object.h"
 #include "ObjectContainer.h"
@@ -444,6 +445,9 @@ Box::loadObjectsFromStorage()
 
             if (newObj) {
                 objects.add(std::move(newObj), groups, id);
+            } else if (status == CboxError::OBJECT_NOT_CREATABLE) {
+                objects.add(std::make_shared<DeprecatedObject>(id), 0xFF);
+                status = CboxError::OK;
             }
         }
         return status;

--- a/controlbox/src/cbox/Box.cpp
+++ b/controlbox/src/cbox/Box.cpp
@@ -279,9 +279,17 @@ Box::deleteObject(DataIn& in, HexCrcDataOut& out)
         status = CboxError::CRC_ERROR_IN_COMMAND;
     }
 
+    auto storageId = id;
+
+    auto deprecated = makeCboxPtr<DeprecatedObject>(id);
+    if (auto obj = deprecated.lock()) {
+        // object is a deprecated one. We should delete the original object id from storage
+        storageId = obj->storageId();
+    }
+
     if (status == CboxError::OK) {
         status = objects.remove(id);
-        storage.disposeObject(id); // todo: event if error?
+        storage.disposeObject(storageId); // todo: event if error?
     }
 
     out.writeResponseSeparator();

--- a/controlbox/src/cbox/DeprecatedObject.h
+++ b/controlbox/src/cbox/DeprecatedObject.h
@@ -60,6 +60,11 @@ public:
     {
         return update_never(now);
     }
+
+    obj_id_t storageId()
+    {
+        return originalId;
+    }
 };
 
 } // end namespace cbox

--- a/controlbox/src/cbox/DeprecatedObject.h
+++ b/controlbox/src/cbox/DeprecatedObject.h
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2018 Elco Jacobs / BrewBlox, based on earlier work of Matthew McGowan
+ *
+ * This file is part of ControlBox.
+ *
+ * Controlbox is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Controlbox.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "CboxError.h"
+#include "ObjectBase.h"
+#include "ObjectIds.h"
+#include <limits>
+
+namespace cbox {
+
+/**
+ * An object that does nothing. When read, it returns the type it becomes when it is activated.
+ */
+class DeprecatedObject : public ObjectBase<std::numeric_limits<uint16_t>::max() - 2> {
+private:
+    obj_id_t originalId;
+
+public:
+    DeprecatedObject(const obj_id_t& oid)
+        : originalId(oid)
+    {
+    }
+    virtual ~DeprecatedObject() = default;
+
+    virtual CboxError streamTo(DataOut& out) const override final
+    {
+        out.put(originalId);
+        return CboxError::OK;
+    }
+
+    virtual CboxError streamFrom(DataIn& out) override final
+    {
+        return CboxError::OBJECT_NOT_WRITABLE;
+    }
+
+    virtual CboxError streamPersistedTo(DataOut& out) const override final
+    {
+        return CboxError::OBJECT_NOT_WRITABLE;
+    }
+
+    virtual update_t update(const update_t& now) override final
+    {
+        return update_never(now);
+    }
+};
+
+} // end namespace cbox


### PR DESCRIPTION
By including unsupported objects found in EEPROM in the object list, we can handle their removal from EEPROM or migration in the UI.

Because deprecated objects can also be system objects, the original id as found in eeprom is included as object data and the DeprecatedObject gets a new id in user space.

This ID can be used to query stored_objects to get the original data for migration or to delete the object from storage.