### PR TITLE
Update device os to 1.4.4 and fix fast digital IO

### DIFF
--- a/app/brewblox/blox/SparkIoBase.h
+++ b/app/brewblox/blox/SparkIoBase.h
@@ -24,11 +24,6 @@
 #include "IoArray.h"
 #include "IoArrayHelpers.h"
 #include "blox/Block.h"
-#include "spark_wiring_constants.h"
-
-#include "fast_pin.h"
-#include "gpio_hal.h"
-#include "pinmap_hal.h"
 
 class SparkIoBase : public IoArray {
 protected:

--- a/app/brewblox/test/makefile
+++ b/app/brewblox/test/makefile
@@ -82,6 +82,7 @@ INCLUDE_DIRS += $(SOURCE_PATH)/platform/spark/device-os/hal/shared
 INCLUDE_DIRS += $(SOURCE_PATH)/platform/spark/device-os/services/inc
 INCLUDE_DIRS += $(SOURCE_PATH)/platform/spark/device-os/hal/src/gcc
 INCLUDE_DIRS += $(SOURCE_PATH)/platform/spark/device-os/hal/src/newhal
+INCLUDE_DIRS += $(SOURCE_PATH)/platform/spark/device-os/wiring/inc
 CPPSRC += /platform/spark/device-os/hal/src/gcc/gpio_hal.cpp
 CPPSRC += /platform/spark/device-os/hal/src/gcc/eeprom_hal.cpp
 CPPSRC += /platform/spark/device-os/hal/src/gcc/filesystem.cpp

--- a/platform/spark/modules/Board/Board.cpp
+++ b/platform/spark/modules/Board/Board.cpp
@@ -20,8 +20,6 @@
 
 #include "Board.h"
 #include "delay_hal.h"
-#include "fast_pin.h"
-#include "gpio_hal.h"
 #include "pwm_hal.h"
 
 bool

--- a/platform/spark/modules/Board/Board.cpp
+++ b/platform/spark/modules/Board/Board.cpp
@@ -16,7 +16,6 @@
  * You should have received a copy of the GNU General Public License
  * along with BrewPi.  If not, see <http://www.gnu.org/licenses/>.
  */
-#include "spark_wiring_constants.h"
 
 #include "Board.h"
 #include "delay_hal.h"

--- a/platform/spark/modules/Board/Board.h
+++ b/platform/spark/modules/Board/Board.h
@@ -20,11 +20,27 @@
 #pragma once
 #include "core_hal.h"
 #include "gpio_hal.h"
+#include "spark_wiring_constants.h"
+
 #if PLATFORM_ID == 3
 #include "pinmap_hal.h"
+inline int32_t
+pinReadFast(pin_t pin)
+{
+    return HAL_GPIO_Read(pin);
+}
+
+inline void
+digitalWriteFast(pin_t pin, uint8_t value)
+{
+    HAL_GPIO_Write(pin, value);
+}
 #else
 #include "pinmap_impl.h"
+
+#include "fast_pin.h"
 #endif
+
 #include <array>
 #include <stdint.h>
 

--- a/platform/spark/modules/BrewPiTouch/BrewPiTouch.cpp
+++ b/platform/spark/modules/BrewPiTouch/BrewPiTouch.cpp
@@ -18,11 +18,7 @@
  */
 
 #include "BrewPiTouch.h"
-#include "spark_wiring_constants.h"
-
-#include "fast_pin.h"
-#include "gpio_hal.h"
-#include "pinmap_hal.h"
+#include "Board.h"
 
 #include <algorithm>
 #include <cstdint>

--- a/platform/spark/modules/Buzzer/Buzzer.cpp
+++ b/platform/spark/modules/Buzzer/Buzzer.cpp
@@ -22,10 +22,7 @@
 #include "Buzzer.h"
 #include "Board.h"
 #include "delay_hal.h"
-#include "spark_wiring.h"
-#include "spark_wiring_constants.h"
-
-#include "fast_pin.h"
+#include "pwm_hal.h"
 
 void
 BuzzerClass::setActive(bool active)
@@ -38,7 +35,7 @@ BuzzerClass::setActive(bool active)
         digitalWriteFast(PIN_ALARM, active);
         break;
     case SparkVersion::V3:
-        analogWrite(PIN_ALARM, active ? 128 : 0, 3000);
+        HAL_PWM_Write_With_Frequency(PIN_ALARM, active ? 128 : 0, 3000);
         break;
     }
 }


### PR DESCRIPTION
- Updates device-os to 1.4.4
- Fixes fast digital IO committed on develop not having the right stubs in gcc build