### PR TITLE
Announce mDNS every 5 minutes

### DIFF
--- a/app/brewblox/connectivity.cpp
+++ b/app/brewblox/connectivity.cpp
@@ -100,9 +100,12 @@ void
 manageConnections(uint32_t now)
 {
     static uint32_t lastConnect = 0;
+    static uint32_t lastAnnounce = 0;
     if (wifiIsConnected) {
-        if (!mdns_started) {
+        if ((!mdns_started) || ((now - lastAnnounce) > 300000)) {
+            // explicit announce every 5 minutes
             mdns_started = mdns.begin(true);
+            lastAnnounce = now;
         }
         if (!http_started) {
             http_started = httpserver.begin();


### PR DESCRIPTION
As a possible workaround that mDNS stops working and the service cannot find the Spark anymore, announce every 5 minutes.
Normally it is only request based, but maybe this helps.