### PR TITLE
Fix for actuators being active on reboot because of older EEPROM settings being loaded while PID is inactive

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -290,8 +290,8 @@
     {
       "label": "build cbox tests local",
       "type": "shell",
-      "command": "make",
-      "args": ["-C", "../controlbox"],
+      "command": "bash",
+      "args": ["../wrapped_make.sh", "-C", "../controlbox"],
       "group": "build",
       "options": {
         "cwd": "${workspaceFolder}/docker"
@@ -326,9 +326,8 @@
     },
     {
       "label": "build lib tests local",
-      "type": "shell",
-      "command": "make",
-      "args": ["-C", "../lib/test"],
+      "command": "bash",
+      "args": ["../wrapped_make.sh", "-C", "../lib/test"],
       "group": "build",
       "options": {
         "cwd": "${workspaceFolder}/docker"

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -345,8 +345,8 @@
     {
       "label": "build app tests local",
       "type": "shell",
-      "command": "make",
-      "args": ["-C", "../app/brewblox/test"],
+      "command": "bash",
+      "args": ["../wrapped_make.sh", "-C", "../app/brewblox/test"],
       "group": "build",
       "options": {
         "cwd": "${workspaceFolder}/docker"


### PR DESCRIPTION
EEPROM settings for targets of PID or PWM were only written when the objects themselves were written externally.
When the PID was disabled, it set the output to zero once. This change was never sent to EEPROM. 

On reboot, the active state would reload for the PWM and if it was loaded later than the PID, this would enable actuators on reboot.

Fix: when the driving block changes whether it is active, write the target block setting to zero/inactive and persist the target block to EEPROM.

Small change also included: maximum period for PWM is now calculated based on previous period duration instead of previous low time.
This is more accurate when the PWM setting is lowered.