### PR TITLE
Keep integral part of output the same when changing Kp

### DIFF
--- a/lib/inc/Pid.h
+++ b/lib/inc/Pid.h
@@ -104,6 +104,10 @@ public:
 
     void kp(const in_t& arg)
     {
+        if (arg != 0) {
+            // scale integral history so integral action doesn't change
+            m_integral = (m_integral * m_kp) / arg;
+        }
         m_kp = arg;
     }
 


### PR DESCRIPTION
The integral part of the output should not change when changing Kp, only how quick it builds up.
Due to the way it was calculated internally, this was not the case. This change scales the integral when changing Kp to fix that.

fixes #112 