### PR TITLE
Improvements to PWM time stretching behavior

### DIFF
--- a/lib/src/ActuatorPwm.cpp
+++ b/lib/src/ActuatorPwm.cpp
@@ -127,6 +127,8 @@ ActuatorPwm::slowPwmUpdate(const update_t& now)
         auto currentHighTime = durations.currentActive;
         auto currentPeriod = durations.currentPeriod;
         auto previousPeriod = durations.previousPeriod;
+        auto previousHighTime = durations.previousActive;
+        auto previousLowTime = previousPeriod - previousHighTime;
         auto wait = duration_millis_t(0);
         auto currentState = actPtr->state();
         auto invDutyTime = m_period - m_dutyTime;
@@ -148,9 +150,9 @@ ActuatorPwm::slowPwmUpdate(const update_t& now)
 
                 // high period can adapt between boundaries
                 // maximum high time is the highest value among:
-                // - 1.5x the previous period minus current desired low time
+                // - 1.5x the previous hight time
                 // - 1.5x the normal high time
-                auto maxHighTime = std::max(m_dutyTime, previousPeriod - invDutyTime) * 3 / 2;
+                auto maxHighTime = std::max(m_dutyTime, previousHighTime) * 3 / 2;
 
                 // make sure that periods following each other do not alternate in high time
                 // if the current period is already longer than the duty, diminish it by 25% of the extra time
@@ -184,9 +186,9 @@ ActuatorPwm::slowPwmUpdate(const update_t& now)
             } else {
                 // low period can adapt between boundaries
                 // maximum low time is the highest value among:
-                // - 1.5x the previous period minus current desired high time
+                // - 1.5x the previous low time
                 // - 1.5x the normal low time
-                auto maxLowTime = std::max(invDutyTime, previousPeriod - m_dutyTime) * 3 / 2;
+                auto maxLowTime = std::max(invDutyTime, previousLowTime) * 3 / 2;
 
                 // make sure that periods following each other do not alternate in low time
                 // if the current period is already longer than the invDuty, diminish it by 33% of the extra time

--- a/lib/src/ActuatorPwm.cpp
+++ b/lib/src/ActuatorPwm.cpp
@@ -154,11 +154,11 @@ ActuatorPwm::slowPwmUpdate(const update_t& now)
                 // - 1.5x the normal high time
                 auto maxHighTime = std::max(m_dutyTime, previousHighTime) * 3 / 2;
 
-                // make sure that periods following each other do not alternate in high time
-                // if the current period is already longer than the duty, diminish it by 25% of the extra time
-                // This prevents alternating between 1500 and 2500 when the total of 2 periods should be 4000.
-                if (currentHighTime > m_dutyTime && twoPeriodHighTime < 2 * m_dutyTime) {
-                    twoPeriodTargetHighTime -= (currentHighTime - m_dutyTime) / 4;
+                // make sure that periods following each other do not continuously alternate in shortend/stretched cycle
+                // by converging to the mean or unadjusted, whichever is higher
+                auto mean = std::max(m_dutyTime, twoPeriodTargetHighTime / 2);
+                if (currentHighTime > mean && previousHighTime < mean) {
+                    twoPeriodTargetHighTime -= (currentHighTime - previousHighTime) / 4;
                 }
 
                 if (currentHighTime < maxHighTime) {
@@ -190,11 +190,11 @@ ActuatorPwm::slowPwmUpdate(const update_t& now)
                 // - 1.5x the normal low time
                 auto maxLowTime = std::max(invDutyTime, previousLowTime) * 3 / 2;
 
-                // make sure that periods following each other do not alternate in low time
-                // if the current period is already longer than the invDuty, diminish it by 33% of the extra time
-                // This prevents alternating between 1500 and 2500 when the total of 2 periods should be 4000.
-                if (thisPeriodLowTime > invDutyTime && twoPeriodLowTime < 2 * invDutyTime) {
-                    twoPeriodTargetLowTime -= (thisPeriodLowTime - invDutyTime) / 3;
+                // make sure that periods following each other do not continuously alternate in shortend/stretched cycle
+                // by converging to the mean or the unadjusted time, whichever is higher
+                auto mean = std::max(invDutyTime, twoPeriodTargetLowTime / 2);
+                if (thisPeriodLowTime > mean && previousLowTime < mean) {
+                    twoPeriodTargetLowTime -= (thisPeriodLowTime - previousLowTime) / 4;
                 }
 
                 if (thisPeriodLowTime < maxLowTime) {

--- a/lib/src/ActuatorPwm.cpp
+++ b/lib/src/ActuatorPwm.cpp
@@ -123,12 +123,9 @@ ActuatorPwm::slowPwmUpdate(const update_t& now)
         auto durations = actPtr->activeDurations(now);
         auto twoPeriodTotalTime = durations.previousPeriod + durations.currentPeriod;
         auto twoPeriodHighTime = durations.previousActive + durations.currentActive;
-        auto twoPeriodLowTime = twoPeriodTotalTime - twoPeriodHighTime;
         auto currentHighTime = durations.currentActive;
-        auto currentPeriod = durations.currentPeriod;
-        auto previousPeriod = durations.previousPeriod;
         auto previousHighTime = durations.previousActive;
-        auto previousLowTime = previousPeriod - previousHighTime;
+
         auto wait = duration_millis_t(0);
         auto currentState = actPtr->state();
         auto invDutyTime = m_period - m_dutyTime;
@@ -146,7 +143,6 @@ ActuatorPwm::slowPwmUpdate(const update_t& now)
                 }
             } else {
                 // for checking the currently achieved value, for this cycle so far and the previous
-                auto twoPeriodTargetHighTime = duration_millis_t(twoPeriodTotalTime * (m_dutySetting / 100));
 
                 // high period can adapt between boundaries
                 // maximum high time is the highest value among:
@@ -154,14 +150,15 @@ ActuatorPwm::slowPwmUpdate(const update_t& now)
                 // - 1.5x the normal high time
                 auto maxHighTime = std::max(m_dutyTime, previousHighTime) * 3 / 2;
 
-                // make sure that periods following each other do not continuously alternate in shortend/stretched cycle
-                // by converging to the mean or unadjusted, whichever is higher
-                auto mean = std::max(m_dutyTime, twoPeriodTargetHighTime / 2);
-                if (currentHighTime > mean && previousHighTime < mean) {
-                    twoPeriodTargetHighTime -= (currentHighTime - previousHighTime) / 4;
-                }
-
                 if (currentHighTime < maxHighTime) {
+                    // for checking the currently achieved value, look back max 2 periods (toggles)
+                    auto twoPeriodTargetHighTime = duration_millis_t(twoPeriodTotalTime * (m_dutySetting / 100));
+                    // make sure that periods following each other do not continuously alternate in shortend/stretched cycle
+                    // by converging to the mean or unadjusted, whichever is higher
+                    auto mean = std::max(m_dutyTime, twoPeriodTargetHighTime / 2);
+                    if (currentHighTime > mean && previousHighTime < mean) {
+                        twoPeriodTargetHighTime -= (currentHighTime - previousHighTime) / 4;
+                    }
                     if (twoPeriodHighTime < twoPeriodTargetHighTime) {
                         wait = std::min(twoPeriodTargetHighTime - twoPeriodHighTime, maxHighTime - currentHighTime);
                     }
@@ -173,33 +170,36 @@ ActuatorPwm::slowPwmUpdate(const update_t& now)
                 m_dutyAchieved = 0;
                 return now + 1000;
             }
-            // for checking the currently achieved value, look back max 2 periods (toggles)
-            auto twoPeriodTargetLowTime = duration_millis_t(twoPeriodTotalTime * ((value_t(100) - m_dutySetting) / 100));
-
-            auto thisPeriodLowTime = currentPeriod - currentHighTime;
+            auto currentPeriod = durations.currentPeriod;
+            auto currentLowTime = currentPeriod - currentHighTime;
 
             if (m_dutySetting > value_t(50)) {
                 // low period is fixed, high period adapts
-                if (thisPeriodLowTime < invDutyTime) {
-                    wait = invDutyTime - thisPeriodLowTime;
+                if (currentLowTime < invDutyTime) {
+                    wait = invDutyTime - currentLowTime;
                 }
             } else {
+                auto previousPeriod = durations.previousPeriod;
+                auto previousLowTime = previousPeriod - previousHighTime;
                 // low period can adapt between boundaries
                 // maximum low time is the highest value among:
                 // - 1.5x the previous low time
                 // - 1.5x the normal low time
                 auto maxLowTime = std::max(invDutyTime, previousLowTime) * 3 / 2;
 
-                // make sure that periods following each other do not continuously alternate in shortend/stretched cycle
-                // by converging to the mean or the unadjusted time, whichever is higher
-                auto mean = std::max(invDutyTime, twoPeriodTargetLowTime / 2);
-                if (thisPeriodLowTime > mean && previousLowTime < mean) {
-                    twoPeriodTargetLowTime -= (thisPeriodLowTime - previousLowTime) / 4;
-                }
+                if (currentLowTime < maxLowTime) {
+                    // for checking the currently achieved value, look back max 2 periods (toggles)
+                    auto twoPeriodTargetLowTime = duration_millis_t(twoPeriodTotalTime * ((value_t(100) - m_dutySetting) / 100));
 
-                if (thisPeriodLowTime < maxLowTime) {
+                    // make sure that periods following each other do not continuously alternate in shortend/stretched cycle
+                    // by converging to the mean or the unadjusted time, whichever is higher
+                    auto mean = std::max(invDutyTime, twoPeriodTargetLowTime / 2);
+                    if (currentLowTime > mean && previousLowTime < mean) {
+                        twoPeriodTargetLowTime -= (currentLowTime - previousLowTime) / 4;
+                    }
+                    auto twoPeriodLowTime = twoPeriodTotalTime - twoPeriodHighTime;
                     if (twoPeriodLowTime < twoPeriodTargetLowTime) {
-                        wait = std::min(twoPeriodTargetLowTime - twoPeriodLowTime, maxLowTime - thisPeriodLowTime);
+                        wait = std::min(twoPeriodTargetLowTime - twoPeriodLowTime, maxLowTime - currentLowTime);
                     }
                 }
             }

--- a/lib/src/ActuatorPwm.cpp
+++ b/lib/src/ActuatorPwm.cpp
@@ -241,7 +241,7 @@ ActuatorPwm::slowPwmUpdate(const update_t& now)
             }
         }
 
-        return now + std::min(update_t(1000), wait >> 1);
+        return now + std::min(update_t(1000), (wait >> 1) + 1);
     }
     return now + 1000;
 }

--- a/lib/test/ActuatorPwm_test.cpp
+++ b/lib/test/ActuatorPwm_test.cpp
@@ -493,27 +493,28 @@ SCENARIO("ActuatorPWM driving mock actuator", "[pwm]")
         CHECK(randomIntervalTest(10, pwm, mock, 20.0, 500, now) == Approx(20.0).margin(0.5));
         CHECK(randomIntervalTest(10, pwm, mock, 80.0, 500, now) == Approx(80.0).margin(0.5));
 
-        // we don use 2% and 98% here, because with the maximum history taken into account it is not achievable under the constraints
+        // we don't use 2% and 98% here, because with the maximum history taken into account it is not achievable under the constraints
         CHECK(randomIntervalTest(10, pwm, mock, 4.0, 500, now) == Approx(4.0).margin(0.5));
         CHECK(randomIntervalTest(10, pwm, mock, 96.0, 500, now) == Approx(96.0).margin(0.5));
     }
 
-    WHEN("The actuator has been set to 30% duty and switches to 5% with minimum ON time at 40% duty")
+    WHEN("The actuator has been set to 30% duty and switches to 20% with minimum ON time at 40% duty")
     {
         pwm.period(10000);                                                               // 10s
         constrained->addConstraint(std::make_unique<ADConstraints::MinOnTime<2>>(4000)); // 4 s
-        pwm.setting(30);                                                                 // will result in 4s on, 13.3s off
+        pwm.setting(30);                                                                 // will result in 4s on, 13.3s period
 
         auto nextUpdate = pwm.update(now);
-        auto lastHighTime = now;
+
         for (; now < 100000; now += 100) {
             if (now > nextUpdate) {
                 nextUpdate = pwm.update(now);
-                if (mock.state() == State::Active) {
-                    lastHighTime = now;
-                }
             }
         }
+
+        auto durations = constrained->activeDurations(now);
+        CHECK(durations.previousPeriod == 13300); // rounded due to update interval
+
         pwm.setting(20);
         nextUpdate = pwm.update(now);
 
@@ -521,7 +522,7 @@ SCENARIO("ActuatorPWM driving mock actuator", "[pwm]")
         {
             CHECK(mock.state() == State::Inactive);
         }
-        THEN("The next low time is stretched even more")
+        THEN("The next low time is stretched to 1.5x the previous one")
         {
             while (mock.state() == State::Inactive) {
                 if (now > nextUpdate) {
@@ -529,16 +530,50 @@ SCENARIO("ActuatorPWM driving mock actuator", "[pwm]")
                 }
                 now += 100;
             }
-            CHECK(now - lastHighTime > 15000);
-
-            AND_THEN("It pwm will settle on the desired duty")
-            {
-                for (; now < 200000; now += 100) {
-                    if (now > nextUpdate) {
-                        nextUpdate = pwm.update(now);
-                    }
+            while (mock.state() == State::Active) {
+                if (now > nextUpdate) {
+                    nextUpdate = pwm.update(now);
                 }
-                CHECK(pwm.value() == 20);
+                now += 100;
+            }
+            durations = constrained->activeDurations(now);
+            CHECK(durations.previousPeriod == 18000); // 9333 * 1.5 + 4000
+        }
+        THEN("It pwm will settle on the desired duty")
+        {
+            for (; now < 200000; now += 100) {
+                if (now > nextUpdate) {
+                    nextUpdate = pwm.update(now);
+                }
+            }
+            CHECK(pwm.value() == 20.0);
+            auto durations = constrained->activeDurations(now);
+            CHECK(double(durations.previousActive) / double(durations.previousPeriod) == 0.2);
+            AND_THEN("The stretched periods will have expected length")
+            {
+                // finish period
+                while (mock.state() == State::Inactive) {
+                    now += 100;
+                    pwm.update(now);
+                }
+                durations = constrained->activeDurations(now);
+                CHECK(durations.previousPeriod == 20000);
+
+                // finish another period
+
+                while (mock.state() == State::Active) {
+                    now += 100;
+                    pwm.update(now);
+                }
+
+                while (mock.state() == State::Inactive) {
+                    now += 100;
+                    pwm.update(now);
+                }
+
+                durations = constrained->activeDurations(now);
+
+                CHECK(durations.previousPeriod == 20000);
             }
         }
     }
@@ -556,7 +591,7 @@ SCENARIO("ActuatorPWM driving mock actuator", "[pwm]")
                     nextUpdate = pwm.update(now);
                 }
                 if (now > 50000) {
-                    CHECK(pwm.value() == Approx(10).margin(1));
+                    CHECK(pwm.value() == Approx(10).margin(2));
                 }
             }
         }


### PR DESCRIPTION
This PR should resolve 2 issues:

- When the PWM setting changed significantly, the length of the next low/high period was not bounded correctly. This made the scenario possible where to achieve a 1% duty cycle after a 40% one, the cycle would be much over 10x the normal cycle.
- When a minimum ON time much longer than the PWM cycle was present, the system could get in a situation where it alternated between a longer and a shorter cycle indefinitely (with both cycles longer than the normal cycle).