### PR TITLE
Fix achieved PWM value to be correct when constraints are active

### DIFF
--- a/lib/test/ActuatorPwm_test.cpp
+++ b/lib/test/ActuatorPwm_test.cpp
@@ -350,6 +350,21 @@ SCENARIO("ActuatorPWM driving mock actuator", "[pwm]")
         CHECK(randomIntervalTest(10, pwm, mock, 96.0, 500, now) == Approx(96.0).margin(0.5));
     }
 
+    WHEN("PWM actuator target is constrained with a minimal ON time, the achieved value is always correct once adjusted")
+    {
+        pwm.period(10000);                                                               // 10s
+        constrained->addConstraint(std::make_unique<ADConstraints::MinOnTime<2>>(5000)); // 5 s
+        pwm.setting(30);
+
+        for (; now < 100000; now += 100) {
+            pwm.update(now);
+            if (now > 50000) {
+                CHECK(pwm.value() == Approx(30).margin(0.5));
+            }
+        }
+        pwm.setting(50);
+    }
+
     WHEN("PWM actuator is set to invalid, the output pin is set low")
     {
         pwm.setting(100);


### PR DESCRIPTION
The achieved PWM duty cycle was reported higher than actual, because it was recalculated when the outpin pin SHOULD go high, not when it actually did.
This PR fixes this by only recalculating when the pin has actually toggled.

Fixes #109