### PR TITLE
Cancel pending active state when changing state is blocked in PWM with low duty cycle

### DIFF
--- a/app/brewblox/blox/ActuatorAnalogMockBlock.h
+++ b/app/brewblox/blox/ActuatorAnalogMockBlock.h
@@ -51,6 +51,7 @@ public:
             stripped.add(blox_ActuatorAnalogMock_setting_tag);
         };
 
+        message.desiredSetting = cnl::unwrap(constrained.desiredSetting());
         message.minSetting = cnl::unwrap(actuator.minSetting());
         message.maxSetting = cnl::unwrap(actuator.maxSetting());
         message.minValue = cnl::unwrap(actuator.minValue());

--- a/lib/src/ActuatorPwm.cpp
+++ b/lib/src/ActuatorPwm.cpp
@@ -221,6 +221,13 @@ ActuatorPwm::slowPwmUpdate(const update_t& now)
             }
             if (currentState != actPtr->state()) {
                 toggled = true;
+            } else if (currentState == State::Inactive && m_dutySetting < 5) {
+                // for duty cycle under 5%, set output to inactive explicitly to cancel any pending active state
+                // when the toggle was blocked. This prevents a low duty cycle to create a lingering pending active state in the mutex
+                // The PWM will continue to try to activate the pin
+                actPtr->desiredState(State::Inactive, now);
+                // increase wait time to not keep retrying each millisecond
+                wait = std::min(duration_millis_t(1000), m_period >> 5);
             }
         }
 


### PR DESCRIPTION
For a duty cycle under 5%, do not leave the target digital actuator desired state on Active when the state change is blocked.

This prevents low duty cycles that happen when pwm value is around zero (setpoint is at target) to list in the mutex as pending. This scenario happens when the cooler is at 15% and controlling the process and the heater never actually activates due to the minimum wait time in the mutex blocking it.

Resolves #129