### PR TITLE
Fix PWM not setting desired state again if it changed twice while the target was constrained

### DIFF
--- a/lib/src/ActuatorPwm.cpp
+++ b/lib/src/ActuatorPwm.cpp
@@ -140,10 +140,10 @@ ActuatorPwm::slowPwmUpdate(const update_t& now)
         auto twoPeriodHighTime = previousHighTime + currentHighTime;
 
         auto wait = duration_millis_t(0);
-        auto currentState = actPtr->state();
+        auto currentDesiredState = actPtr->desiredState();
         auto invDutyTime = m_period - m_dutyTime;
 
-        if (currentState == State::Active) {
+        if (currentDesiredState == State::Active) {
             if (m_dutySetting == value_t(100)) {
                 m_dutyAchieved = 100;
                 return now + 1000;
@@ -185,8 +185,7 @@ ActuatorPwm::slowPwmUpdate(const update_t& now)
                     }
                 }
             }
-            m_valueValid = true;
-        } else if (currentState == State::Inactive) {
+        } else if (currentDesiredState == State::Inactive) {
             if (m_dutySetting == value_t(0)) {
                 m_dutyAchieved = 0;
                 return now + 1000;
@@ -229,16 +228,14 @@ ActuatorPwm::slowPwmUpdate(const update_t& now)
                     }
                 }
             }
-            m_valueValid = true;
-        } else {
-            m_valueValid = false;
         }
 
         bool toggled = false;
+        auto currentState = actPtr->state();
 
         // Toggle actuator if necessary
-        if (m_enabled && m_settingValid && wait == 0) {
-            if (currentState == State::Inactive) {
+        if (m_enabled && m_settingValid && (wait == 0 || currentState != currentDesiredState)) {
+            if (currentDesiredState == State::Inactive) {
                 actPtr->desiredState(State::Active, now);
             } else {
                 actPtr->desiredState(State::Inactive, now);
@@ -253,12 +250,17 @@ ActuatorPwm::slowPwmUpdate(const update_t& now)
             m_dutyAchieved = 0;
         } else {
             // calculate achieved duty cycle
-            auto dutyAchieved = (value_t(100) * twoPeriodHighTime) / twoPeriodElapsed;
-            if (toggled // end of high or low time or
-                        // current period is long enough to start using the current achieved value including this period
-                || (currentState == State::Inactive && dutyAchieved < m_dutyAchieved)
-                || (currentState == State::Active && dutyAchieved > m_dutyAchieved)) {
-                m_dutyAchieved = dutyAchieved;
+            if (currentState == State::Unknown) {
+                m_valueValid = false;
+            } else {
+                auto dutyAchieved = (value_t(100) * twoPeriodHighTime) / twoPeriodElapsed;
+                if (toggled // end of high or low time or
+                            // current period is long enough to start using the current achieved value including this period
+                    || (currentState == State::Inactive && dutyAchieved < m_dutyAchieved)
+                    || (currentState == State::Active && dutyAchieved > m_dutyAchieved)) {
+                    m_dutyAchieved = dutyAchieved;
+                    m_valueValid = true;
+                }
             }
         }
 

--- a/lib/test/ActuatorPwm_test.cpp
+++ b/lib/test/ActuatorPwm_test.cpp
@@ -591,9 +591,9 @@ SCENARIO("ActuatorPWM driving mock actuator", "[pwm]")
             for (; now < 100000; now += 100) {
                 if (now >= nextUpdate) {
                     nextUpdate = pwm.update(now);
-                }
-                if (now > 50000) {
-                    CHECK(pwm.value() == Approx(10).margin(2));
+                    if (now > 60000) {
+                        CHECK(pwm.value() == Approx(10).margin(2));
+                    }
                 }
             }
         }


### PR DESCRIPTION
This PR fixes this scenario:
- The digital actuator is constrained and cannot go high
- PWM wants to turn actuator on -> desired state set to 1
- PWM value changes to zero, sees actuator state already 0 due to constraint, performs no write

result: desired state left at 1 while it should be 0