### PR TITLE
Add small delay in main loop to yield system thread

### DIFF
--- a/app/brewblox/BrewBlox.cpp
+++ b/app/brewblox/BrewBlox.cpp
@@ -224,6 +224,18 @@ logger()
 }
 
 void
+logEvent(const std::string& event)
+{
+    cbox::DataOut& out = theConnectionPool().logDataOut();
+    out.write('<');
+    out.write('!');
+    for (const auto& c : event) {
+        out.write(c);
+    }
+    out.write('>');
+}
+
+void
 updateBrewbloxBox()
 {
     brewbloxBox().update(ticks.millis());

--- a/app/brewblox/BrewBlox.h
+++ b/app/brewblox/BrewBlox.h
@@ -45,3 +45,6 @@ updateBrewbloxBox();
 
 const char*
 versionCsv();
+
+void
+logEvent(const std::string& event);

--- a/app/brewblox/connectivity.cpp
+++ b/app/brewblox/connectivity.cpp
@@ -117,7 +117,7 @@ manageConnections(uint32_t now)
             client.write(System.deviceID());
             client.write("</p></body></html>\n\n");
             client.flush();
-            delay(5);
+            HAL_Delay_Milliseconds(5);
             client.stop();
         }
         return;
@@ -202,7 +202,7 @@ updateFirmwareStreamHandler(Stream& stream)
     uint8_t invalidCommands = 0;
 
     while (true) {
-        delay(1);
+        HAL_Delay_Milliseconds(1);
         int recv = stream.read();
         switch (recv) {
         case 'F':

--- a/app/brewblox/main.cpp
+++ b/app/brewblox/main.cpp
@@ -87,6 +87,13 @@ displayTick()
     }
 }
 
+void
+onSetupModeBegin()
+{
+    logEvent("SETUP_MODE");
+    HAL_Delay_Milliseconds(100);
+}
+
 #if PLATFORM_ID != PLATFORM_GCC
 STARTUP(
     boardInit();
@@ -106,6 +113,7 @@ setup()
 #endif
 
     System.on(setup_update, watchdogCheckin);
+    System.on(setup_begin, onSetupModeBegin);
     HAL_Delay_Milliseconds(1);
 
 #if PLATFORM_ID == PLATFORM_GCC

--- a/app/brewblox/main.cpp
+++ b/app/brewblox/main.cpp
@@ -27,6 +27,7 @@
 #include "cbox/Object.h"
 #include "connectivity.h"
 #include "d4d.hpp"
+#include "delay_hal.h"
 #include "display/screens/WidgetsScreen.h"
 #include "display/screens/startup_screen.h"
 #include "eeprom_hal.h"
@@ -105,6 +106,7 @@ setup()
 #endif
 
     System.on(setup_update, watchdogCheckin);
+    HAL_Delay_Milliseconds(1);
 
 #if PLATFORM_ID == PLATFORM_GCC
     manageConnections(0); // init network early to websocket display emulation works during setup()
@@ -116,6 +118,7 @@ setup()
     D4D_TCH_SetCalibration(defaultCalib);
 
     StartupScreen::activate();
+    HAL_Delay_Milliseconds(1);
 
     StartupScreen::setProgress(10);
     StartupScreen::setStep("Power cycling peripherals");
@@ -124,18 +127,22 @@ setup()
         displayTick();
     };
     enablePheripheral5V(true);
+    HAL_Delay_Milliseconds(1);
 
     StartupScreen::setProgress(30);
     StartupScreen::setStep("Init OneWire");
     theOneWire();
 
+    HAL_Delay_Milliseconds(1);
     StartupScreen::setProgress(40);
     StartupScreen::setStep("Init BrewBlox framework");
     brewbloxBox();
 
+    HAL_Delay_Milliseconds(1);
     StartupScreen::setProgress(80);
     StartupScreen::setStep("Loading objects");
     brewbloxBox().loadObjectsFromStorage(); // init box and load stored objects
+    HAL_Delay_Milliseconds(1);
     StartupScreen::setProgress(100);
 
     // perform pending EEPROM erase while we're waiting. Can take up to 500ms and stalls all code execution
@@ -146,6 +153,7 @@ setup()
 
     while (ticks.millis() < 5000) {
         displayTick();
+        HAL_Delay_Milliseconds(1);
     };
 
     WidgetsScreen::activate();
@@ -154,6 +162,7 @@ setup()
 #endif
 
     wifiInit();
+    HAL_Delay_Milliseconds(1);
 }
 
 void
@@ -164,6 +173,7 @@ loop()
         manageConnections(ticks.millis());
         brewbloxBox().hexCommunicate();
     }
+
     ticks.switchTaskTimer(TicksClass::TaskId::BlocksUpdate);
     updateBrewbloxBox();
 
@@ -172,6 +182,7 @@ loop()
 
     ticks.switchTaskTimer(TicksClass::TaskId::System);
     watchdogCheckin();
+    HAL_Delay_Milliseconds(1);
 }
 
 void

--- a/controlbox/src/cbox/Box.cpp
+++ b/controlbox/src/cbox/Box.cpp
@@ -1,7 +1,8 @@
 /*
- * Copyright 2014-2016 Matthew McGowan.
+ * Copyright 2019 BrewPi B.V. / Elco Jacobs
+ * based on earlier work of Matthew McGowan.
  *
- * This file is part of Nice Firmware.
+ * This file is part of BrewBlox.
  *
  * Controlbox is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
Our application code is free of delays. We think this might cause problems that the system thread is rarely yielded and tasks might pile up.
Before this change, it was possible to trigger a hard fault sometimes by entering listening mode. I have not been able to reproduce that since this change.

In general, giving the system thread some guaranteed time to perform system health tasks and manage the network seems like a good idea.

Also added an event to notify devcon that setup/listening mode was triggered.

Noticed so far:
- triggering listening mode is more reliable and responsive. `brewblox-ctl wifi` seems to work better too
- bootloader flash works as expected