### PR TITLE
Fix waiting for TCP client to receive new firmware

### DIFF
--- a/app/brewblox/BrewBlox.cpp
+++ b/app/brewblox/BrewBlox.cpp
@@ -312,8 +312,8 @@ applicationCommand(uint8_t cmdId, cbox::DataIn& in, cbox::EncodedDataOut& out)
             theConnectionPool().closeAll();
             updateFirmwareFromStream(in.streamType());
             uint8_t reason = uint8_t(RESET_USER_REASON::FIRMWARE_UPDATE_FAILED);
-            handleReset(true, reason); // reset in case the firmware update failed
             BlinkFirmwareUpdate.setActive(false);
+            handleReset(true, reason); // reset in case the firmware update failed
         }
         return true;
     }

--- a/app/brewblox/connectivity.cpp
+++ b/app/brewblox/connectivity.cpp
@@ -262,13 +262,13 @@ updateFirmwareFromStream(cbox::StreamType streamType)
     } else {
         TCPServer server(8332); // re-open TCP server
 
-        TCPClient client;
         while (true) {
-            client = server.available();
+            TCPClient client = server.available();
             if (client) {
                 updateFirmwareStreamHandler(client);
                 client.stop();
             }
+            HAL_Delay_Milliseconds(1); // allow thread switch so system thread can set up client
         }
     }
 }


### PR DESCRIPTION
Added a 1ms delay to allow thread switching while waiting for TCP client to receive new firmware from.
Our theory is that the while loop without delay blocked the system thread from successfully setting up the new client, creating a blocking loop.