### PR TITLE
Restart all services on WiFi reconnect

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 compile_commands.json
 .ccls-cache/
+.vscode/.cortex-debug.*

--- a/controlbox/src/cbox/spark/ConnectionsTcp.h
+++ b/controlbox/src/cbox/spark/ConnectionsTcp.h
@@ -42,6 +42,7 @@ public:
 class TcpConnectionSource : public ConnectionSource {
 private:
     TCPServer server;
+    bool server_started = false;
 
 public:
     TcpConnectionSource(uint16_t port)
@@ -52,10 +53,16 @@ public:
     std::unique_ptr<Connection> newConnection() override final
     {
         if (spark::WiFi.ready() && !spark::WiFi.listening()) {
+            if (!server_started) {
+                server_started = server.begin();
+            }
+
             TCPClient newClient = server.available();
             if (newClient.connected()) {
                 return std::make_unique<TcpConnection>(std::move(newClient));
             }
+        } else {
+            server_started = false;
         }
         return nullptr;
     }


### PR DESCRIPTION
On network loss, network services for mDNS, TCP communciation (8332) and web server (port 80) did not restart properly.

They are now explicitly restart after network loss, which seems to help connectivity issues!