### PR TITLE
Fix initialization of bidrectioninal IO pins top1 and top2

### DIFF
--- a/app/brewblox/blox/SparkIoBase.h
+++ b/app/brewblox/blox/SparkIoBase.h
@@ -59,7 +59,7 @@ public:
                 digitalWriteFast(PIN_V3_TOP1_DIR, isOutput);
             }
 #endif
-#ifdef PIN_V3_TOP1_DIR
+#ifdef PIN_V3_TOP2_DIR
             if (pin == PIN_V3_TOP2) {
                 bool isOutput = (config == ChannelConfig::ACTIVE_HIGH || config == ChannelConfig::ACTIVE_LOW);
                 HAL_Pin_Mode(PIN_V3_TOP2_DIR, OUTPUT);

--- a/platform/spark/modules/Board/Board.cpp
+++ b/platform/spark/modules/Board/Board.cpp
@@ -52,29 +52,29 @@ boardInit()
 {
 #if PLATFORM_ID == 8 || PLATFORM_ID == 3 // P1 or simulation
     HAL_Pin_Mode(PIN_V3_BOTTOM1, OUTPUT);
-    HAL_Pin_Mode(PIN_V3_BOTTOM2, OUTPUT);
-    HAL_Pin_Mode(PIN_V3_TOP2, OUTPUT);
-    HAL_Pin_Mode(PIN_V3_TOP3, OUTPUT);
-
     digitalWriteFast(PIN_V3_BOTTOM1, LOW);
+
+    HAL_Pin_Mode(PIN_V3_BOTTOM2, OUTPUT);
     digitalWriteFast(PIN_V3_BOTTOM2, LOW);
-    digitalWriteFast(PIN_V3_TOP2, INPUT_PULLDOWN);
-    digitalWriteFast(PIN_V3_TOP3, LOW);
 
 #ifdef PIN_V3_TOP1
     HAL_Pin_Mode(PIN_V3_TOP1, INPUT_PULLDOWN);
-    digitalWriteFast(PIN_V3_TOP1, LOW);
 #endif
 
 #ifdef PIN_V3_TOP1_DIR
     HAL_Pin_Mode(PIN_V3_TOP1_DIR, OUTPUT);
-    digitalWriteFast(PIN_V3_TOP1_DIR, HIGH); // configure as input
+    digitalWriteFast(PIN_V3_TOP1_DIR, LOW); // configure as input
 #endif
+
+    HAL_Pin_Mode(PIN_V3_TOP2, INPUT_PULLDOWN);
 
 #ifdef PIN_V3_TOP2_DIR
     HAL_Pin_Mode(PIN_V3_TOP2_DIR, OUTPUT);
     digitalWriteFast(PIN_V3_TOP2_DIR, LOW); // configure as input
 #endif
+
+    HAL_Pin_Mode(PIN_V3_TOP3, OUTPUT);
+    digitalWriteFast(PIN_V3_TOP3, LOW);
 
 #ifdef PIN_12V_ENABLE
     HAL_Pin_Mode(PIN_12V_ENABLE, OUTPUT);

--- a/platform/spark/modules/Board/Board.h
+++ b/platform/spark/modules/Board/Board.h
@@ -64,8 +64,8 @@ enum class SparkVersion : uint8_t {
 
 #if !defined(SWD_JTAG_ENABLE)
 #define PIN_V3_TOP1 D4
-#define PIN_V3_TOP1_DIR D3
-#define PIN_V3_TOP2_DIR D5
+#define PIN_V3_TOP1_DIR D5
+#define PIN_V3_TOP2_DIR D3
 #endif
 
 #if !defined(SWD_JTAG_ENABLE) && !defined(SWD_ENABLE)


### PR DESCRIPTION
Top 1 and top 2 have a level shifter with bidirectional IO support.
The direction was not initialized correctly.
Up until the last release, they were hard coded as output, which is why it didn't cause issues earlier.