### PR TITLE
Fix arm-gcc 5.3 compatibility, ci build with 5.3

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -3,7 +3,7 @@ resources:
     - repository: self
   containers: 
     - container: compiler
-      image: brewblox/firmware-compiler:arm-gcc-8
+      image: brewblox/firmware-compiler:arm-gcc-5
       
 trigger:
   tags:

--- a/docker/compiler/Dockerfile
+++ b/docker/compiler/Dockerfile
@@ -15,8 +15,11 @@ RUN apt-get update -q \
   && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 # install arm compiler
-ENV GCC_ARM_URL="https://armkeil.blob.core.windows.net/developer/Files/downloads/gnu-rm/8-2019q3/RC1.1/gcc-arm-none-eabi-8-2019-q3-update-linux.tar.bz2" \
-  GCC_ARM_VERSION="8-2019-q3-update"
+ENV GCC_ARM_URL="https://launchpad.net/gcc-arm-embedded/5.0/5-2016-q1-update/+download/gcc-arm-none-eabi-5_3-2016q1-20160330-linux.tar.bz2" \
+  GCC_ARM_VERSION="5_3-2016q1"
+
+# ENV GCC_ARM_URL="https://armkeil.blob.core.windows.net/developer/Files/downloads/gnu-rm/8-2019q3/RC1.1/gcc-arm-none-eabi-8-2019-q3-update-linux.tar.bz2" \
+#  GCC_ARM_VERSION="8-2019-q3-update"  
 
 RUN dpkg --add-architecture i386 \
   && apt-get update -q \

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "2"
 services:
     compiler:
-        image: brewblox/firmware-compiler:arm-gcc-8
+        image: brewblox/firmware-compiler:arm-gcc-5
         container_name: firmware-compiler
         privileged: true
         environment:

--- a/lib/inc/FixedPoint.h
+++ b/lib/inc/FixedPoint.h
@@ -2,6 +2,14 @@
 
 #ifdef __arm__
 #define CNL_RELEASE true
+
+#include <string>
+// forward declare std::to_string. Arm gcc 5.3 compiler cannot find it in headers and cnl has references to it in headers
+namespace std {
+template <typename T>
+string to_string(T);
+}
+
 #endif
 
 #define CNL_USE_INT128 false

--- a/lib/src/FixedPoint.cpp
+++ b/lib/src/FixedPoint.cpp
@@ -19,6 +19,9 @@
 
 #include "FixedPoint.h"
 
+// workaround for arm 5.3 not having some to_string functions
+#include <string_operators.h>
+
 std::string
 to_string_dec(const fp12_t& t, uint8_t decimals)
 {
@@ -31,7 +34,9 @@ to_string_dec(const fp12_t& t, uint8_t decimals)
 
     auto rounder = (t >= 0) ? calc_t{0.5} : calc_t{-0.5};
     auto asInt = static_cast<int32_t>(scale * calc_t{t} + rounder);
-    auto s = std::to_string(asInt);
+
+    std::string s;
+    s << asInt;
 
     int missingZeros = int(decimals) + 1 - s.length() + (asInt < 0);
     auto insertAt = s.begin() + (asInt < 0);

--- a/lib/test/makefile
+++ b/lib/test/makefile
@@ -52,7 +52,6 @@ CPPFLAGS += -isystem $(BOOST_ROOT)
 
 CFLAGS += $(patsubst %,-I%,$(INCLUDE_DIRS)) -I.
 CFLAGS += -ffunction-sections -Wall
-CFLAGS += -ffunction-sections -Wall
 CFLAGS += -Wno-deprecated
 CFLAGS += -Wnull-dereference 
 CPPFLAGS += -fdiagnostics-show-template-tree -fno-elide-type # GCC8 required


### PR DESCRIPTION
Particle still only supports arm-gcc 5.3. Boo!

To be safe, we'll build our firmware with 5.3 too.