### PR TITLE
Fix for too many wifi.connect calls causing application thread block

### DIFF
--- a/app/brewblox/blox/TicksBlock.h
+++ b/app/brewblox/blox/TicksBlock.h
@@ -52,10 +52,10 @@ public:
         message.secondsSinceEpoch = ticks.getNow();
         message.millisSinceBoot = ticks.millis();
 
-        message.avgCommunicationTask = ticks.taskTimers()[0];
-        message.avgBlocksUpdateTask = ticks.taskTimers()[1];
-        message.avgDisplayTask = ticks.taskTimers()[2];
-        message.avgSystemTask = ticks.taskTimers()[3];
+        message.avgCommunicationTask = ticks.taskTime(0);
+        message.avgBlocksUpdateTask = ticks.taskTime(1);
+        message.avgDisplayTask = ticks.taskTime(2);
+        message.avgSystemTask = ticks.taskTime(3);
 
         return streamProtoTo(out, &message, blox_Ticks_fields, blox_Ticks_size);
     }

--- a/app/brewblox/connectivity.h
+++ b/app/brewblox/connectivity.h
@@ -46,4 +46,4 @@ bool
 listeningModeEnabled();
 
 void
-manageConnections();
+manageConnections(uint32_t now);

--- a/app/brewblox/main.cpp
+++ b/app/brewblox/main.cpp
@@ -150,7 +150,7 @@ loop()
 {
     ticks.switchTaskTimer(TicksClass::TaskId::Communication);
     if (!listeningModeEnabled()) {
-        manageConnections();
+        manageConnections(ticks.millis());
         brewbloxBox().hexCommunicate();
     }
     ticks.switchTaskTimer(TicksClass::TaskId::BlocksUpdate);

--- a/app/brewblox/main.cpp
+++ b/app/brewblox/main.cpp
@@ -101,7 +101,7 @@ setup()
     System.on(setup_update, watchdogCheckin);
 
 #if PLATFORM_ID == PLATFORM_GCC
-    manageConnections(); // init network early to websocket display emulation works during setup()
+    manageConnections(0); // init network early to websocket display emulation works during setup()
 #endif
 
     // init display

--- a/lib/inc/Ticks.h
+++ b/lib/inc/Ticks.h
@@ -83,12 +83,12 @@ public:
         return impl;
     }
 
-    enum class TaskId {
-        Communication,
-        BlocksUpdate,
-        DisplayUpdate,
-        System,
-        NumTasks,
+    enum class TaskId : uint8_t {
+        Communication = 0,
+        BlocksUpdate = 1,
+        DisplayUpdate = 2,
+        System = 3,
+        NumTasks = 4,
     };
 
     void switchTaskTimer(TaskId startedTask)
@@ -101,9 +101,9 @@ public:
         lastTimerTick = now;
     }
 
-    const auto& taskTimers() const
+    ticks_millis_t taskTime(uint8_t id)
     {
-        return timers;
+        return timers[id];
     }
 
 private:


### PR DESCRIPTION
Having the wrong WiFi credentials caused 10 second hangups of the main loop.

My theory of why this happened:

After 1000 executions of the main loop without WiFi, we called WiFi.connect.

These 1000 loop runs take very little time, so this means we called WiFi.connect very often.

WiFi.connect is an aysnc system thread function, it should not block the application thread. But because we called it too often, we saturated the system thread queue. Because the new call cannot be scheduled in the background, it blocks the application thread instead.

Fixes:
- Only call WiFi.connect when WiFi.connecting() returns false.
- Instead of calling it every 1000 loops without WiFi, call it every 60 seconds.
