### PR TITLE
Power cycle peripherals at startup and then perform OneWire bus master init

### DIFF
--- a/app/brewblox/AppTicks.h
+++ b/app/brewblox/AppTicks.h
@@ -22,28 +22,11 @@
 #include "blox/TicksBlock.h"
 
 #if defined(SPARK)
-#if PLATFORM_ID != 3 || defined(STDIN_SERIAL)
-#include "cbox/spark/ConnectionsSerial.h"
-#endif
-#include "cbox/spark/ConnectionsTcp.h"
 #include "wiring/TicksWiring.h"
 using TicksClass = Ticks<TicksWiring>;
 #else
-#include "cbox/ConnectionsStringStream.h"
 #include <MockTicks.h>
 using TicksClass = Ticks<MockTicks>;
-#endif
-
-#if !defined(PLATFORM_ID) || PLATFORM_ID == 3
-#include "OneWireNull.h"
-#include "test/MockOneWireScanningFactory.h"
-using OneWireDriver = OneWireNull;
-#define ONEWIRE_ARG
-#else
-#include "DS248x.h"
-#include "OneWireScanningFactory.h"
-using OneWireDriver = DS248x;
-#define ONEWIRE_ARG 0x00
 #endif
 
 const ticks_seconds_t&

--- a/app/brewblox/BrewBlox.cpp
+++ b/app/brewblox/BrewBlox.cpp
@@ -69,8 +69,28 @@ void
 updateFirmwareFromStream(cbox::StreamType streamType){};
 #endif
 
-// define separately to make it available for tests
-#if !defined(SPARK)
+// Include OneWire implementation depending on platform
+#if !defined(PLATFORM_ID) || PLATFORM_ID == 3
+#include "OneWireNull.h"
+#include "test/MockOneWireScanningFactory.h"
+using OneWireDriver = OneWireNull;
+#define ONEWIRE_ARG
+#else
+#include "DS248x.h"
+#include "OneWireScanningFactory.h"
+using OneWireDriver = DS248x;
+#define ONEWIRE_ARG 0x00
+#endif
+
+// Include serial connection for platform
+#if defined(SPARK)
+#if PLATFORM_ID != 3 || defined(STDIN_SERIAL)
+#include "cbox/spark/ConnectionsSerial.h"
+#endif
+#include "cbox/spark/ConnectionsTcp.h"
+#else
+#include "cbox/ConnectionsStringStream.h"
+
 cbox::StringStreamConnectionSource&
 testConnectionSource()
 {

--- a/app/brewblox/blox/ActuatorAnalogMockBlock.h
+++ b/app/brewblox/blox/ActuatorAnalogMockBlock.h
@@ -51,6 +51,7 @@ public:
             stripped.add(blox_ActuatorAnalogMock_setting_tag);
         };
 
+        message.desiredSetting = cnl::unwrap(constrained.desiredSetting());
         message.minSetting = cnl::unwrap(actuator.minSetting());
         message.maxSetting = cnl::unwrap(actuator.maxSetting());
         message.minValue = cnl::unwrap(actuator.minValue());

--- a/app/brewblox/main.cpp
+++ b/app/brewblox/main.cpp
@@ -55,6 +55,7 @@ watchdogReset()
 }
 
 #if PLATFORM_THREADING
+#include "spark_wiring_watchdog.h"
 ApplicationWatchdog appWatchdog(60000, watchdogReset);
 inline void
 watchdogCheckin()

--- a/app/brewblox/main.cpp
+++ b/app/brewblox/main.cpp
@@ -108,15 +108,20 @@ setup()
     StartupScreen::activate();
 
     StartupScreen::setProgress(10);
-    StartupScreen::setStep("Init BrewBlox framework");
-    brewbloxBox();
+    StartupScreen::setStep("Power cycling pheripherals");
 
-    StartupScreen::setProgress(60);
+    while (ticks.millis() < 2000) {
+        displayTick();
+    };
+    enablePheripheral5V(true);
+
+    StartupScreen::setProgress(30);
     StartupScreen::setStep("Init OneWire");
     theOneWire();
 
-    StartupScreen::setProgress(70);
-    StartupScreen::setStep("Init BrewBlox");
+    StartupScreen::setProgress(40);
+    StartupScreen::setStep("Init BrewBlox framework");
+    brewbloxBox();
 
     StartupScreen::setProgress(80);
     StartupScreen::setStep("Loading objects");

--- a/app/brewblox/test/AutoDiscover_test.cpp
+++ b/app/brewblox/test/AutoDiscover_test.cpp
@@ -20,6 +20,7 @@
 #include <catch.hpp>
 
 #include "BrewBloxTestBox.h"
+#include "blox/DS2408Block.h"
 #include "blox/DS2413Block.h"
 #include "blox/TempSensorOneWireBlock.h"
 #include "cbox/CboxPtr.h"

--- a/app/brewblox/test/BrewBloxTestBox.cpp
+++ b/app/brewblox/test/BrewBloxTestBox.cpp
@@ -20,6 +20,7 @@
 #include "BrewBloxTestBox.h"
 #include "blox/Spark3PinsBlock.h"
 #include "cbox/CboxPtr.h"
+#include "cbox/ConnectionsStringStream.h"
 
 BrewBloxTestBox::BrewBloxTestBox()
     : in(std::make_shared<std::stringstream>())

--- a/lib/inc/OneWire.h
+++ b/lib/inc/OneWire.h
@@ -58,6 +58,7 @@ public:
     {
         // base class OneWireLowLevelInterface configures pin or bus master IC
 #if ONEWIRE_SEARCH
+        init();
         reset_search();
 #endif
     }

--- a/lib/src/ActuatorPwm.cpp
+++ b/lib/src/ActuatorPwm.cpp
@@ -221,6 +221,13 @@ ActuatorPwm::slowPwmUpdate(const update_t& now)
             }
             if (currentState != actPtr->state()) {
                 toggled = true;
+            } else if (currentState == State::Inactive && m_dutySetting < 5) {
+                // for duty cycle under 5%, set output to inactive explicitly to cancel any pending active state
+                // when the toggle was blocked. This prevents a low duty cycle to create a lingering pending active state in the mutex
+                // The PWM will continue to try to activate the pin
+                actPtr->desiredState(State::Inactive, now);
+                // increase wait time to not keep retrying each millisecond
+                wait = std::min(duration_millis_t(1000), m_period >> 5);
             }
         }
 

--- a/platform/spark/modules/Board/Board.cpp
+++ b/platform/spark/modules/Board/Board.cpp
@@ -82,13 +82,13 @@ boardInit()
 #ifdef PIN_12V_ENABLE
     HAL_Pin_Mode(PIN_12V_ENABLE, OUTPUT);
     // TODO: temporary until 12V can be toggled by software
-    HAL_GPIO_Write(PIN_12V_ENABLE, HIGH);
+    HAL_GPIO_Write(PIN_12V_ENABLE, LOW);
 #endif
 
 #ifdef PIN_5V_ENABLE
     HAL_Pin_Mode(PIN_5V_ENABLE, OUTPUT);
     // 5V on RJ12 enabled by default, 12V disabled to prevent damaging wrongly connected peripherals
-    HAL_GPIO_Write(PIN_5V_ENABLE, HIGH);
+    HAL_GPIO_Write(PIN_5V_ENABLE, LOW);
 #endif
 
     HAL_GPIO_Write(PIN_ALARM, LOW);
@@ -132,15 +132,26 @@ boardInit()
 #endif
 }
 
-#if defined(PIN_LCD_BACKLIGHT) && defined(SPARK)
 void
-displayBrightness(uint8_t v)
+enablePheripheral5V(bool enabled)
 {
-    HAL_PWM_Write_With_Frequency(PIN_LCD_BACKLIGHT, v, 100);
-}
-#else
-void
-displayBrightness(uint8_t v)
-{
-}
+#if defined(PIN_5V_ENABLE)
+    HAL_GPIO_Write(PIN_5V_ENABLE, enabled);
 #endif
+}
+
+void
+enablePheripheral12V(bool enabled)
+{
+#if defined(PIN_12V_ENABLE)
+    HAL_GPIO_Write(PIN_12V_ENABLE, enabled);
+#endif
+}
+
+void
+displayBrightness(uint8_t v)
+{
+#if defined(PIN_LCD_BACKLIGHT) && defined(SPARK)
+    HAL_PWM_Write_With_Frequency(PIN_LCD_BACKLIGHT, v, 100);
+#endif
+}

--- a/platform/spark/modules/Board/Board.h
+++ b/platform/spark/modules/Board/Board.h
@@ -112,3 +112,8 @@ getSparkVersion();
 
 void
 boardInit();
+
+void
+enablePheripheral5V(bool enabled);
+void
+enablePheripheral12V(bool enabled);


### PR DESCRIPTION
During startup, do not enable peripheral 5V for the first 2 seconds.

This ensures that all connected devices (sensors, expansion boards) get a hard reset and are in a known state.
