### PR TITLE
Fix segfault in firmware when deleting a constraint created before the balancer itself

### DIFF
--- a/lib/inc/Balancer.h
+++ b/lib/inc/Balancer.h
@@ -72,7 +72,7 @@ public:
                          requesters.end());
     }
 
-    value_t constrain(const uint8_t& requester_id, const value_t& val)
+    value_t constrain(uint8_t& requester_id, const value_t& val)
     {
         auto match = find_if(requesters.begin(), requesters.end(), [&requester_id](const Request& r) {
             return r.id == requester_id;
@@ -83,8 +83,9 @@ public:
             return std::min(val, match->granted);
         };
 
-        // not found. Could happen is actuator was created before the balancer. Register entry now (on first request).
-        registerEntry(requester_id);
+        // not found. Could happen is actuator was created before the balancer.
+        // assign new requester id
+        requester_id = registerEntry();
         return 0;
     }
 
@@ -140,7 +141,7 @@ template <uint8_t ID>
 class Balanced : public Base {
 private:
     const std::function<std::shared_ptr<Balancer<ID>>()> m_balancer;
-    uint8_t m_req_id;
+    mutable uint8_t m_req_id; // can be updated by balancer in request
 
 public:
     explicit Balanced(

--- a/lib/inc/Balancer.h
+++ b/lib/inc/Balancer.h
@@ -68,7 +68,8 @@ public:
 
     void unregisterEntry(const uint8_t& requester_id)
     {
-        requesters.erase(std::remove_if(requesters.begin(), requesters.end(), [&requester_id](const Request& r) { return r.id == requester_id; }));
+        requesters.erase(std::remove_if(requesters.begin(), requesters.end(), [&requester_id](const Request& r) { return r.id == requester_id; }),
+                         requesters.end());
     }
 
     value_t constrain(const uint8_t& requester_id, const value_t& val)
@@ -82,7 +83,9 @@ public:
             return std::min(val, match->granted);
         };
 
-        return 0; // not found. Should not be possible because Balanced registers in constructor
+        // not found. Could happen is actuator was created before the balancer. Register entry now (on first request).
+        registerEntry(requester_id);
+        return 0;
     }
 
     value_t granted(const uint8_t& requester_id) const

--- a/lib/src/spark/TimerInterrupts.cpp
+++ b/lib/src/spark/TimerInterrupts.cpp
@@ -74,7 +74,7 @@ TimerInterrupts::add(std::function<void()>&& func)
 void
 TimerInterrupts::remove(uint8_t id)
 {
-    funcs.erase(std::remove_if(funcs.begin(), funcs.end(), [&id](const FuncEntry& fe) { return fe.id == id; }));
+    funcs.erase(std::remove_if(funcs.begin(), funcs.end(), [&id](const FuncEntry& fe) { return fe.id == id; }), funcs.end());
     if (funcs.empty()) {
         TIM_Cmd(TIM4, DISABLE);
     }


### PR DESCRIPTION
This is a subtle bug when using std::erase.

When a balanced constraint is created before the actual balancer, it doesn't exist in the requesters vector. When the constraint is deleted, the wrong overload of std::erase was used. std::remove_if returned std::end() (not found) and std::erase tried to delete it.

iterator erase(const_iterator pos); // 1)
iterator erase(const_iterator first, const_iterator last); // 2)
1) removes element pointed-to by the iterator. 2) removes a sequence of elements minus last (as is usual in the standard library).

From: https://dev.krzaq.cc/post/an-erase-remove-idiom-gotcha/