### PR TITLE
Static multi-tap filters instead of reconfigurable ones to enable automatic filter selection for PID derivative gain

### DIFF
--- a/app/brewblox/blox/SetpointSensorPairBlock.h
+++ b/app/brewblox/blox/SetpointSensorPairBlock.h
@@ -32,7 +32,8 @@ public:
         if (res == cbox::CboxError::OK) {
             pair.setting(cnl::wrap<temp_t>(newData.storedSetting));
             pair.settingValid(newData.settingEnabled);
-            pair.configureFilter(uint8_t(newData.filter), cnl::wrap<fp12_t>(newData.filterThreshold));
+            pair.filterChoice(uint8_t(newData.filter));
+            pair.filterThreshold(cnl::wrap<fp12_t>(newData.filterThreshold));
 
             if (newData.resetFilter || sensor.getId() != newData.sensorId) {
                 sensor.setId(newData.sensorId);

--- a/app/brewblox/test/AcutatorOffsetBlock_test.cpp
+++ b/app/brewblox/test/AcutatorOffsetBlock_test.cpp
@@ -146,7 +146,7 @@ SCENARIO("A Blox ActuatorOffset object can be created from streamed protobuf dat
                                             "value: 86016 "
                                             "settingEnabled: true "
                                             "storedSetting: 131072 "
-                                            "filterThreshold: 4096 "
+                                            "filterThreshold: 20480 "
                                             "valueUnfiltered: 86016"); // setting 32, value 21 (setpoint adjusted to 20 + 12)
     }
 
@@ -164,7 +164,7 @@ SCENARIO("A Blox ActuatorOffset object can be created from streamed protobuf dat
                                             "value: 110592 "
                                             "settingEnabled: true "
                                             "storedSetting: 81920 "
-                                            "filterThreshold: 4096 "
+                                            "filterThreshold: 20480 "
                                             "valueUnfiltered: 110592"); // 20, 27 (unaffected)
     }
 

--- a/app/brewblox/test/PidBlock_test.cpp
+++ b/app/brewblox/test/PidBlock_test.cpp
@@ -64,7 +64,7 @@ SCENARIO("A Blox Pid object can be created from streamed protobuf data")
     newPair.set_sensorid(100);
     newPair.set_storedsetting(cnl::unwrap(temp_t(21)));
     newPair.set_settingenabled(true);
-    newPair.set_filter(blox::SetpointSensorPair_FilterChoice::SetpointSensorPair_FilterChoice_FILT_30s);
+    newPair.set_filter(blox::SetpointSensorPair_FilterChoice::SetpointSensorPair_FilterChoice_FILT_15s);
     newPair.set_filterthreshold(cnl::unwrap(temp_t(1)));
     testBox.put(newPair);
 

--- a/lib/inc/FilterChain.h
+++ b/lib/inc/FilterChain.h
@@ -24,7 +24,6 @@
 #include <memory>
 #include <vector>
 
-
 class FilterChain {
 private:
     struct Stage {
@@ -48,6 +47,9 @@ public:
     int32_t read() const;                               // read from last filter
     uint32_t minSampleInterval(uint8_t filterNr) const; // get minimum sample interval of filter at index i
     uint32_t minSampleInterval() const;                 // get minimum sample interval of filter at last filter
+
+    uint8_t intervalToFilterNr(uint32_t maxInterval) const; // get slowest filter number with interval faster than argument
+
     uint32_t getCount() const
     {
         return counter;
@@ -65,6 +67,6 @@ public:
     int64_t readWithNFractionBits(uint8_t filterNr, uint8_t bits) const;
     int64_t readWithNFractionBits(uint8_t bits) const;
     int32_t readLastInput() const;
-    IirFilter::DerivativeResult readDerivative() const;
+    IirFilter::DerivativeResult readDerivative(uint8_t filterNr) const;
     void reset(const int32_t& value);
 };

--- a/lib/inc/FilterChain.h
+++ b/lib/inc/FilterChain.h
@@ -41,12 +41,12 @@ public:
 
     void add(const int32_t& val);
     void setParams(const std::vector<uint8_t>& params, const std::vector<uint8_t>& intervals, const int32_t& stepThreshold);
-    void setStepThreshold(const int32_t& threshold);    // set the step detection threshold
-    int32_t getStepThreshold() const;                   // get the step detection threshold of last filter
-    int32_t read(uint8_t filterNr) const;               // read from specified filter
-    int32_t read() const;                               // read from last filter
-    uint32_t minSampleInterval(uint8_t filterNr) const; // get minimum sample interval of filter at index i
-    uint32_t minSampleInterval() const;                 // get minimum sample interval of filter at last filter
+    void setStepThreshold(const int32_t& threshold); // set the step detection threshold
+    int32_t getStepThreshold() const;                // get the step detection threshold of last filter
+    int32_t read(uint8_t filterNr) const;            // read from specified filter
+    int32_t read() const;                            // read from last filter
+    uint32_t sampleInterval(uint8_t filterNr) const; // get minimum sample interval of filter at index i
+    uint32_t sampleInterval() const;                 // get minimum sample interval of filter at last filter
 
     uint8_t intervalToFilterNr(uint32_t maxInterval) const; // get slowest filter number with interval faster than argument
 
@@ -56,7 +56,7 @@ public:
     }; // return count. Can be used to synchronize sensor switching
     uint32_t getCount(uint8_t filterNr) const
     {
-        return counter / minSampleInterval(filterNr - 1);
+        return counter / sampleInterval(filterNr - 1);
     }; // return count for a specific filter
     uint8_t length() const
     {

--- a/lib/inc/FpFilterChain.h
+++ b/lib/inc/FpFilterChain.h
@@ -103,10 +103,10 @@ public:
     }
 
     template <typename U>
-    U readDerivativeForInterval(uint32_t numUpdates) const
+    U readDerivativeForInterval(uint32_t maxInterval) const
     {
         // select filter in chain with an update interval to have the optimal amount of filtering for the period requested
-        return readDerivative<U>(chain.intervalToFilterNr(numUpdates / 6));
+        return readDerivative<U>(chain.intervalToFilterNr(maxInterval));
     }
 
     void reset(const value_type& value)

--- a/lib/inc/SetpointSensorPair.h
+++ b/lib/inc/SetpointSensorPair.h
@@ -39,14 +39,13 @@ private:
     bool m_settingEnabled = false;
     const std::function<std::shared_ptr<TempSensor>()> m_sensor;
     FpFilterChain<temp_t> m_filter;
-    uint8_t m_filterChoice = 0;         // input filter index
     uint8_t m_sensorFailureCount = 255; // force a reset on init
 
 public:
     explicit SetpointSensorPair(
         std::function<std::shared_ptr<TempSensor>()>&& _sensor)
         : m_sensor(_sensor)
-        , m_filter(0)
+        , m_filter(1)
     {
         update();
     }
@@ -102,7 +101,7 @@ public:
 
     auto filterChoice() const
     {
-        return m_filterChoice;
+        return m_filter.getReadIdx();
     }
 
     auto filterThreshold() const
@@ -110,17 +109,17 @@ public:
         return m_filter.getStepThreshold();
     }
 
-    void configureFilter(uint8_t choice, temp_t threshold)
+    void filterChoice(uint8_t choice)
+    {
+        m_filter.setReadIdx(choice);
+    }
+
+    auto filterThreshold(temp_t threshold)
     {
         if (threshold == 0) {
-            threshold = temp_t(1);
+            threshold = 1;
         }
-        if (m_filterChoice != choice) {
-            m_filterChoice = choice;
-            m_filter.setParams(choice, threshold);
-        } else {
-            m_filter.setStepThreshold(threshold);
-        }
+        m_filter.setStepThreshold(threshold);
     }
 
     void update()

--- a/lib/inc/SetpointSensorPair.h
+++ b/lib/inc/SetpointSensorPair.h
@@ -117,7 +117,7 @@ public:
     auto filterThreshold(temp_t threshold)
     {
         if (threshold == 0) {
-            threshold = 1;
+            threshold = 5;
         }
         m_filter.setStepThreshold(threshold);
     }

--- a/lib/inc/SetpointSensorPair.h
+++ b/lib/inc/SetpointSensorPair.h
@@ -46,7 +46,7 @@ public:
     explicit SetpointSensorPair(
         std::function<std::shared_ptr<TempSensor>()>&& _sensor)
         : m_sensor(_sensor)
-        , m_filter(m_filterChoice)
+        , m_filter(0)
     {
         update();
     }
@@ -144,9 +144,9 @@ public:
         return setting() - value();
     }
 
-    auto derivative()
+    auto derivative(uint32_t period)
     {
-        return m_filter.readDerivative<derivative_t>();
+        return m_filter.readDerivativeForInterval<derivative_t>(period);
     }
 
     void resetFilter()

--- a/lib/src/FilterChain.cpp
+++ b/lib/src/FilterChain.cpp
@@ -52,7 +52,7 @@ FilterChain::add(const int32_t& val)
         nextFilterIn = s.filter.readWithNFractionBits(nextFilterInFractionBits);
     }
     counter++;
-    if (counter == minSampleInterval()) {
+    if (counter == sampleInterval()) {
         counter = 0; // reset counter if last filter has had all its updates
     }
 }
@@ -153,7 +153,7 @@ FilterChain::readWithNFractionBits(uint8_t bits) const
 }
 
 uint32_t
-FilterChain::minSampleInterval(uint8_t filterNr) const
+FilterChain::sampleInterval(uint8_t filterNr) const
 {
     if (filterNr > stages.size() - 1) {
         return 1;
@@ -173,7 +173,7 @@ FilterChain::intervalToFilterNr(uint32_t maxInterval) const
     uint32_t stageInterval = 1;
     for (auto it = stages.begin() + 1; it != stages.end(); it++) {
         stageInterval *= it->interval;
-        if (stageInterval <= maxInterval) {
+        if (stageInterval < maxInterval) {
             filterNr++;
         } else {
             break;
@@ -183,9 +183,9 @@ FilterChain::intervalToFilterNr(uint32_t maxInterval) const
 }
 
 uint32_t
-FilterChain::minSampleInterval() const
+FilterChain::sampleInterval() const
 {
-    return minSampleInterval(stages.size() - 1);
+    return sampleInterval(stages.size() - 1);
 }
 
 uint8_t
@@ -217,7 +217,7 @@ FilterChain::readDerivative(uint8_t filterNr) const
     }
     auto retv = stages[filterNr].filter.readDerivative();
     // Scale back derivative to account for sample interval in slower updating stages
-    auto inputSamplesPerOutputChange = minSampleInterval(filterNr - 1);
+    auto inputSamplesPerOutputChange = filterNr > 0 ? sampleInterval(filterNr - 1) : 1;
     retv.result = retv.result / inputSamplesPerOutputChange;
     return retv;
 }

--- a/lib/src/Pid.cpp
+++ b/lib/src/Pid.cpp
@@ -29,7 +29,8 @@ Pid::update()
             active(true);
         }
         m_error = input->error();
-        m_derivative = input->derivative();
+        m_derivative = m_td ? input->derivative(m_td) : 0;
+
         m_integral = m_ti ? m_integral + m_error : 0;
     } else {
         if (active()) {

--- a/lib/src/Pid.cpp
+++ b/lib/src/Pid.cpp
@@ -29,7 +29,7 @@ Pid::update()
             active(true);
         }
         m_error = input->error();
-        m_derivative = m_td ? input->derivative(m_td) : 0;
+        m_derivative = m_td ? input->derivative(m_td / 2) : 0;
 
         m_integral = m_ti ? m_integral + m_error : 0;
     } else {

--- a/lib/test/FilterChainTest.cpp
+++ b/lib/test/FilterChainTest.cpp
@@ -209,7 +209,7 @@ test_frequencies(
     double t = 0;
     double dt = double(1.0) / double(input_freq);
     double max_period = 1.0 / *std::min_element(freq.begin(), freq.end());
-    double t_end = std::max(10.0 * max_period, 10.0 * chain.minSampleInterval() * dt);
+    double t_end = std::max(10.0 * max_period, 10.0 * chain.sampleInterval() * dt);
     double sensor = 0;
     double max = 0;
     double t_max = 0;
@@ -321,19 +321,19 @@ SCENARIO("Filters in chain are ran at specified intervals", "[filterchain][inter
         {
             FilterChain chain1({2, 2, 2, 2, 2, 2}, {1, 1, 1, 1, 1, 1});
             countSameValueAtOutPut(chain1, 1, 0);
-            CHECK(chain1.minSampleInterval() == 1);
+            CHECK(chain1.sampleInterval() == 1);
 
             FilterChain chain2({2, 2, 2, 2, 2, 2}, {2, 1, 2, 1, 1, 4});
             countSameValueAtOutPut(chain2, 4, 15);
-            CHECK(chain2.minSampleInterval() == 16);
+            CHECK(chain2.sampleInterval() == 16);
 
             FilterChain chain3({2, 2, 2, 2, 2, 2}, {2, 2, 2, 1, 1, 4});
             countSameValueAtOutPut(chain3, 8, 31);
-            CHECK(chain3.minSampleInterval() == 32);
+            CHECK(chain3.sampleInterval() == 32);
 
             FilterChain chain4({2, 2, 2, 2, 2, 2}, {4, 2, 1, 4, 2, 1});
             countSameValueAtOutPut(chain4, 64, 63);
-            CHECK(chain4.minSampleInterval() == 64);
+            CHECK(chain4.sampleInterval() == 64);
         }
     }
     WHEN("The sample rates are specified")
@@ -374,7 +374,7 @@ SCENARIO("Filters in chain are ran at specified intervals", "[filterchain][inter
     {
         FilterChain chain({2, 2, 2, 2, 2, 2}, {2, 2, 3, 3, 4, 4});
         CHECK(chain.intervalToFilterNr(1) == 0);
-        CHECK(chain.intervalToFilterNr(2) == 1);
+        CHECK(chain.intervalToFilterNr(2) == 0);
         CHECK(chain.intervalToFilterNr(3) == 1);
         CHECK(chain.intervalToFilterNr(2 * 2) == 1);
         CHECK(chain.intervalToFilterNr(2 * 2 * 3 - 1) == 2);

--- a/lib/test/FilterChainTest.cpp
+++ b/lib/test/FilterChainTest.cpp
@@ -369,6 +369,19 @@ SCENARIO("Filters in chain are ran at specified intervals", "[filterchain][inter
             }
         }
     }
+
+    WHEN("A filter chain is downsampled at each stage, the slowest filter nr with an update interval of at least a certain frequency can be queried")
+    {
+        FilterChain chain({2, 2, 2, 2, 2, 2}, {2, 2, 3, 3, 4, 4});
+        CHECK(chain.intervalToFilterNr(1) == 0);
+        CHECK(chain.intervalToFilterNr(2) == 1);
+        CHECK(chain.intervalToFilterNr(3) == 1);
+        CHECK(chain.intervalToFilterNr(2 * 2) == 1);
+        CHECK(chain.intervalToFilterNr(2 * 2 * 3 - 1) == 2);
+        CHECK(chain.intervalToFilterNr(2 * 2 * 3 * 3) == 3);
+        CHECK(chain.intervalToFilterNr(2 * 2 * 3 * 3 * 4) == 4);
+        CHECK(chain.intervalToFilterNr(2 * 2 * 3 * 3 * 4 * 4) == 5);
+    }
 }
 
 SCENARIO("Filters chain output matches manually cascaded filters", "[filterchain][match]")

--- a/lib/test/FpFilterChainTest.cpp
+++ b/lib/test/FpFilterChainTest.cpp
@@ -173,10 +173,10 @@ SCENARIO("Fixed point filterchain using temp_t")
             CHECK(findStepResponseDelay(chain, 0.9) == 1368);
         }
 
-        AND_WHEN("The derivative is requested over a larger period")
+        AND_WHEN("The derivative is requested with a certain period")
         {
             using derivative_t = safe_elastic_fixed_point<1, 23, int32_t>;
-            uint32_t period = 100;
+            uint32_t period = 200;
             const temp_t amplIn = period / (2.0 * M_PI); // derivative max 1
 
             auto c = FpFilterChain<temp_t>(0);
@@ -204,8 +204,8 @@ SCENARIO("Fixed point filterchain using temp_t")
             }
 
             CHECK(maxDerivative12 > 0.8);
-            CHECK(maxDerivative25 > 0.5);
-            CHECK(maxDerivative100 < 0.1);
+            CHECK(maxDerivative25 > 0.5);  // sample rate of 25 should have most of the sine wave left
+            CHECK(maxDerivative100 < 0.1); // sample rate of 100 should filted out the sine with period 200
         }
     }
 }

--- a/lib/test/FpFilterChainTest.cpp
+++ b/lib/test/FpFilterChainTest.cpp
@@ -32,55 +32,29 @@ using temp_t = safe_elastic_fixed_point<11, 12, int32_t>;
 
 SCENARIO("Fixed point filterchain using temp_t")
 {
+
     std::vector<std::vector<uint8_t>> chainsSpecs = {{0},
                                                      {0, 1},
                                                      {0, 1, 1}};
 
-    for (auto& chainSpec : chainsSpecs) {
-        std::stringstream chain_str;
-        std::ostream_iterator<uint8_t> out_it(chain_str, ", ");
-        std::copy(chainSpec.begin(), chainSpec.end(), out_it);
-
-        GIVEN("A filter chain of filters: " + chain_str.str())
+    for (uint8_t filter = 0; filter < 6; filter++) {
+        GIVEN("A filter chain tapped at stage " + std::to_string(filter))
         {
-            auto chain = FpFilterChain<temp_t>(chainSpec);
+            auto chain = FpFilterChain<temp_t>(filter);
 
             temp_t step = 10;
             WHEN("A step input of std::to_string(step) is applied")
             {
                 uint32_t count = 0;
-                while (count++ < 2000) {
+                while (count++ < 3000) {
                     chain.add(step);
                 }
                 THEN("The steady state output matches the step amplitude")
                 {
+                    INFO(filter);
                     CHECK(chain.read() == Approx(temp_t(10)).epsilon(0.001));
                 }
             }
-        }
-    }
-
-    GIVEN("A chain of filters that is not downsampled in between")
-    {
-        auto chain = FpFilterChain<temp_t>({0, 0}, std::vector<uint8_t>{1, 1});
-
-        WHEN("A step input of 100 is applied")
-        {
-            uint32_t count = 0;
-            temp_t step = 100;
-            //char csv[] = "../test-results/test.csv";
-            ///std::ofstream csvFile(csv);
-            while (count++ < 1000) {
-                chain.add(step);
-                /*				csvFile << count;
-				for(int i = 0; i < chain.length(); i++){
-					csvFile << "," << chain.read(i);
-				}
-				csvFile << std::endl;
-*/
-            }
-            //csvFile.close();
-            CHECK_THAT(chain.read(), IsWithinOf(temp_t(0.01), temp_t(100.0)));
         }
     }
 
@@ -90,17 +64,6 @@ SCENARIO("Fixed point filterchain using temp_t")
             auto result = ampl * temp_t(sin(2.0 * M_PI * t / period));
             return temp_t(result);
         };
-
-        auto chains
-            = std::vector<FpFilterChain<temp_t>>{
-                FpFilterChain<temp_t>({0, 0}, std::vector<uint8_t>{2, 1}), // 28
-                FpFilterChain<temp_t>({2, 0}, std::vector<uint8_t>{4, 1}), // 56
-                FpFilterChain<temp_t>({2, 2, 0}, {4, 3, 1}),               // 171
-                FpFilterChain<temp_t>({2, 2, 2}, {4, 3, 1}),               // 257
-                FpFilterChain<temp_t>({2, 2, 2, 0}, {4, 4, 3, 1}),         // 683
-                FpFilterChain<temp_t>({2, 2, 2, 2}, {4, 4, 4, 1}),         // 1343
-                FpFilterChain<temp_t>({2, 2, 2, 2, 0}, {4, 4, 4, 3, 1}),   // 2729
-            };
 
         auto findGainAtPeriod = [&sine](FpFilterChain<temp_t>& c, const uint32_t& period, bool checkMaxDerivative = true) {
             using derivative_t = safe_elastic_fixed_point<1, 23, int32_t>;
@@ -150,33 +113,35 @@ SCENARIO("Fixed point filterchain using temp_t")
 
         THEN("They block higher frequencies and pass lower frequencies")
         {
-            CHECK(findHalfAmplitudePeriod(chains[0]) == 28);
-            CHECK(findGainAtPeriod(chains[0], 14) < 0.1);
-            CHECK(findGainAtPeriod(chains[0], 56) > 0.8);
+            auto chain = FpFilterChain<temp_t>(0);
+            CHECK(findHalfAmplitudePeriod(chain) == 13);
+            CHECK(findGainAtPeriod(chain, 7) < 0.1);
+            CHECK(findGainAtPeriod(chain, 26) > 0.8);
 
-            CHECK(findHalfAmplitudePeriod(chains[1]) == 55);
-            CHECK(findGainAtPeriod(chains[1], 28) < 0.1);
-            CHECK(findGainAtPeriod(chains[1], 120) > 0.8);
+            chain = FpFilterChain<temp_t>(1);
+            CHECK(findHalfAmplitudePeriod(chain) == 43);
+            CHECK(findGainAtPeriod(chain, 22) < 0.1);
+            CHECK(findGainAtPeriod(chain, 86) > 0.8);
 
-            CHECK(findHalfAmplitudePeriod(chains[2]) == 171);
-            CHECK(findGainAtPeriod(chains[2], 80) < 0.1);
-            CHECK(findGainAtPeriod(chains[2], 300) > 0.8);
+            chain = FpFilterChain<temp_t>(2);
+            CHECK(findHalfAmplitudePeriod(chain) == 91);
+            CHECK(findGainAtPeriod(chain, 46) < 0.1);
+            CHECK(findGainAtPeriod(chain, 182) > 0.8);
 
-            CHECK(findHalfAmplitudePeriod(chains[3]) == 257);
-            CHECK(findGainAtPeriod(chains[3], 120) < 0.1);
-            CHECK(findGainAtPeriod(chains[3], 500) > 0.8);
+            chain = FpFilterChain<temp_t>(3);
+            CHECK(findHalfAmplitudePeriod(chain) == 184);
+            CHECK(findGainAtPeriod(chain, 92) < 0.1);
+            CHECK(findGainAtPeriod(chain, 368) > 0.8);
 
-            CHECK(findHalfAmplitudePeriod(chains[4]) == 683);
-            CHECK(findGainAtPeriod(chains[4], 300) < 0.1);
-            CHECK(findGainAtPeriod(chains[4], 1200) > 0.8);
+            chain = FpFilterChain<temp_t>(4);
+            CHECK(findHalfAmplitudePeriod(chain) == 519);
+            CHECK(findGainAtPeriod(chain, 259) < 0.1);
+            CHECK(findGainAtPeriod(chain, 1038) > 0.8);
 
-            CHECK(findHalfAmplitudePeriod(chains[5]) == 1343);
-            CHECK(findGainAtPeriod(chains[5], 600) < 0.1);
-            CHECK(findGainAtPeriod(chains[5], 2400) > 0.8);
-
-            CHECK(findHalfAmplitudePeriod(chains[6]) == 2730);
-            CHECK(findGainAtPeriod(chains[6], 1200) < 0.1);
-            CHECK(findGainAtPeriod(chains[6], 4800) > 0.8);
+            chain = FpFilterChain<temp_t>(5);
+            CHECK(findHalfAmplitudePeriod(chain) == 1546);
+            CHECK(findGainAtPeriod(chain, 773) < 0.1);
+            CHECK(findGainAtPeriod(chain, 3096) > 0.8);
         }
 
         AND_WHEN("The step threshold is set, a slow filter will respond much quicker to a step input")
@@ -198,38 +163,49 @@ SCENARIO("Fixed point filterchain using temp_t")
                 // std::cout << "\n";
                 return t;
             };
-
-            CHECK(findStepResponseDelay(chains[6], temp_t(100)) == 2496);
-            CHECK(findStepResponseDelay(chains[6], temp_t(10)) == 2496);
-            CHECK(findStepResponseDelay(chains[6], temp_t(0.9)) == 2496);
-            chains[6].setStepThreshold(1);
-            CHECK(findStepResponseDelay(chains[6], 100) < 400);
-            CHECK(findStepResponseDelay(chains[6], 10) < 2496 / 2);
-            CHECK(findStepResponseDelay(chains[6], 0.9) == 2496);
+            auto chain = FpFilterChain<temp_t>(5);
+            CHECK(findStepResponseDelay(chain, temp_t(100)) == 1368);
+            CHECK(findStepResponseDelay(chain, temp_t(10)) == 1368);
+            CHECK(findStepResponseDelay(chain, temp_t(0.9)) == 1368);
+            chain.setStepThreshold(1);
+            CHECK(findStepResponseDelay(chain, 100) < 400);
+            CHECK(findStepResponseDelay(chain, 10) < 1368 / 2);
+            CHECK(findStepResponseDelay(chain, 0.9) == 1368);
         }
-    }
 
-    WHEN("A different filterchain spec is chosen that is longer")
-    {
-        auto chain = FpFilterChain<temp_t>(3); // 5 min
-
-        // generate noisy input with average value 10
-        uint32_t count = 0;
-        while (count++ < 600) {
-            chain.add(temp_t(8) + temp_t(count % 2) + temp_t(count % 3) / 2 + temp_t(count % 5) / 4 + temp_t(count % 7) / 6);
-        }
-        REQUIRE(chain.read() == Approx(temp_t(10)).epsilon(0.01));
-
-        chain.setParams(5, temp_t(100)); // 20min
-        REQUIRE(chain.read() == Approx(temp_t(10)).epsilon(0.01));
-
-        THEN("The filter output stays between expected boundaries")
+        AND_WHEN("The derivative is requested over a larger period")
         {
-            uint32_t count = 0;
-            while (count++ < 2000) {
-                chain.add(temp_t(8) + temp_t(count % 2) + temp_t(count % 3) / 2 + temp_t(count % 5) / 4 + temp_t(count % 7) / 6);
-                CHECK(chain.read() == Approx(temp_t(10)).epsilon(0.01));
+            using derivative_t = safe_elastic_fixed_point<1, 23, int32_t>;
+            uint32_t period = 100;
+            const temp_t amplIn = period / (2.0 * M_PI); // derivative max 1
+
+            auto c = FpFilterChain<temp_t>(0);
+
+            derivative_t maxDerivative12 = 0;
+            derivative_t maxDerivative25 = 0;
+            derivative_t maxDerivative100 = 0;
+            for (uint32_t t = 0; t < period * 10; ++t) {
+                auto wave = sine(t, period, amplIn);
+                c.add(wave);
+
+                auto derivative = c.readDerivativeForInterval<derivative_t>(12);
+                if (derivative > maxDerivative12) {
+                    maxDerivative12 = derivative;
+                }
+                derivative = c.readDerivativeForInterval<derivative_t>(25);
+                if (derivative > maxDerivative25) {
+                    maxDerivative25 = derivative;
+                }
+
+                derivative = c.readDerivativeForInterval<derivative_t>(100);
+                if (derivative > maxDerivative100) {
+                    maxDerivative100 = derivative;
+                }
             }
+
+            CHECK(maxDerivative12 > 0.8);
+            CHECK(maxDerivative25 > 0.5);
+            CHECK(maxDerivative100 < 0.1);
         }
     }
 }

--- a/lib/test/FpFilterChainTest.cpp
+++ b/lib/test/FpFilterChainTest.cpp
@@ -37,7 +37,7 @@ SCENARIO("Fixed point filterchain using temp_t")
                                                      {0, 1},
                                                      {0, 1, 1}};
 
-    for (uint8_t filter = 0; filter < 6; filter++) {
+    for (uint8_t filter = 0; filter <= 6; filter++) {
         GIVEN("A filter chain tapped at stage " + std::to_string(filter))
         {
             auto chain = FpFilterChain<temp_t>(filter);
@@ -113,32 +113,37 @@ SCENARIO("Fixed point filterchain using temp_t")
 
         THEN("They block higher frequencies and pass lower frequencies")
         {
-            auto chain = FpFilterChain<temp_t>(0);
+            auto chain = FpFilterChain<temp_t>(0); // unfiltered
+            CHECK(findHalfAmplitudePeriod(chain) == 10);
+            CHECK(findGainAtPeriod(chain, 5, false) > 0.9);
+            CHECK(findGainAtPeriod(chain, 20, false) > 0.9);
+
+            chain = FpFilterChain<temp_t>(1);
             CHECK(findHalfAmplitudePeriod(chain) == 13);
             CHECK(findGainAtPeriod(chain, 7) < 0.1);
             CHECK(findGainAtPeriod(chain, 26) > 0.8);
 
-            chain = FpFilterChain<temp_t>(1);
+            chain = FpFilterChain<temp_t>(2);
             CHECK(findHalfAmplitudePeriod(chain) == 43);
             CHECK(findGainAtPeriod(chain, 22) < 0.1);
             CHECK(findGainAtPeriod(chain, 86) > 0.8);
 
-            chain = FpFilterChain<temp_t>(2);
+            chain = FpFilterChain<temp_t>(3);
             CHECK(findHalfAmplitudePeriod(chain) == 91);
             CHECK(findGainAtPeriod(chain, 46) < 0.1);
             CHECK(findGainAtPeriod(chain, 182) > 0.8);
 
-            chain = FpFilterChain<temp_t>(3);
+            chain = FpFilterChain<temp_t>(4);
             CHECK(findHalfAmplitudePeriod(chain) == 184);
             CHECK(findGainAtPeriod(chain, 92) < 0.1);
             CHECK(findGainAtPeriod(chain, 368) > 0.8);
 
-            chain = FpFilterChain<temp_t>(4);
+            chain = FpFilterChain<temp_t>(5);
             CHECK(findHalfAmplitudePeriod(chain) == 519);
             CHECK(findGainAtPeriod(chain, 259) < 0.1);
             CHECK(findGainAtPeriod(chain, 1038) > 0.8);
 
-            chain = FpFilterChain<temp_t>(5);
+            chain = FpFilterChain<temp_t>(6);
             CHECK(findHalfAmplitudePeriod(chain) == 1546);
             CHECK(findGainAtPeriod(chain, 773) < 0.1);
             CHECK(findGainAtPeriod(chain, 3096) > 0.8);
@@ -163,7 +168,7 @@ SCENARIO("Fixed point filterchain using temp_t")
                 // std::cout << "\n";
                 return t;
             };
-            auto chain = FpFilterChain<temp_t>(5);
+            auto chain = FpFilterChain<temp_t>(6);
             CHECK(findStepResponseDelay(chain, temp_t(100)) == 1368);
             CHECK(findStepResponseDelay(chain, temp_t(10)) == 1368);
             CHECK(findStepResponseDelay(chain, temp_t(0.9)) == 1368);
@@ -179,7 +184,7 @@ SCENARIO("Fixed point filterchain using temp_t")
             uint32_t period = 200;
             const temp_t amplIn = period / (2.0 * M_PI); // derivative max 1
 
-            auto c = FpFilterChain<temp_t>(0);
+            auto c = FpFilterChain<temp_t>(1);
 
             derivative_t maxDerivative12 = 0;
             derivative_t maxDerivative25 = 0;

--- a/lib/test/PidTest.cpp
+++ b/lib/test/PidTest.cpp
@@ -510,7 +510,8 @@ SCENARIO("PID Test with PWM actuator", "[pid]")
         [&sensor]() { return sensor; });
     input->settingValid(true);
     input->setting(20);
-    input->configureFilter(0, fp12_t(5));
+    input->filterChoice(1);
+    input->filterThreshold(5);
 
     auto mockIo = std::make_shared<MockIoArray>();
     auto mock = ActuatorDigital([mockIo]() { return mockIo; }, 1);
@@ -880,7 +881,8 @@ SCENARIO("PID Test with PWM actuator", "[pid]")
     {
         pid.kp(10);
         pid.ti(2000);
-        input->configureFilter(0, temp_t(99));
+        input->filterChoice(1);
+        input->filterThreshold(99);
         auto testStep = [&](uint16_t td) {
             pid.td(td);
             auto start = now;

--- a/lib/test/PidTest.cpp
+++ b/lib/test/PidTest.cpp
@@ -73,6 +73,8 @@ SCENARIO("PID Test with mock actuator", "[pid]")
 
         input->setting(21);
         sensor->value(20);
+        input->resetFilter();
+
         for (int32_t i = 0; i < 1000; ++i) {
             input->update();
             pid.update();
@@ -92,6 +94,7 @@ SCENARIO("PID Test with mock actuator", "[pid]")
 
         input->setting(21);
         sensor->value(20);
+        input->resetFilter();
 
         for (int32_t i = 0; i < 1000; ++i) {
             input->update();
@@ -122,6 +125,7 @@ SCENARIO("PID Test with mock actuator", "[pid]")
 
         input->setting(30);
         sensor->value(20);
+        input->resetFilter();
 
         fp12_t mockVal;
         double accumulatedError = 0;
@@ -134,8 +138,8 @@ SCENARIO("PID Test with mock actuator", "[pid]")
         }
 
         CHECK(mockVal == 29);
-        CHECK(pid.error() == Approx(1.23).epsilon(0.01)); // the filter introduces some delay, which is why this is not 1.0
-        CHECK(pid.p() == Approx(12.3).epsilon(0.01));
+        CHECK(pid.error() == Approx(1).epsilon(0.1)); // the filter introduces some delay, which is why this is not exactly 1.0
+        CHECK(pid.p() == Approx(10).epsilon(0.1));
         CHECK(pid.i() == Approx(accumulatedError * (10.0 / 2000)).epsilon(0.001));
         CHECK(pid.integral() == Approx(accumulatedError).epsilon(0.001));
         CHECK(pid.d() == Approx(-10 * 9.0 / 900 * 200).epsilon(0.001));
@@ -151,6 +155,7 @@ SCENARIO("PID Test with mock actuator", "[pid]")
 
         input->setting(20);
         sensor->value(30);
+        input->resetFilter();
 
         fp12_t mockVal;
         double accumulatedError = 0;
@@ -163,8 +168,8 @@ SCENARIO("PID Test with mock actuator", "[pid]")
         }
 
         CHECK(mockVal == 21);
-        CHECK(pid.error() == Approx(-1.23).epsilon(0.01)); // the filter introduces some delay, which is why this is not 1.0
-        CHECK(pid.p() == Approx(12.3).epsilon(0.01));
+        CHECK(pid.error() == Approx(-1).epsilon(0.1)); // the filter introduces some delay, which is why this is not 1.0
+        CHECK(pid.p() == Approx(10).epsilon(0.1));
         CHECK(pid.i() == Approx(accumulatedError * (-10.0 / 2000)).epsilon(0.001));
         CHECK(pid.integral() == Approx(accumulatedError).epsilon(0.001));
         CHECK(pid.d() == Approx(-10 * 9.0 / 900 * 200).epsilon(0.001));
@@ -180,6 +185,7 @@ SCENARIO("PID Test with mock actuator", "[pid]")
 
         input->setting(21);
         sensor->value(20);
+        input->resetFilter();
         actuator->minSetting(0);
         actuator->maxSetting(20);
 
@@ -225,6 +231,7 @@ SCENARIO("PID Test with mock actuator", "[pid]")
 
         input->setting(19);
         sensor->value(20);
+        input->resetFilter();
         actuator->minSetting(0);
         actuator->maxSetting(20);
 
@@ -269,6 +276,7 @@ SCENARIO("PID Test with mock actuator", "[pid]")
 
         input->setting(21);
         sensor->value(20);
+        input->resetFilter();
         actuator->minValue(5);
         actuator->maxValue(20);
 
@@ -312,6 +320,7 @@ SCENARIO("PID Test with mock actuator", "[pid]")
 
         input->setting(19);
         sensor->value(20);
+        input->resetFilter();
         actuator->minValue(5);
         actuator->maxValue(20);
 
@@ -355,6 +364,7 @@ SCENARIO("PID Test with mock actuator", "[pid]")
 
         input->setting(21);
         sensor->value(20);
+        input->resetFilter();
 
         int32_t i = 0;
         for (; i <= 10000; ++i) {
@@ -544,6 +554,7 @@ SCENARIO("PID Test with PWM actuator", "[pid]")
 
         input->setting(21);
         sensor->value(20);
+        input->resetFilter();
 
         run1000seconds();
 
@@ -558,6 +569,7 @@ SCENARIO("PID Test with PWM actuator", "[pid]")
 
         input->setting(21);
         sensor->value(20);
+        input->resetFilter();
 
         run1000seconds();
 
@@ -582,6 +594,7 @@ SCENARIO("PID Test with PWM actuator", "[pid]")
 
         input->setting(30);
         sensor->value(20);
+        input->resetFilter();
 
         fp12_t mockVal;
         double accumulatedError = 0;
@@ -604,8 +617,8 @@ SCENARIO("PID Test with PWM actuator", "[pid]")
         }
 
         CHECK(mockVal == 29);
-        CHECK(pid.error() == Approx(1.23).epsilon(0.01)); // the filter introduces some delay, which is why this is not 1.0
-        CHECK(pid.p() == Approx(12.3).epsilon(0.01));
+        CHECK(pid.error() == Approx(1).epsilon(0.1)); // the filter introduces some delay, which is why this is not 1.0
+        CHECK(pid.p() == Approx(10).epsilon(0.1));
         CHECK(pid.i() == Approx(accumulatedError * (10.0 / 2000)).epsilon(0.05)); // some integral anti-windup will occur at the start
         CHECK(pid.d() == Approx(-10 * 9.0 / 900 * 200).epsilon(0.01));
 
@@ -620,6 +633,7 @@ SCENARIO("PID Test with PWM actuator", "[pid]")
 
         input->setting(20);
         sensor->value(30);
+        input->resetFilter();
 
         fp12_t mockVal;
         double accumulatedError = 0;
@@ -642,8 +656,8 @@ SCENARIO("PID Test with PWM actuator", "[pid]")
         }
 
         CHECK(mockVal == 21);
-        CHECK(pid.error() == Approx(-1.23).epsilon(0.01)); // the filter introduces some delay, which is why this is not 1.0
-        CHECK(pid.p() == Approx(12.3).epsilon(0.01));
+        CHECK(pid.error() == Approx(-1).epsilon(0.1)); // the filter introduces some delay, which is why this is not 1.0
+        CHECK(pid.p() == Approx(10).epsilon(0.1));
         CHECK(pid.i() == Approx(accumulatedError * (-10.0 / 2000)).epsilon(0.05)); // some integral anti-windup will occur at the start
         CHECK(pid.d() == Approx(-10 * 9.0 / 900 * 200).epsilon(0.01));
 


### PR DESCRIPTION
Filters are implemented as a cascade of filter stages with progressively longer update intervals.
Filtering is done by adding past input and output values. More filtering will include older values and therefore cause a longer delay.

Before this PR, we changed which stages were used for each filter selection.
I have changed this to always use the same filter stages, but depending on the filter level selected, read from a certain stage.

This enabled me to solve a different problem:
- For the PID, you want the proportional gain to act on the input as quickly as possible. Delay in the filter prevents this.
- For the PID, you want some filtering for the derivative gain to distinguish between ramps and noise/bit flips.
These 2 requirements are at odds.

Because the different filter levels are now available simultaneously, I can select a derivative filter independently of the input filtering.
By selecting a later filter stage when Td is larger, we can automatically select a filter that removes noise but not a derivative that we want to act on.