### PR TITLE
Fix channel config being lost for OneWire actuators

### DIFF
--- a/app/brewblox/blox/DigitalActuatorBlock.h
+++ b/app/brewblox/blox/DigitalActuatorBlock.h
@@ -81,6 +81,7 @@ public:
 
     virtual cbox::update_t update(const cbox::update_t& now) override final
     {
+        actuator.update();
         constrained.update(now);
         return now + 1000;
     }

--- a/app/brewblox/blox/MotorValveBlock.h
+++ b/app/brewblox/blox/MotorValveBlock.h
@@ -34,10 +34,10 @@ public:
 
         if (result == cbox::CboxError::OK) {
             if (hwDevice.getId() != message.hwDevice) {
-                valve.startChannel(0, true); // unregister at old hwDevice
+                valve.startChannel(0); // unregister at old hwDevice
                 hwDevice.setId(message.hwDevice);
             }
-            valve.startChannel(message.startChannel, false);
+            valve.startChannel(message.startChannel);
             setDigitalConstraints(message.constrainedBy, constrained, objectsRef);
             constrained.desiredState(ActuatorDigitalBase::State(message.desiredState));
         }


### PR DESCRIPTION
Configured channel was stored after it could be claimed successfully.
When the target block still has to be created, this would fail and the config would not be persisted.

Fix is to store both desired channel and channel in use and delay/retry claiming later.