### PR TITLE
Adjust PWM algorithm to not overcompensate for history when duty cycle is increased

### DIFF
--- a/app/brewblox/test/AcutatorPwmBlock_test.cpp
+++ b/app/brewblox/test/AcutatorPwmBlock_test.cpp
@@ -83,7 +83,7 @@ SCENARIO("A Blox ActuatorPwm object can be created from streamed protobuf data")
 
     CHECK(testBox.lastReplyHasStatusOk());
     CHECK(decoded.ShortDebugString() == "actuatorId: 100 "
-                                        "period: 4000 setting: 81920 "
+                                        "period: 4000 setting: 81920 value: 81797 "
                                         "constrainedBy { constraints { min: 40960 } } "
                                         "drivenActuatorId: 100 "
                                         "enabled: true "

--- a/app/brewblox/test/BalancerAndMutexBlock_test.cpp
+++ b/app/brewblox/test/BalancerAndMutexBlock_test.cpp
@@ -308,7 +308,7 @@ SCENARIO("Two pin actuators are constrained by a mutex", "[balancer, mutex]")
             testBox.processInputToProto(decoded);
             CHECK(testBox.lastReplyHasStatusOk());
             CHECK(decoded.ShortDebugString() == "actuatorId: 102 "
-                                                "period: 4000 setting: 204800 "
+                                                "period: 4000 setting: 204800 value: 163758 "
                                                 "constrainedBy { "
                                                 "constraints { "
                                                 "balanced { balancerId: 200 granted: 204800 id: 1 } "
@@ -351,7 +351,7 @@ SCENARIO("Two pin actuators are constrained by a mutex", "[balancer, mutex]")
         {
             auto decoded = blox::ActuatorPwm();
             testBox.processInputToProto(decoded);
-            CHECK(decoded.value() == Approx(cnl::unwrap(ActuatorAnalog::value_t(50))).epsilon(0.03));
+            CHECK(decoded.value() == Approx(cnl::unwrap(ActuatorAnalog::value_t(50))).epsilon(0.05));
         }
 
         // read a pwm actuator 2
@@ -362,7 +362,7 @@ SCENARIO("Two pin actuators are constrained by a mutex", "[balancer, mutex]")
         {
             auto decoded = blox::ActuatorPwm();
             testBox.processInputToProto(decoded);
-            CHECK(decoded.value() == Approx(cnl::unwrap(ActuatorAnalog::value_t(50))).epsilon(0.03));
+            CHECK(decoded.value() == Approx(cnl::unwrap(ActuatorAnalog::value_t(50))).epsilon(0.05));
         }
     }
 }

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - bash: |
-          git submodule update --init --recursive
+          git submodule update --init --recursive --jobs 4
         displayName: Init submodules
 
       - bash: |
@@ -52,7 +52,7 @@ jobs:
 
     steps:
       - bash: |
-          git submodule update --init --recursive
+          git submodule update --init --recursive --jobs 4
         displayName: Init submodules
 
       - bash: |
@@ -84,7 +84,7 @@ jobs:
 
     steps:
       - bash: |
-          git submodule update --init --recursive
+          git submodule update --init --recursive --jobs 4
         displayName: Init submodules
 
       - bash: |

--- a/build/clean-all.sh
+++ b/build/clean-all.sh
@@ -8,4 +8,6 @@ sudo chown -R $USER "$ROOT_DIR"
 make -C "../app/brewblox/test" clean
 make -C "../lib/test" clean
 make -C "../controlbox" clean
-make clean
+make clean PLATFORM=gcc
+make clean PLATFORM=p1
+make clean PLATFORM=photon


### PR DESCRIPTION
When the PWM target was held back by a constraint (mutex for example), it would have an extra long low period.

When it was finally allowed to go active, it would use a shortened low period in the next cycle to compensate for the stretched previous one.
This caused too much actuator action in the first 1 or 2 cycles.

Extra limits were added for this scenario.
For shortened previous cycles, the algorithm now also scales them back to normal duration using the current duty setting, which prevents overcompensation when the duty cycle is changing.