### PR TITLE
Move filter to setpoint and make filter and integral resetable externally

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,382 +1,366 @@
 {
-    // See https://go.microsoft.com/fwlink/?LinkId=733558
-    // for the documentation about the tasks.json format
-    "version": "2.0.0",
-    "tasks": [
-        {
-            "label": "build_p1",
-            "command": "docker-compose",
-            "args": [
-                "exec",
-                "compiler",
-                "bash",
-                "../wrapped_make.sh",
-                "APP=brewblox",
-                "PLATFORM=p1"
-            ],
-            "group": "build",
-            "options": {
-                "cwd": "${workspaceFolder}/docker"
-            },
-            "presentation": {
-                "echo": true,
-                "reveal": "always",
-                "focus": true,
-                "panel": "shared",
-                "showReuseMessage": false,
-                "clear": false
-            },
-            "problemMatcher": "$gcc"
-        },
-        {
-            "label": "build_photon",
-            "command": "docker-compose",
-            "args": [
-                "exec",
-                "compiler",
-                "bash",
-                "../wrapped_make.sh",
-                "APP=brewblox",
-                "PLATFORM=photon"
-            ],
-            "group": "build",
-            "options": {
-                "cwd": "${workspaceFolder}/docker"
-            },
-            "presentation": {
-                "echo": true,
-                "reveal": "always",
-                "focus": true,
-                "panel": "shared",
-                "showReuseMessage": false,
-                "clear": false
-            },
-            "problemMatcher": "$gcc"
-        },
-        {
-            "label": "build_gcc_local",
-            "command": "bash",
-            "args": [
-                "../wrapped_make.sh",
-                "APP=brewblox",
-                "PLATFORM=gcc"
-            ],
-            "group": "build",
-            "options": {
-                "cwd": "${workspaceFolder}/build"
-            },
-            "presentation": {
-                "echo": true,
-                "reveal": "always",
-                "focus": true,
-                "panel": "shared",
-                "showReuseMessage": false,
-                "clear": false
-            },
-            "problemMatcher": "$gcc"
-        },
-        {
-            "label": "flash_p1",
-            "command": "docker-compose",
-            "args": [
-                "exec",
-                "compiler",
-                "bash",
-                "../wrapped_make.sh",
-                "APP=brewblox",
-                "PLATFORM=p1",
-                "all",
-                "program-dfu"
-            ],
-            "group": "build",
-            "options": {
-                "cwd": "${workspaceFolder}/docker"
-            },
-            "presentation": {
-                "echo": true,
-                "reveal": "always",
-                "focus": true,
-                "panel": "shared",
-                "showReuseMessage": false,
-                "clear": false
-            },
-            "problemMatcher": "$gcc",
-            "dependsOn": [
-                "trigger_dfu",
-                "restart_compiler",
-            ]
-        },
-        {
-            "label": "flash_photon",
-            "command": "docker-compose",
-            "args": [
-                "exec",
-                "compiler",
-                "bash",
-                "../wrapped_make.sh",
-                "APP=brewblox",
-                "PLATFORM=photon",
-                "all",
-                "program-dfu"
-            ],
-            "group": "build",
-            "options": {
-                "cwd": "${workspaceFolder}/docker"
-            },
-            "presentation": {
-                "echo": true,
-                "reveal": "always",
-                "focus": true,
-                "panel": "shared",
-                "showReuseMessage": false,
-                "clear": false
-            },
-            "problemMatcher": "$gcc",
-            "dependsOn": [
-                "trigger_dfu",
-                "restart_compiler",
-            ]
-        },
-        {
-            "label": "trigger_dfu",
-            "command": "docker",
-            "args": [
-                "run",
-                "--rm",
-                "--privileged",
-                "brewblox/firmware-flasher:develop",
-                "trigger-dfu"
-            ],
-            "group": "build",
-            "options": {
-                "cwd": "${workspaceFolder}/docker"
-            },
-            "presentation": {
-                "echo": true,
-                "reveal": "always",
-                "focus": true,
-                "panel": "shared",
-                "showReuseMessage": false,
-                "clear": false
-            },
-            "problemMatcher": "$gcc"
-        },
-        {
-            "label": "restart_compiler",
-            "command": "bash",
-            "args": [
-                "start-compiler.sh",
-            ],
-            "group": "build",
-            "options": {
-                "cwd": "${workspaceFolder}/docker"
-            },
-            "presentation": {
-                "echo": true,
-                "reveal": "always",
-                "focus": true,
-                "panel": "shared",
-                "showReuseMessage": false,
-                "clear": false
-            },
-            "problemMatcher": "$gcc"
-        },
-        {
-            "label": "touch_gcc",
-            "type": "shell",
-            "command": "touch",
-            "args": [
-                "device_key.der",
-                "server_key.der",
-                "eeprom.bin"
-            ],
-            "options": {
-                "cwd": "${workspaceFolder}/build/target/brewblox-gcc"
-            },
-            "presentation": {
-                "echo": false,
-                "reveal": "never",
-                "focus": false,
-                "panel": "shared",
-                "showReuseMessage": false,
-                "clear": false
-            }
-        },
-        {
-            "label": "build_and_touch_gcc",
-            "dependsOn": [
-                "build_gcc",
-                "touch_gcc"
-            ]
-        },
-        {
-            "label": "compile proto",
-            "type": "shell",
-            "command": "docker-compose",
-            "args": [
-                "exec",
-                "compiler",
-                "bash",
-                "compile-proto.sh"
-            ],
-            "group": "build",
-            "options": {
-                "cwd": "${workspaceFolder}/docker"
-            },
-            "presentation": {
-                "echo": true,
-                "reveal": "always",
-                "focus": false,
-                "panel": "shared",
-                "showReuseMessage": false,
-                "clear": true
-            },
-            "problemMatcher": []
-        },
-        {
-            "label": "build app tests",
-            "type": "shell",
-            "command": "docker-compose",
-            "args": [
-                "exec",
-                "compiler",
-                "bash",
-                "../wrapped_make.sh",
-                "-C",
-                "../app/brewblox/test"
-            ],
-            "group": "build",
-            "options": {
-                "cwd": "${workspaceFolder}/docker"
-            },
-            "presentation": {
-                "echo": true,
-                "reveal": "always",
-                "focus": true,
-                "panel": "shared",
-                "showReuseMessage": false,
-                "clear": true
-            },
-            "problemMatcher": "$gcc"
-        },
-        {
-            "label": "build lib tests",
-            "type": "shell",
-            "command": "docker-compose",
-            "args": [
-                "exec",
-                "compiler",
-                "bash",
-                "../wrapped_make.sh",
-                "-C",
-                "../lib/test"
-            ],
-            "group": "build",
-            "options": {
-                "cwd": "${workspaceFolder}/docker"
-            },
-            "presentation": {
-                "echo": true,
-                "reveal": "always",
-                "focus": true,
-                "panel": "shared",
-                "showReuseMessage": false,
-                "clear": true
-            },
-            "problemMatcher": "$gcc"
-        },
-        {
-            "label": "build cbox tests",
-            "type": "shell",
-            "command": "docker-compose",
-            "args": [
-                "exec",
-                "compiler",
-                "bash",
-                "../wrapped_make.sh",
-                "-C",
-                "../controlbox"
-            ],
-            "group": "build",
-            "options": {
-                "cwd": "${workspaceFolder}/docker"
-            },
-            "presentation": {
-                "echo": true,
-                "reveal": "always",
-                "focus": true,
-                "panel": "shared",
-                "showReuseMessage": false,
-                "clear": true
-            },
-            "problemMatcher": "$gcc"
-        },
-        {
-            "label": "ci",
-            "command": "docker-compose",
-            "args": [
-                "exec",
-                "compiler",
-                "bash",
-                "run-ci.sh",
-            ],
-            "group": "build",
-            "options": {
-                "cwd": "${workspaceFolder}/docker"
-            },
-            "presentation": {
-                "echo": true,
-                "reveal": "always",
-                "focus": true,
-                "panel": "shared",
-                "showReuseMessage": false,
-                "clear": false
-            },
-            "problemMatcher": "$gcc"
-        },
-        {
-            "label": "build lib tests local",
-            "type": "shell",
-            "command": "make",
-            "args": [
-                "-C",
-                "../lib/test"
-            ],
-            "group": "build",
-            "options": {
-                "cwd": "${workspaceFolder}/docker"
-            },
-            "presentation": {
-                "echo": true,
-                "reveal": "always",
-                "focus": true,
-                "panel": "shared",
-                "showReuseMessage": false,
-                "clear": true
-            },
-            "problemMatcher": "$gcc"
-        },
-        {
-            "label": "build app tests local",
-            "type": "shell",
-            "command": "make",
-            "args": [
-                "-C",
-                "../app/brewblox/test"
-            ],
-            "group": "build",
-            "options": {
-                "cwd": "${workspaceFolder}/docker"
-            },
-            "presentation": {
-                "echo": true,
-                "reveal": "always",
-                "focus": true,
-                "panel": "shared",
-                "showReuseMessage": false,
-                "clear": true
-            },
-            "problemMatcher": "$gcc"
-        },
-    ]
+  // See https://go.microsoft.com/fwlink/?LinkId=733558
+  // for the documentation about the tasks.json format
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "build_p1",
+      "command": "docker-compose",
+      "args": [
+        "exec",
+        "compiler",
+        "bash",
+        "../wrapped_make.sh",
+        "APP=brewblox",
+        "PLATFORM=p1"
+      ],
+      "group": "build",
+      "options": {
+        "cwd": "${workspaceFolder}/docker"
+      },
+      "presentation": {
+        "echo": true,
+        "reveal": "always",
+        "focus": true,
+        "panel": "shared",
+        "showReuseMessage": false,
+        "clear": false
+      },
+      "problemMatcher": "$gcc"
+    },
+    {
+      "label": "build_photon",
+      "command": "docker-compose",
+      "args": [
+        "exec",
+        "compiler",
+        "bash",
+        "../wrapped_make.sh",
+        "APP=brewblox",
+        "PLATFORM=photon"
+      ],
+      "group": "build",
+      "options": {
+        "cwd": "${workspaceFolder}/docker"
+      },
+      "presentation": {
+        "echo": true,
+        "reveal": "always",
+        "focus": true,
+        "panel": "shared",
+        "showReuseMessage": false,
+        "clear": false
+      },
+      "problemMatcher": "$gcc"
+    },
+    {
+      "label": "build_gcc_local",
+      "command": "bash",
+      "args": ["../wrapped_make.sh", "APP=brewblox", "PLATFORM=gcc"],
+      "group": "build",
+      "options": {
+        "cwd": "${workspaceFolder}/build"
+      },
+      "presentation": {
+        "echo": true,
+        "reveal": "always",
+        "focus": true,
+        "panel": "shared",
+        "showReuseMessage": false,
+        "clear": false
+      },
+      "problemMatcher": "$gcc"
+    },
+    {
+      "label": "flash_p1",
+      "command": "docker-compose",
+      "args": [
+        "exec",
+        "compiler",
+        "bash",
+        "../wrapped_make.sh",
+        "APP=brewblox",
+        "PLATFORM=p1",
+        "all",
+        "program-dfu"
+      ],
+      "group": "build",
+      "options": {
+        "cwd": "${workspaceFolder}/docker"
+      },
+      "presentation": {
+        "echo": true,
+        "reveal": "always",
+        "focus": true,
+        "panel": "shared",
+        "showReuseMessage": false,
+        "clear": false
+      },
+      "problemMatcher": "$gcc",
+      "dependsOn": ["trigger_dfu", "restart_compiler"]
+    },
+    {
+      "label": "flash_photon",
+      "command": "docker-compose",
+      "args": [
+        "exec",
+        "compiler",
+        "bash",
+        "../wrapped_make.sh",
+        "APP=brewblox",
+        "PLATFORM=photon",
+        "all",
+        "program-dfu"
+      ],
+      "group": "build",
+      "options": {
+        "cwd": "${workspaceFolder}/docker"
+      },
+      "presentation": {
+        "echo": true,
+        "reveal": "always",
+        "focus": true,
+        "panel": "shared",
+        "showReuseMessage": false,
+        "clear": false
+      },
+      "problemMatcher": "$gcc",
+      "dependsOn": ["trigger_dfu", "restart_compiler"]
+    },
+    {
+      "label": "trigger_dfu",
+      "command": "docker",
+      "args": [
+        "run",
+        "--rm",
+        "--privileged",
+        "brewblox/firmware-flasher:develop",
+        "trigger-dfu"
+      ],
+      "group": "build",
+      "options": {
+        "cwd": "${workspaceFolder}/docker"
+      },
+      "presentation": {
+        "echo": true,
+        "reveal": "always",
+        "focus": true,
+        "panel": "shared",
+        "showReuseMessage": false,
+        "clear": false
+      },
+      "problemMatcher": "$gcc"
+    },
+    {
+      "label": "restart_compiler",
+      "command": "bash",
+      "args": ["start-compiler.sh"],
+      "group": "build",
+      "options": {
+        "cwd": "${workspaceFolder}/docker"
+      },
+      "presentation": {
+        "echo": true,
+        "reveal": "always",
+        "focus": true,
+        "panel": "shared",
+        "showReuseMessage": false,
+        "clear": false
+      },
+      "problemMatcher": "$gcc"
+    },
+    {
+      "label": "touch_gcc",
+      "type": "shell",
+      "command": "touch",
+      "args": ["device_key.der", "server_key.der", "eeprom.bin"],
+      "options": {
+        "cwd": "${workspaceFolder}/build/target/brewblox-gcc"
+      },
+      "presentation": {
+        "echo": false,
+        "reveal": "never",
+        "focus": false,
+        "panel": "shared",
+        "showReuseMessage": false,
+        "clear": false
+      }
+    },
+    {
+      "label": "build_and_touch_gcc",
+      "dependsOn": ["build_gcc", "touch_gcc"]
+    },
+    {
+      "label": "compile proto",
+      "type": "shell",
+      "command": "docker-compose",
+      "args": ["exec", "compiler", "bash", "compile-proto.sh"],
+      "group": "build",
+      "options": {
+        "cwd": "${workspaceFolder}/docker"
+      },
+      "presentation": {
+        "echo": true,
+        "reveal": "always",
+        "focus": false,
+        "panel": "shared",
+        "showReuseMessage": false,
+        "clear": true
+      },
+      "problemMatcher": []
+    },
+    {
+      "label": "build app tests",
+      "type": "shell",
+      "command": "docker-compose",
+      "args": [
+        "exec",
+        "compiler",
+        "bash",
+        "../wrapped_make.sh",
+        "-C",
+        "../app/brewblox/test"
+      ],
+      "group": "build",
+      "options": {
+        "cwd": "${workspaceFolder}/docker"
+      },
+      "presentation": {
+        "echo": true,
+        "reveal": "always",
+        "focus": true,
+        "panel": "shared",
+        "showReuseMessage": false,
+        "clear": true
+      },
+      "problemMatcher": "$gcc"
+    },
+    {
+      "label": "build lib tests",
+      "type": "shell",
+      "command": "docker-compose",
+      "args": [
+        "exec",
+        "compiler",
+        "bash",
+        "../wrapped_make.sh",
+        "-C",
+        "../lib/test"
+      ],
+      "group": "build",
+      "options": {
+        "cwd": "${workspaceFolder}/docker"
+      },
+      "presentation": {
+        "echo": true,
+        "reveal": "always",
+        "focus": true,
+        "panel": "shared",
+        "showReuseMessage": false,
+        "clear": true
+      },
+      "problemMatcher": "$gcc"
+    },
+    {
+      "label": "build cbox tests",
+      "type": "shell",
+      "command": "docker-compose",
+      "args": [
+        "exec",
+        "compiler",
+        "bash",
+        "../wrapped_make.sh",
+        "-C",
+        "../controlbox"
+      ],
+      "group": "build",
+      "options": {
+        "cwd": "${workspaceFolder}/docker"
+      },
+      "presentation": {
+        "echo": true,
+        "reveal": "always",
+        "focus": true,
+        "panel": "shared",
+        "showReuseMessage": false,
+        "clear": true
+      },
+      "problemMatcher": "$gcc"
+    },
+    {
+      "label": "ci",
+      "command": "docker-compose",
+      "args": ["exec", "compiler", "bash", "run-ci.sh"],
+      "group": "build",
+      "options": {
+        "cwd": "${workspaceFolder}/docker"
+      },
+      "presentation": {
+        "echo": true,
+        "reveal": "always",
+        "focus": true,
+        "panel": "shared",
+        "showReuseMessage": false,
+        "clear": false
+      },
+      "problemMatcher": "$gcc"
+    },
+    {
+      "label": "build lib tests local",
+      "type": "shell",
+      "command": "make",
+      "args": ["-C", "../lib/test"],
+      "group": "build",
+      "options": {
+        "cwd": "${workspaceFolder}/docker"
+      },
+      "presentation": {
+        "echo": true,
+        "reveal": "always",
+        "focus": true,
+        "panel": "shared",
+        "showReuseMessage": false,
+        "clear": true
+      },
+      "problemMatcher": "$gcc"
+    },
+    {
+      "label": "build app tests local",
+      "type": "shell",
+      "command": "make",
+      "args": ["-C", "../app/brewblox/test"],
+      "group": "build",
+      "options": {
+        "cwd": "${workspaceFolder}/docker"
+      },
+      "presentation": {
+        "echo": true,
+        "reveal": "always",
+        "focus": true,
+        "panel": "shared",
+        "showReuseMessage": false,
+        "clear": true
+      },
+      "problemMatcher": "$gcc"
+    },
+    {
+      "label": "clean all",
+      "type": "shell",
+      "command": "bash",
+      "args": ["clean-all.sh"],
+      "group": "build",
+      "options": {
+        "cwd": "${workspaceFolder}/build"
+      },
+      "presentation": {
+        "echo": true,
+        "reveal": "always",
+        "focus": true,
+        "panel": "shared",
+        "showReuseMessage": false,
+        "clear": true
+      },
+      "problemMatcher": "$gcc"
+    }
+  ]
 }

--- a/app/brewblox/blox/PidBlock.h
+++ b/app/brewblox/blox/PidBlock.h
@@ -12,7 +12,7 @@
 
 class PidBlock : public Block<BrewbloxOptions_BlockType_Pid> {
 private:
-    cbox::CboxPtr<ProcessValue<Pid::in_t>> input;
+    cbox::CboxPtr<SetpointSensorPair> input;
     cbox::CboxPtr<ActuatorAnalogConstrained> output;
 
     Pid pid;
@@ -39,10 +39,12 @@ public:
             pid.enabled(newData.enabled);
             input.setId(newData.inputId);
             output.setId(newData.outputId);
-            pid.configureFilter(uint8_t(newData.filter), cnl::wrap<Pid::in_t>(newData.filterThreshold));
             pid.kp(cnl::wrap<Pid::in_t>(newData.kp));
             pid.ti(newData.ti);
             pid.td(newData.td);
+            if (newData.integralReset != 0) {
+                pid.setIntegral(cnl::wrap<Pid::out_t>(newData.integralReset));
+            }
         }
         return res;
     }
@@ -89,8 +91,6 @@ public:
             stripped.add(blox_Pid_outputValue_tag);
         }
 
-        message.filter = blox_Pid_FilterChoice(pid.filterChoice());
-        message.filterThreshold = cnl::unwrap(pid.filterThreshold());
         message.enabled = pid.enabled();
         message.active = pid.active();
         message.kp = cnl::unwrap(pid.kp());
@@ -114,8 +114,6 @@ public:
         blox_Pid message = blox_Pid_init_zero;
         message.inputId = input.getId();
         message.outputId = output.getId();
-        message.filter = blox_Pid_FilterChoice(pid.filterChoice());
-        message.filterThreshold = cnl::unwrap(pid.filterThreshold());
         message.enabled = pid.enabled();
         message.kp = cnl::unwrap(pid.kp());
         message.ti = pid.ti();

--- a/app/brewblox/blox/SetpointSensorPairBlock.h
+++ b/app/brewblox/blox/SetpointSensorPairBlock.h
@@ -32,9 +32,8 @@ public
             pair.setting(cnl::wrap<temp_t>(newData.storedSetting));
             pair.settingValid(newData.settingEnabled);
             pair.configureFilter(uint8_t(newData.filter), cnl::wrap<fp12_t>(newData.filterThreshold));
-            
-            
-            if(newData.resetFilter || sensor.getId() != newData.sensorId){
+
+            if (newData.resetFilter || sensor.getId() != newData.sensorId) {
                 sensor.setId(newData.sensorId);
                 pair.resetFilter();
             }
@@ -59,11 +58,16 @@ public
         } else {
             stripped.add(blox_SetpointSensorPair_setting_tag);
         };
+        if (pair.sensorValid()) {
+            message.valueUnfiltered = cnl::unwrap(pair.valueUnfiltered());
+        } else {
+            stripped.add(blox_SetpointSensorPair_valueUnfiltered_tag);
+        }
 
         message.filter = blox_SetpointSensorPair_FilterChoice(pair.filterChoice());
         message.filterThreshold = cnl::unwrap(pair.filterThreshold());
 
-        stripped.copyToMessage(message.strippedFields, message.strippedFields_count, 2);
+        stripped.copyToMessage(message.strippedFields, message.strippedFields_count, 3);
 
         return streamProtoTo(out, &message, blox_SetpointSensorPair_fields, blox_SetpointSensorPair_size);
     }

--- a/app/brewblox/test/AcutatorOffsetBlock_test.cpp
+++ b/app/brewblox/test/AcutatorOffsetBlock_test.cpp
@@ -145,7 +145,8 @@ SCENARIO("A Blox ActuatorOffset object can be created from streamed protobuf dat
                                             "setting: 131072 "
                                             "value: 86016 "
                                             "settingEnabled: true "
-                                            "storedSetting: 131072"); // setting 32, value 21 (setpoint adjusted to 20 + 12)
+                                            "storedSetting: 131072 "
+                                            "filterThreshold: 4096"); // setting 32, value 21 (setpoint adjusted to 20 + 12)
     }
 
     // read target pair
@@ -161,7 +162,8 @@ SCENARIO("A Blox ActuatorOffset object can be created from streamed protobuf dat
                                             "setting: 81920 "
                                             "value: 110592 "
                                             "settingEnabled: true "
-                                            "storedSetting: 81920"); // 20, 27 (unaffected)
+                                            "storedSetting: 81920 "
+                                            "filterThreshold: 4096"); // 20, 27 (unaffected)
     }
 
     AND_WHEN("The reference setpoint is disabled")

--- a/app/brewblox/test/AcutatorOffsetBlock_test.cpp
+++ b/app/brewblox/test/AcutatorOffsetBlock_test.cpp
@@ -146,7 +146,8 @@ SCENARIO("A Blox ActuatorOffset object can be created from streamed protobuf dat
                                             "value: 86016 "
                                             "settingEnabled: true "
                                             "storedSetting: 131072 "
-                                            "filterThreshold: 4096"); // setting 32, value 21 (setpoint adjusted to 20 + 12)
+                                            "filterThreshold: 4096 "
+                                            "valueUnfiltered: 86016"); // setting 32, value 21 (setpoint adjusted to 20 + 12)
     }
 
     // read target pair
@@ -163,7 +164,8 @@ SCENARIO("A Blox ActuatorOffset object can be created from streamed protobuf dat
                                             "value: 110592 "
                                             "settingEnabled: true "
                                             "storedSetting: 81920 "
-                                            "filterThreshold: 4096"); // 20, 27 (unaffected)
+                                            "filterThreshold: 4096 "
+                                            "valueUnfiltered: 110592"); // 20, 27 (unaffected)
     }
 
     AND_WHEN("The reference setpoint is disabled")

--- a/app/brewblox/test/SetpointSensorPairBlock_test.cpp
+++ b/app/brewblox/test/SetpointSensorPairBlock_test.cpp
@@ -89,7 +89,8 @@ SCENARIO("A Blox SetpointSensorPair object can be created from streamed protobuf
                                         "settingEnabled: true "
                                         "storedSetting: 86016 "
                                         "filter: FILT_3m "
-                                        "filterThreshold: 2048");
+                                        "filterThreshold: 2048 "
+                                        "valueUnfiltered: 81920");
 
     WHEN("The sensor is invalid for over 10 seconds")
     {
@@ -120,7 +121,8 @@ SCENARIO("A Blox SetpointSensorPair object can be created from streamed protobuf
                                                 "storedSetting: 86016 "
                                                 "filter: FILT_3m "
                                                 "filterThreshold: 2048 "
-                                                "strippedFields: 6");
+                                                "strippedFields: 6 "
+                                                "strippedFields: 11");
         }
     }
 
@@ -151,7 +153,8 @@ SCENARIO("A Blox SetpointSensorPair object can be created from streamed protobuf
                                                 "settingEnabled: true "
                                                 "storedSetting: 86016 "
                                                 "filter: FILT_3m "
-                                                "filterThreshold: 2048");
+                                                "filterThreshold: 2048 "
+                                                "valueUnfiltered: 102400");
         }
 
         AND_THEN("Sending a filter reset trigger will force the filter state to the current value")
@@ -174,7 +177,8 @@ SCENARIO("A Blox SetpointSensorPair object can be created from streamed protobuf
                                                 "settingEnabled: true "
                                                 "storedSetting: 86016 "
                                                 "filter: FILT_3m "
-                                                "filterThreshold: 2048");
+                                                "filterThreshold: 2048 "
+                                                "valueUnfiltered: 102400");
         }
     }
 }

--- a/app/brewblox/test/SetpointSensorPairBlock_test.cpp
+++ b/app/brewblox/test/SetpointSensorPairBlock_test.cpp
@@ -68,6 +68,8 @@ SCENARIO("A Blox SetpointSensorPair object can be created from streamed protobuf
     newPair.set_sensorid(100);
     newPair.set_settingenabled(true);
     newPair.set_storedsetting(cnl::unwrap(temp_t(21)));
+    newPair.set_filter(blox::SetpointSensorPair::FilterChoice::SetpointSensorPair_FilterChoice_FILT_3m);
+    newPair.set_filterthreshold(cnl::unwrap(temp_t(0.5)));
     testBox.put(newPair);
 
     testBox.processInput();
@@ -85,9 +87,11 @@ SCENARIO("A Blox SetpointSensorPair object can be created from streamed protobuf
                                         "setting: 86016 "
                                         "value: 81920 "
                                         "settingEnabled: true "
-                                        "storedSetting: 86016");
+                                        "storedSetting: 86016 "
+                                        "filter: FILT_3m "
+                                        "filterThreshold: 2048");
 
-    WHEN("The sensor is invalid")
+    WHEN("The sensor is invalid for over 10 seconds")
     {
         auto cboxPtr = brewbloxBox().makeCboxPtr<TempSensorMockBlock>(100);
         auto ptr = cboxPtr.lock();
@@ -95,7 +99,9 @@ SCENARIO("A Blox SetpointSensorPair object can be created from streamed protobuf
 
         ptr->get().connected(false);
 
-        testBox.update(1000);
+        for (cbox::update_t t = 1000; t <= 12000; t += 100) {
+            testBox.update(t);
+        }
 
         THEN("The input value is flagged as stripped field")
         {
@@ -112,7 +118,63 @@ SCENARIO("A Blox SetpointSensorPair object can be created from streamed protobuf
                                                 "setting: 86016 "
                                                 "settingEnabled: true "
                                                 "storedSetting: 86016 "
+                                                "filter: FILT_3m "
+                                                "filterThreshold: 2048 "
                                                 "strippedFields: 6");
+        }
+    }
+
+    WHEN("The mock sensor value is changed to 25")
+    {
+        auto cboxPtr = brewbloxBox().makeCboxPtr<TempSensorMockBlock>(100);
+        auto ptr = cboxPtr.lock();
+        REQUIRE(ptr);
+
+        ptr->get().value(25);
+
+        testBox.update(1000);
+
+        THEN("The value that is read is still at the old value due to filtering immediately after")
+        {
+            // read pair
+            testBox.put(uint16_t(0)); // msg id
+            testBox.put(commands::READ_OBJECT);
+            testBox.put(cbox::obj_id_t(101));
+
+            auto decoded = blox::SetpointSensorPair();
+            testBox.processInputToProto(decoded);
+
+            CHECK(testBox.lastReplyHasStatusOk());
+            CHECK(decoded.ShortDebugString() == "sensorId: 100 "
+                                                "setting: 86016 "
+                                                "value: 81920 "
+                                                "settingEnabled: true "
+                                                "storedSetting: 86016 "
+                                                "filter: FILT_3m "
+                                                "filterThreshold: 2048");
+        }
+
+        AND_THEN("Sending a filter reset trigger will force the filter state to the current value")
+        {
+            testBox.put(uint16_t(0)); // msg id
+            testBox.put(commands::WRITE_OBJECT);
+            testBox.put(cbox::obj_id_t(101));
+            testBox.put(uint8_t(0xFF));
+            testBox.put(SetpointSensorPairBlock::staticTypeId());
+
+            newPair.set_resetfilter(true);
+            testBox.put(newPair);
+            auto decoded = blox::SetpointSensorPair();
+            testBox.processInputToProto(decoded);
+
+            CHECK(testBox.lastReplyHasStatusOk());
+            CHECK(decoded.ShortDebugString() == "sensorId: 100 "
+                                                "setting: 86016 "
+                                                "value: 102400 "
+                                                "settingEnabled: true "
+                                                "storedSetting: 86016 "
+                                                "filter: FILT_3m "
+                                                "filterThreshold: 2048");
         }
     }
 }

--- a/build/clean-all.sh
+++ b/build/clean-all.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -e
+
+MY_DIR=$(dirname "$(readlink -f "$0")")
+ROOT_DIR=$(dirname "$(readlink -f "$MY_DIR")")
+
+sudo chown -R $USER "$ROOT_DIR"
+make -C "../app/brewblox/test" clean
+make -C "../lib/test" clean
+make -C "../cbox/test" clean
+make clean

--- a/lib/inc/Pid.h
+++ b/lib/inc/Pid.h
@@ -37,9 +37,9 @@ private:
 
     // state
     in_t m_error = in_t{0};
-    in_t m_p = in_t{0};
-    in_t m_i = in_t{0};
-    in_t m_d = in_t{0};
+    out_t m_p = out_t{0};
+    out_t m_i = out_t{0};
+    out_t m_d = out_t{0};
     integral_t m_integral = integral_t{0};
     derivative_t m_derivative = derivative_t{0};
 
@@ -145,6 +145,13 @@ public:
     auto active() const
     {
         return m_active;
+    }
+    void setIntegral(const out_t& newIntegratorPart)
+    {
+        if (m_kp == 0) {
+            return;
+        }
+        m_integral = newIntegratorPart * m_ti / m_kp;
     }
 
 private:

--- a/lib/inc/SetpointSensorPair.h
+++ b/lib/inc/SetpointSensorPair.h
@@ -19,6 +19,8 @@
 
 #pragma once
 
+#include "FixedPoint.h"
+#include "FpFilterChain.h"
 #include "ProcessValue.h"
 #include "TempSensor.h"
 #include "Temperature.h"
@@ -28,32 +30,45 @@
 /*
  * A process value has a setting and an current value
  */
-class SetpointSensorPair : public ProcessValue<temp_t> {
+class SetpointSensorPair : public ProcessValue<fp12_t> {
+public:
+    using derivative_t = safe_elastic_fixed_point<1, 23, int32_t>;
+
 private:
-    temp_t m_setting = 20;
+    fp12_t m_setting = 20;
     bool m_settingEnabled = false;
     const std::function<std::shared_ptr<TempSensor>()> m_sensor;
+    FpFilterChain<fp12_t> m_filter;
+    uint8_t m_filterChoice = 0;         // input filter index
+    uint8_t m_sensorFailureCount = 255; // force a reset on init
 
 public:
     explicit SetpointSensorPair(
         std::function<std::shared_ptr<TempSensor>()>&& _sensor)
         : m_sensor(_sensor)
+        , m_filter(m_filterChoice)
     {
+        update();
     }
 
     virtual ~SetpointSensorPair() = default;
 
-    virtual void setting(temp_t const& setting) override final
+    virtual void setting(fp12_t const& setting) override final
     {
         m_setting = setting;
     }
 
-    virtual temp_t setting() const override final
+    virtual fp12_t setting() const override final
     {
         return m_setting;
     }
 
-    virtual temp_t value() const override final
+    virtual fp12_t value() const override final
+    {
+        return m_filter.read();
+    }
+
+    fp12_t valueUnfiltered() const
     {
         if (auto sPtr = m_sensor()) {
             return sPtr->value();
@@ -63,6 +78,11 @@ public:
     }
 
     bool valueValid() const override final
+    {
+        return m_sensorFailureCount <= 10;
+    }
+
+    bool sensorValid() const
     {
         if (auto sens = m_sensor()) {
             return sens->valid();
@@ -78,5 +98,59 @@ public:
     virtual void settingValid(bool v) override final
     {
         m_settingEnabled = v;
+    }
+
+    auto filterChoice() const
+    {
+        return m_filterChoice;
+    }
+
+    auto filterThreshold() const
+    {
+        return m_filter.getStepThreshold();
+    }
+
+    void configureFilter(uint8_t choice, const fp12_t& threshold)
+    {
+        if (m_filterChoice != choice) {
+            m_filterChoice = choice;
+            m_filter.setParams(choice, threshold);
+        } else {
+            m_filter.setStepThreshold(threshold);
+        }
+    }
+
+    void update()
+    {
+        if (sensorValid()) {
+            auto val = valueUnfiltered();
+            if (!valueValid()) {
+                m_filter.reset(val);
+            }
+            m_filter.add(val);
+            m_sensorFailureCount = 0;
+        } else {
+            if (m_sensorFailureCount < 255) {
+                m_sensorFailureCount++;
+            }
+        }
+    }
+
+    auto error()
+    {
+        return setting() - value();
+    }
+
+    auto derivative()
+    {
+        return m_filter.readDerivative<derivative_t>();
+    }
+
+    void resetFilter()
+    {
+        if (sensorValid()) {
+            m_filter.reset(valueUnfiltered());
+            m_sensorFailureCount = 0;
+        }
     }
 };

--- a/lib/src/IirFilter.cpp
+++ b/lib/src/IirFilter.cpp
@@ -121,9 +121,7 @@ int64_t
 IirFilter::unshift(const int64_t val, uint8_t shift) const
 {
     const int64_t rounder = 1 << (shift - 1);
-    // round towards zero, which is unbiased
-    // safer than away from zero, which can make the value run away from zero slowly
-    int64_t rounded = (val > 0) ? val - rounder : val + rounder;
+    int64_t rounded = val + rounder;
     return rounded >> shift;
 }
 

--- a/lib/test/ActuatorOffset_test.cpp
+++ b/lib/test/ActuatorOffset_test.cpp
@@ -52,6 +52,7 @@ SCENARIO("ActuatorOffset offsets one setpoint from another", "[ActuatorOffset]")
         CHECK(act->value() == 0.0);    // actual value is still zero, because targetSensor has not changed
 
         targetSensor->value(30.0);
+        target->resetFilter();
         act->update();
         CHECK(act->value() == 10.0); // actual value is 10 when sensor has reached setpoint
 
@@ -60,16 +61,20 @@ SCENARIO("ActuatorOffset offsets one setpoint from another", "[ActuatorOffset]")
         CHECK(target->setting() == 10.0);
         CHECK(act->setting() == -10.0); // difference between setpoints is now 10
         act->update();
+
         CHECK(act->value() == 10.0); // value is still 10, because targetSensor has not changed
 
         targetSensor->value(10.0);
+        target->resetFilter();
         act->update();
         CHECK(act->value() == -10.0); // value is -10 when sensor has reached setpoint
 
         reference->setting(10.0);
         referenceSensor->value(15.0);
+        reference->resetFilter();
         target->setting(20.0);
         targetSensor->value(20.0);
+        target->resetFilter();
         act->setting(12.0);
 
         // when using the reference setting as value to offset from (default):
@@ -150,6 +155,9 @@ SCENARIO("ActuatorOffset offsets one setpoint from another", "[ActuatorOffset]")
         act->selectedReference(ActuatorOffset::SettingOrValue::VALUE);
         target->setting(20);
         referenceSensor->connected(false);
+        for (int i = 0; i <= 10; i++) {
+            reference->update(); // will only switch to invalid after 10s disconnected
+        }
         act->setting(12.0);
 
         CHECK(target->setting() == 20.0); // unchanged

--- a/lib/test/PidTest.cpp
+++ b/lib/test/PidTest.cpp
@@ -54,12 +54,14 @@ SCENARIO("PID Test with mock actuator", "[pid]")
         pid.ti(0);
         pid.td(0);
 
-        input->setting(21);
-        sensor->value(20);
-
-        for (int32_t i = 0; i < 100; ++i) {
-            pid.update(); // update 100 times to settle input filter
+        for (int32_t i = 0; i < 1000; ++i) {
+            input->setting(21);
+            sensor->value(20);
         }
+
+        input->update();
+        pid.update();
+
         CHECK(actuator->setting() == Approx(10).margin(0.01));
     }
 
@@ -71,8 +73,8 @@ SCENARIO("PID Test with mock actuator", "[pid]")
 
         input->setting(21);
         sensor->value(20);
-
         for (int32_t i = 0; i < 1000; ++i) {
+            input->update();
             pid.update();
         }
 
@@ -92,6 +94,7 @@ SCENARIO("PID Test with mock actuator", "[pid]")
         sensor->value(20);
 
         for (int32_t i = 0; i < 1000; ++i) {
+            input->update();
             pid.update();
         }
 
@@ -120,11 +123,12 @@ SCENARIO("PID Test with mock actuator", "[pid]")
         input->setting(30);
         sensor->value(20);
 
-        temp_t mockVal;
+        fp12_t mockVal;
         double accumulatedError = 0;
         for (int32_t i = 0; i <= 900; ++i) {
-            mockVal = temp_t(20) + (temp_t(9) * i) / 900;
+            mockVal = fp12_t(20) + (fp12_t(9) * i) / 900;
             sensor->value(mockVal);
+            input->update();
             pid.update();
             accumulatedError += pid.error();
         }
@@ -148,11 +152,12 @@ SCENARIO("PID Test with mock actuator", "[pid]")
         input->setting(20);
         sensor->value(30);
 
-        temp_t mockVal;
+        fp12_t mockVal;
         double accumulatedError = 0;
         for (int32_t i = 0; i <= 900; ++i) {
-            mockVal = temp_t(30) - (temp_t(9) * i) / 900;
+            mockVal = fp12_t(30) - (fp12_t(9) * i) / 900;
             sensor->value(mockVal);
+            input->update();
             pid.update();
             accumulatedError += pid.error();
         }
@@ -180,6 +185,7 @@ SCENARIO("PID Test with mock actuator", "[pid]")
 
         double accumulatedError = 0;
         for (int32_t i = 0; i <= 10000; ++i) {
+            input->update();
             pid.update();
             accumulatedError += pid.error();
         }
@@ -196,6 +202,7 @@ SCENARIO("PID Test with mock actuator", "[pid]")
         input->setting(19);
         accumulatedError = 0;
         for (int32_t i = 0; i <= 10000; ++i) {
+            input->update();
             pid.update();
             accumulatedError += pid.error();
         }
@@ -223,6 +230,7 @@ SCENARIO("PID Test with mock actuator", "[pid]")
 
         double accumulatedError = 0;
         for (int32_t i = 0; i <= 10000; ++i) {
+            input->update();
             pid.update();
             accumulatedError += pid.error();
         }
@@ -238,6 +246,7 @@ SCENARIO("PID Test with mock actuator", "[pid]")
         input->setting(21);
         accumulatedError = 0;
         for (int32_t i = 0; i <= 10000; ++i) {
+            input->update();
             pid.update();
             accumulatedError += pid.error();
         }
@@ -265,10 +274,10 @@ SCENARIO("PID Test with mock actuator", "[pid]")
 
         double accumulatedError = 0;
         for (int32_t i = 0; i <= 10000; ++i) {
+            input->update();
             pid.update();
             accumulatedError += pid.error();
         }
-        pid.update();
 
         double integratorValueWithoutAntiWindup = accumulatedError * (10.0 / 2000);
         CHECK(integratorValueWithoutAntiWindup == Approx(50.0).epsilon(0.01));
@@ -281,6 +290,7 @@ SCENARIO("PID Test with mock actuator", "[pid]")
         input->setting(19);
         accumulatedError = 0;
         for (int32_t i = 0; i <= 10000; ++i) {
+            input->update();
             pid.update();
             accumulatedError += pid.error();
         }
@@ -307,6 +317,7 @@ SCENARIO("PID Test with mock actuator", "[pid]")
 
         double accumulatedError = 0;
         for (int32_t i = 0; i <= 10000; ++i) {
+            input->update();
             pid.update();
             accumulatedError += pid.error();
         }
@@ -322,6 +333,7 @@ SCENARIO("PID Test with mock actuator", "[pid]")
         input->setting(21);
         accumulatedError = 0;
         for (int32_t i = 0; i <= 10000; ++i) {
+            input->update();
             pid.update();
             accumulatedError += pid.error();
         }
@@ -335,7 +347,7 @@ SCENARIO("PID Test with mock actuator", "[pid]")
         CHECK(actuator->setting() == Approx(-10).margin(0.01));
     }
 
-    WHEN("The PID input is invalid for over 10 seconds, the actuator is set to invalid and the PID is inactive")
+    WHEN("The sensor of the PID input becomes invalid")
     {
         pid.kp(10);
         pid.ti(2000);
@@ -349,17 +361,25 @@ SCENARIO("PID Test with mock actuator", "[pid]")
             if (i == 2000) {
                 sensor->connected(false);
             }
+            input->update();
             pid.update();
             if (!pid.active()) {
                 break;
             }
         }
-        CHECK(i == 2010);
-        CHECK(actuator->settingValid() == false);
+        THEN("The input becomes invalid after 5 seconds")
+        {
+            CHECK(i == 2010);
+        }
+        AND_THEN("PID is inactive")
+        {
+            CHECK(actuator->settingValid() == false);
+        }
 
         AND_WHEN("The input becomes valid again, the pid and actuator become active again")
         {
             sensor->connected(true);
+            input->update();
             pid.update();
 
             CHECK(pid.active() == true);
@@ -399,6 +419,7 @@ SCENARIO("PID Test with offset actuator", "[pid]")
     pid.td(0);
 
     for (int32_t i = 0; i < 100; ++i) {
+        reference->update();
         pid.update(); // update 100 times to settle input filter
     }
 
@@ -412,16 +433,19 @@ SCENARIO("PID Test with offset actuator", "[pid]")
     WHEN("The PID input sensor becomes invalid")
     {
         referenceSensor->connected(false);
+        reference->update();
         pid.update();
 
-        THEN("The target setpoint is set to invalid after 10 failed updates")
+        THEN("The input value becomes invalid and the target setpoint is set to invalid after 10 failed sensor reads")
         {
             for (uint8_t i = 0; i < 10; ++i) {
                 CHECK(pid.active() == true);
                 CHECK(target->settingValid() == true);
+                reference->update();
                 pid.update();
             }
 
+            CHECK(reference->valueValid() == false);
             CHECK(pid.active() == false);
             CHECK(target->settingValid() == false);
         }
@@ -429,8 +453,10 @@ SCENARIO("PID Test with offset actuator", "[pid]")
         AND_WHEN("The sensor comes back alive, the pid and setpoint are active/valid again")
         {
             referenceSensor->connected(true);
+            reference->update();
             pid.update();
 
+            CHECK(reference->valueValid() == true);
             CHECK(pid.active() == true);
             CHECK(target->settingValid() == true);
         }
@@ -439,6 +465,7 @@ SCENARIO("PID Test with offset actuator", "[pid]")
     WHEN("The PID is disabled")
     {
         pid.enabled(false);
+        reference->update();
         pid.update();
 
         THEN("The target setpoint is set to invalid")
@@ -452,6 +479,7 @@ SCENARIO("PID Test with offset actuator", "[pid]")
             target->setting(20.0);
             target->settingValid(true);
             CHECK(target->settingValid() == true);
+            reference->update();
             pid.update();
 
             THEN("The already disabled PID doesn't affect it")
@@ -472,6 +500,7 @@ SCENARIO("PID Test with PWM actuator", "[pid]")
         [&sensor]() { return sensor; });
     input->settingValid(true);
     input->setting(20);
+    input->configureFilter(0, fp12_t(1));
 
     auto mockIo = std::make_shared<MockIoArray>();
     auto mock = ActuatorDigital([mockIo]() { return mockIo; }, 1);
@@ -489,8 +518,6 @@ SCENARIO("PID Test with PWM actuator", "[pid]")
 
     pid.enabled(true);
 
-    pid.configureFilter(0, Pid::in_t(1));
-
     auto nextPwmUpdate = now;
     auto nextPidUpdate = now;
 
@@ -501,6 +528,7 @@ SCENARIO("PID Test with PWM actuator", "[pid]")
                 nextPwmUpdate = pwm.update(now);
             }
             if (now >= nextPidUpdate) {
+                input->update();
                 pid.update();
                 actuator->update();
                 nextPidUpdate = now + 1000;
@@ -555,7 +583,7 @@ SCENARIO("PID Test with PWM actuator", "[pid]")
         input->setting(30);
         sensor->value(20);
 
-        temp_t mockVal;
+        fp12_t mockVal;
         double accumulatedError = 0;
 
         auto start = now;
@@ -564,8 +592,9 @@ SCENARIO("PID Test with PWM actuator", "[pid]")
                 nextPwmUpdate = pwm.update(now);
             }
             if (now >= nextPidUpdate) {
-                mockVal = temp_t(20.0 + 9.0 * (now - start) / 900'000);
+                mockVal = fp12_t(20.0 + 9.0 * (now - start) / 900'000);
                 sensor->value(mockVal);
+                input->update();
                 pid.update();
                 actuator->update();
                 accumulatedError += pid.error();
@@ -592,7 +621,7 @@ SCENARIO("PID Test with PWM actuator", "[pid]")
         input->setting(20);
         sensor->value(30);
 
-        temp_t mockVal;
+        fp12_t mockVal;
         double accumulatedError = 0;
 
         auto start = now;
@@ -601,8 +630,9 @@ SCENARIO("PID Test with PWM actuator", "[pid]")
                 nextPwmUpdate = pwm.update(now);
             }
             if (now >= nextPidUpdate) {
-                mockVal = temp_t(30.0 - 9.0 * (now - start) / 900'000);
+                mockVal = fp12_t(30.0 - 9.0 * (now - start) / 900'000);
                 sensor->value(mockVal);
+                input->update();
                 pid.update();
                 actuator->update();
                 accumulatedError += pid.error();
@@ -620,14 +650,14 @@ SCENARIO("PID Test with PWM actuator", "[pid]")
         CHECK(actuator->setting() == pid.p() + pid.i() + pid.d());
     }
 
-    WHEN("When changing Ti")
+    WHEN("When changing Ti is changed")
     {
         pid.kp(-10);
         pid.ti(2000);
         pid.td(200);
 
-        input->setting(20);
-        sensor->value(21);
+        // sensor is left at 20
+        input->setting(19);
 
         auto start = now;
         while (now <= start + 1000'000) {
@@ -635,6 +665,7 @@ SCENARIO("PID Test with PWM actuator", "[pid]")
                 nextPwmUpdate = pwm.update(now);
             }
             if (now >= nextPidUpdate) {
+                input->update();
                 pid.update();
                 actuator->update();
                 nextPidUpdate = now + 1000;
@@ -648,6 +679,7 @@ SCENARIO("PID Test with PWM actuator", "[pid]")
         CHECK(pid.d() == Approx(0.0).margin(0.01));
 
         pid.ti(1000);
+        input->update();
         pid.update();
 
         THEN("The integral action is unchanged")
@@ -666,8 +698,8 @@ SCENARIO("PID Test with PWM actuator", "[pid]")
         pid.ti(2000);
         pid.td(200);
 
-        input->setting(20);
-        sensor->value(25);
+        // sensor is left at 20
+        input->setting(15);
 
         auto start = now;
         while (now <= start + 1000'000) {
@@ -675,6 +707,7 @@ SCENARIO("PID Test with PWM actuator", "[pid]")
                 nextPwmUpdate = pwm.update(now);
             }
             if (now >= nextPidUpdate) {
+                input->update();
                 pid.update();
                 actuator->update();
                 nextPidUpdate = now + 1000;
@@ -698,6 +731,7 @@ SCENARIO("PID Test with PWM actuator", "[pid]")
                     nextPwmUpdate = pwm.update(now);
                 }
                 if (now >= nextPidUpdate) {
+                    input->update();
                     pid.update();
                     actuator->update();
                     nextPidUpdate = now + 1000;
@@ -705,6 +739,7 @@ SCENARIO("PID Test with PWM actuator", "[pid]")
                 ++now;
             }
 
+            input->update();
             pid.update();
 
             CHECK(pid.p() == Approx(50).epsilon(0.01));
@@ -724,6 +759,7 @@ SCENARIO("PID Test with PWM actuator", "[pid]")
                     nextPwmUpdate = pwm.update(now);
                 }
                 if (now >= nextPidUpdate) {
+                    input->update();
                     pid.update();
                     actuator->update();
                     nextPidUpdate = now + 1000;
@@ -731,6 +767,7 @@ SCENARIO("PID Test with PWM actuator", "[pid]")
                 ++now;
             }
 
+            input->update();
             pid.update();
 
             CHECK(pid.p() == Approx(125).epsilon(0.01));
@@ -744,6 +781,7 @@ SCENARIO("PID Test with PWM actuator", "[pid]")
     WHEN("The PID is disabled")
     {
         pid.enabled(false);
+        input->update();
         pid.update();
 
         THEN("The pwm setting is set to invalid")
@@ -757,6 +795,7 @@ SCENARIO("PID Test with PWM actuator", "[pid]")
             actuator->settingValid(true);
             CHECK(actuator->settingValid() == true);
             CHECK(actuator->setting() == 50);
+            input->update();
             pid.update();
 
             THEN("The disabled PID doesn't affect it")

--- a/lib/test/PidTest.cpp
+++ b/lib/test/PidTest.cpp
@@ -805,4 +805,18 @@ SCENARIO("PID Test with PWM actuator", "[pid]")
             }
         }
     }
+
+    WHEN("The integral part is set externally")
+    {
+        pid.kp(10);
+        pid.ti(1000);
+        pid.td(0);
+        pid.setIntegral(20);
+        pid.update();
+
+        THEN("The new output matches what whas set")
+        {
+            CHECK(pid.i() == 20);
+        }
+    }
 }


### PR DESCRIPTION
This moves the filter out of the PID and into the setpoint sensor pair that the PID uses as input, so it can be shared.

This is also probably clearer for the end user.

This PR includes some other changes to PID and filter behavior:
- The filter now holds the sensor value instead of the error, so the PID responds immediately to setpoint changes.
- The derivative that is reported is now of the sensor, not the error (this changes its sign)
- Fixes a rounding error in the filter
- The filter can be reset to current sensor value externally
- The integral can be set to any value externally except zero (to exclude protobuf defaults). To reset to zero, set to 0.001 instead.
