### PR TITLE
For filter and PID that require an accurate 1s interval, keep track of update frequency and adapt

### DIFF
--- a/app/brewblox/test/PidBlock_test.cpp
+++ b/app/brewblox/test/PidBlock_test.cpp
@@ -109,9 +109,10 @@ SCENARIO("A Blox Pid object can be created from streamed protobuf data")
     testBox.processInput();
     CHECK(testBox.lastReplyHasStatusOk());
 
-    // update 1000 seconds (PID updates every second, t is in ms)
+    // update 999 seconds (PID updates every second, t is in ms)
+    // one extra update will be triggered on proto receive
     uint32_t t = 0;
-    for (; t < 1000'000; ++t) {
+    for (; t < 999'000; t += 100) {
         testBox.update(t);
     }
 

--- a/lib/inc/IntervalHelper.h
+++ b/lib/inc/IntervalHelper.h
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2019 BrewPi B.V.
+ *
+ * This file is part of the BrewBlox Control Library.
+ *
+ * BrewPi is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * BrewPi is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with BrewPi.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "TicksTypes.h"
+
+/*
+ * A process value has a setting and an current value
+ */
+template <ticks_millis_t INTERVAL>
+class IntervalHelper {
+private:
+    duration_millis_t m_accumulatedUpdateLateness = 0;
+    ticks_millis_t m_lastUpdate = -INTERVAL;
+
+public:
+    IntervalHelper() = default;
+
+    ~IntervalHelper() = default;
+
+    ticks_millis_t update(const ticks_millis_t& now, bool& doUpdate)
+    {
+        // interval is max 1000ms. Can be shortened to make up for previous updates that were overdue
+        auto interval = m_accumulatedUpdateLateness >= INTERVAL ? 0 : INTERVAL - m_accumulatedUpdateLateness;
+        auto elapsed = now - m_lastUpdate;
+
+        if (elapsed >= interval) {
+            doUpdate = true;
+            m_lastUpdate = now;
+            m_accumulatedUpdateLateness += elapsed;
+            m_accumulatedUpdateLateness = m_accumulatedUpdateLateness > INTERVAL ? m_accumulatedUpdateLateness - INTERVAL : 0;
+            interval = m_accumulatedUpdateLateness >= INTERVAL ? 0 : INTERVAL - m_accumulatedUpdateLateness;
+            return now + interval;
+        }
+        return now + interval - elapsed;
+    }
+};

--- a/lib/inc/Pid.h
+++ b/lib/inc/Pid.h
@@ -104,6 +104,10 @@ public:
 
     void kp(const in_t& arg)
     {
+        if (arg != 0) {
+            // scale integral history so integral action doesn't change
+            m_integral = (m_integral * m_kp) / arg;
+        }
         m_kp = arg;
     }
 

--- a/lib/test/ActuatorPwm_test.cpp
+++ b/lib/test/ActuatorPwm_test.cpp
@@ -20,7 +20,6 @@
 #include <catch.hpp>
 
 #include <stdlib.h> /* srand, rand */
-#include <time.h>   /* time, to seed rand */
 
 #include "ActuatorAnalogConstrained.h"
 #include "ActuatorDigital.h"

--- a/lib/test/IntervalHelperTest.cpp
+++ b/lib/test/IntervalHelperTest.cpp
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2018 BrewPi B.V.
+ *
+ * This file is part of the BrewBlox Control Library.
+ *
+ * BrewPi is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * BrewPi is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with BrewPi.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <catch.hpp>
+
+#include "../inc/IntervalHelper.h"
+#include <stdlib.h> /* srand, rand */
+
+SCENARIO("IntervalHelper test")
+{
+    WHEN("The interval helper is irregularly updated, it will still give the correct number of updates")
+    {
+        auto testInterval = [](int maxDelay) {
+            IntervalHelper<1000> ivh;
+
+            ticks_millis_t now = 0;
+            int numUpdates = 0;
+            ticks_millis_t nextUpdate = 0;
+            while (now < 1000'000) {
+                bool doUpdate = false;
+
+                nextUpdate = ivh.update(now, doUpdate);
+                CHECK(nextUpdate <= now + 1000);
+                if (doUpdate) {
+                    numUpdates++;
+                }
+                auto delay = std::rand() % maxDelay / 5;
+                if (delay > 4 * maxDelay / 5) {
+                    delay = delay * 5; // only use maximum delay in 20% of the cases
+                }
+                now = now + delay;
+            }
+            CHECK(numUpdates == 1000);
+        };
+
+        testInterval(100);
+        testInterval(1000);
+        testInterval(1500);
+        testInterval(3000);
+    }
+}


### PR DESCRIPTION
The filter in Setpoint and the integrator in the PID require that they are updated exactly every second for predictable response times.
When for some reason the control loop is running slow, the update interval can be longer and they will respond slower than expected.

This PR introduces a small helper class that keeps track of the interval and adjusts to make up for lateness.

fixes #110 