### PR TITLE
Allow PID integral to cross zero to reduce alternating between heating/cooling

### DIFF
--- a/lib/src/Pid.cpp
+++ b/lib/src/Pid.cpp
@@ -108,13 +108,16 @@ Pid::update()
                         }
                     }
 
-                    // make sure integral does not cross zero and does not increase by anti-windup
-                    integral_t newIntegral = m_integral - antiWindup;
-                    if (m_integral >= 0) {
-                        m_integral = std::clamp(newIntegral, integral_t(0), m_integral);
-                    } else {
-                        m_integral = std::clamp(newIntegral, m_integral, integral_t(0));
+                    // if integral has opposite sign to the proportional part, don't let anti-windup
+                    // increase the integral part past -10% of proportional part
+                    fp12_t limit = m_p * fp12_t{-0.1};
+                    if (m_p > 0 && m_i < limit) {
+                        return;
                     }
+                    if (m_p < 0 && m_i > limit) {
+                        return;
+                    }
+                    m_integral = m_integral - antiWindup;
                 }
             }
         }


### PR DESCRIPTION
The integral was not allowed to cross zero. This creates the following issue:

- Assume process with temperature loss to the environment and a heater and cooler.
- Temperature is fluctuating closely around the setpoint, so proportional part is zero for both PIDs
- Heater PID has a positive integral to offset temperature loss
- Cooler PID has the integral held at zero.

On a small fluctuation that moves the process temperature above the setpoint, the cooler will want to activate, because it has no built-up integral.
If it can activate, it can hold the mutex and block the heater.

This PR relaxes the limits on anti-windup, allowing the integral part to increase to up to -10% of the proportional part. 

TODO: Is this correct? Does it reduce alternating actuators?
