### PR TITLE
Configurable fluctuations in mock sensor

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -50,12 +50,12 @@
       "type": "cppdbg",
       "request": "launch",
       "program": "${workspaceFolder}/app/brewblox/test/build/brewblox_test_runner",
-      "args": [],
       "stopAtEntry": false,
       "cwd": "${workspaceFolder}",
       "environment": [
         {
-          "LSAN_OPTIONS": "verbosity=1:log_threads=1"
+          "name": "LSAN_OPTIONS",
+          "value": "verbosity=1:log_threads=1"
         }
       ],
       "externalConsole": false,

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -171,10 +171,30 @@
       "problemMatcher": "$gcc"
     },
     {
-      "label": "restart_compiler",
+      "label": "start_compiler",
       "command": "bash",
       "args": [
         "start-compiler.sh"
+      ],
+      "group": "build",
+      "options": {
+        "cwd": "${workspaceFolder}/docker"
+      },
+      "presentation": {
+        "echo": true,
+        "reveal": "always",
+        "focus": true,
+        "panel": "shared",
+        "showReuseMessage": false,
+        "clear": false
+      },
+      "problemMatcher": "$gcc"
+    },
+    {
+      "label": "restart_compiler",
+      "command": "bash",
+      "args": [
+        "start-compiler.sh -r"
       ],
       "group": "build",
       "options": {

--- a/app/brewblox/test/AcutatorOffsetBlock_test.cpp
+++ b/app/brewblox/test/AcutatorOffsetBlock_test.cpp
@@ -43,7 +43,7 @@ SCENARIO("A Blox ActuatorOffset object can be created from streamed protobuf dat
     testBox.put(TempSensorMockBlock::staticTypeId());
 
     auto newSensor1 = blox::TempSensorMock();
-    newSensor1.set_value(cnl::unwrap(temp_t(21.0)));
+    newSensor1.set_setting(cnl::unwrap(temp_t(21.0)));
     newSensor1.set_connected(true);
     testBox.put(newSensor1);
 
@@ -74,7 +74,7 @@ SCENARIO("A Blox ActuatorOffset object can be created from streamed protobuf dat
     testBox.put(TempSensorMockBlock::staticTypeId());
 
     auto newSensor2 = blox::TempSensorMock();
-    newSensor2.set_value(cnl::unwrap(temp_t(27.0)));
+    newSensor2.set_setting(cnl::unwrap(temp_t(27.0)));
     newSensor2.set_connected(true);
     testBox.put(newSensor2);
 

--- a/app/brewblox/test/PidBlock_test.cpp
+++ b/app/brewblox/test/PidBlock_test.cpp
@@ -52,7 +52,7 @@ SCENARIO("A Blox Pid object with mock analog actuator")
     testBox.put(TempSensorMockBlock::staticTypeId());
 
     auto newSensor = blox::TempSensorMock();
-    newSensor.set_value(cnl::unwrap(temp_t(20.0)));
+    newSensor.set_setting(cnl::unwrap(temp_t(20.0)));
     newSensor.set_connected(true);
     testBox.put(newSensor);
 
@@ -222,7 +222,7 @@ SCENARIO("A Blox Pid object with mock analog actuator")
         testBox.put(TempSensorMockBlock::staticTypeId());
 
         auto newSensor = blox::TempSensorMock();
-        newSensor.set_value(cnl::unwrap(temp_t(99.5)));
+        newSensor.set_setting(cnl::unwrap(temp_t(99.5)));
         newSensor.set_connected(true);
         testBox.put(newSensor);
 

--- a/app/brewblox/test/SetpointProfileBlock_test.cpp
+++ b/app/brewblox/test/SetpointProfileBlock_test.cpp
@@ -51,7 +51,7 @@ SCENARIO("A SetpointProfile block")
             testBox.put(TempSensorMockBlock::staticTypeId());
 
             auto newSensor = blox::TempSensorMock();
-            newSensor.set_value(cnl::unwrap(temp_t(20.0)));
+            newSensor.set_setting(cnl::unwrap(temp_t(20.0)));
             newSensor.set_connected(true);
             testBox.put(newSensor);
 

--- a/app/brewblox/test/SetpointSensorPairBlock_test.cpp
+++ b/app/brewblox/test/SetpointSensorPairBlock_test.cpp
@@ -50,7 +50,7 @@ SCENARIO("A Blox SetpointSensorPair object can be created from streamed protobuf
     testBox.put(TempSensorMockBlock::staticTypeId());
 
     auto newSensor = blox::TempSensorMock();
-    newSensor.set_value(cnl::unwrap(temp_t(20.0)));
+    newSensor.set_setting(cnl::unwrap(temp_t(20.0)));
     newSensor.set_connected(true);
     testBox.put(newSensor);
 
@@ -132,7 +132,7 @@ SCENARIO("A Blox SetpointSensorPair object can be created from streamed protobuf
         auto ptr = cboxPtr.lock();
         REQUIRE(ptr);
 
-        ptr->get().value(25);
+        ptr->get().setting(25);
 
         testBox.update(1000);
 

--- a/app/brewblox/test/TempSensorMockBlock_test.cpp
+++ b/app/brewblox/test/TempSensorMockBlock_test.cpp
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2018 BrewPi B.V.
+ *
+ * This file is part of BrewBlox.
+ *
+ * BrewPi is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * BrewPi is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with BrewPi.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <catch.hpp>
+#include <cstdio>
+#include <iomanip>
+#include <iostream>
+
+#include "../BrewBlox.h"
+#include "BrewBloxTestBox.h"
+#include "Temperature.h"
+#include "blox/TempSensorMockBlock.h"
+#include "cbox/Box.h"
+#include "cbox/DataStream.h"
+#include "cbox/DataStreamIo.h"
+#include "cbox/Object.h"
+#include "proto/test/cpp/TempSensorMock_test.pb.h"
+#include "testHelpers.h"
+
+SCENARIO("A TempSensorMock block")
+{
+    BrewBloxTestBox testBox;
+    using commands = cbox::Box::CommandID;
+
+    testBox.reset();
+
+    // create mock sensor
+    testBox.put(uint16_t(0)); // msg id
+    testBox.put(commands::CREATE_OBJECT);
+    testBox.put(cbox::obj_id_t(100));
+    testBox.put(uint8_t(0xFF));
+    testBox.put(TempSensorMockBlock::staticTypeId());
+
+    auto newSensor = blox::TempSensorMock();
+    newSensor.set_setting(cnl::unwrap(temp_t(20.0)));
+    newSensor.set_connected(true);
+    testBox.put(newSensor);
+
+    testBox.processInput();
+    CHECK(testBox.lastReplyHasStatusOk());
+
+    WHEN("The mock sensor value is changed to 25")
+    {
+        auto cboxPtr = brewbloxBox().makeCboxPtr<TempSensorMockBlock>(100);
+        auto ptr = cboxPtr.lock();
+        REQUIRE(ptr);
+
+        ptr->get().setting(25);
+
+        testBox.update(1000);
+
+        THEN("The value that is read back is correct")
+        {
+            // read pair
+            testBox.put(uint16_t(0)); // msg id
+            testBox.put(commands::READ_OBJECT);
+            testBox.put(cbox::obj_id_t(100));
+
+            auto decoded = blox::TempSensorMock();
+            testBox.processInputToProto(decoded);
+
+            CHECK(testBox.lastReplyHasStatusOk());
+            CHECK(decoded.ShortDebugString() == "value: 102400 connected: true setting: 102400");
+        }
+    }
+
+    WHEN("Fluctuations are set")
+    {
+
+        testBox.put(uint16_t(0)); // msg id
+        testBox.put(commands::WRITE_OBJECT);
+        testBox.put(cbox::obj_id_t(100));
+        testBox.put(uint8_t(0xFF));
+        testBox.put(TempSensorMockBlock::staticTypeId());
+
+        auto newSensor = blox::TempSensorMock();
+        newSensor.set_setting(cnl::unwrap(temp_t(20.0)));
+        newSensor.set_connected(true);
+
+        {
+            auto newFluct = newSensor.add_fluctuations();
+            newFluct->set_amplitude(cnl::unwrap(temp_t{2}));
+            newFluct->set_period(2000);
+        }
+
+        {
+            auto newFluct = newSensor.add_fluctuations();
+            newFluct->set_amplitude(cnl::unwrap(temp_t{3}));
+            newFluct->set_period(3000);
+        }
+
+        testBox.put(newSensor);
+
+        testBox.processInput();
+        CHECK(testBox.lastReplyHasStatusOk());
+
+        testBox.update(1000);
+
+        THEN("The value that is read back is correct")
+        {
+            // read pair
+            testBox.put(uint16_t(0)); // msg id
+            testBox.put(commands::READ_OBJECT);
+            testBox.put(cbox::obj_id_t(100));
+
+            auto decoded = blox::TempSensorMock();
+            testBox.processInputToProto(decoded);
+
+            CHECK(testBox.lastReplyHasStatusOk());
+            CHECK(decoded.ShortDebugString() == "value: 90856 connected: true setting: 81920 fluctuations { amplitude: 8192 period: 2000 } fluctuations { amplitude: 12288 period: 3000 }");
+        }
+    }
+}

--- a/docker/firmware-compiler/amd/Dockerfile
+++ b/docker/firmware-compiler/amd/Dockerfile
@@ -7,7 +7,7 @@ ENV TZ=Europe/Amsterdam \
 # install various build deps
 RUN apt-get update -q \
   && apt-get install -qy curl \
-  && apt-get install -qy --no-install-recommends build-essential autoconf automake libtool unzip pkg-config libprotobuf-dev protobuf-compiler tzdata git bash dfu-util python python-pip gdb lcov rsync colormake \
+  && apt-get install -qy --no-install-recommends build-essential autoconf automake libtool unzip pkg-config libprotobuf-dev protobuf-compiler tzdata git bash dfu-util python python-pip gdb lcov rsync \
   && pip install --upgrade pip setuptools \
   # and install protobuf python package (used by nanopb), and pyserial (used by program-dfu)
   && pip install protobuf pyserial compiledb \

--- a/docker/start-compiler.sh
+++ b/docker/start-compiler.sh
@@ -3,7 +3,17 @@ set -e
 
 pushd "$(dirname "$(readlink -f "$0")")" > /dev/null
 
-docker-compose down
+while getopts ":r" opt; do
+  case $opt in
+    r)
+      docker-compose down # pass -r to restart, without -r will only guarantee up
+      ;;
+    \?)
+      echo "Invalid option: -$OPTARG" >&2
+      ;;
+  esac
+done
+
 touch .env
 ENV_MOUNTDIR="$(grep MOUNTDIR .env)"
 

--- a/lib/inc/ActuatorDigitalConstrained.h
+++ b/lib/inc/ActuatorDigitalConstrained.h
@@ -159,7 +159,7 @@ public:
         return m_desiredState;
     }
 
-    const std::vector<std::unique_ptr<Constraint>>&
+    const auto&
     constraintsList() const
     {
         return constraints;

--- a/lib/inc/ActuatorPwm.h
+++ b/lib/inc/ActuatorPwm.h
@@ -48,15 +48,12 @@ private:
     bool m_settingValid = true;
     bool m_valueValid = true;
 
-    static constexpr const auto maxDuty()
+    static constexpr value_t maxDuty()
     {
         return value_t{100};
     }
 
-    auto dutyFraction() const
-    {
-        return safe_elastic_fixed_point<2, 29>(cnl::quotient(m_dutySetting + (cnl::numeric_limits<value_t>::min() >> 1), maxDuty()));
-    }
+    safe_elastic_fixed_point<2, 28> dutyFraction() const;
 
     // separate flag for manually disabling the pwm actuator
     bool m_enabled = true;

--- a/lib/inc/TempSensorMock.h
+++ b/lib/inc/TempSensorMock.h
@@ -26,8 +26,8 @@
 
 class TempSensorMock final : public TempSensor {
 private:
-    temp_t m_value = 0;
-    temp_t m_valueWithFluctuations = 0;
+    temp_t m_setting = 0;
+    temp_t m_fluctuationsSum = 0;
     bool m_connected = false;
 
 public:
@@ -45,15 +45,18 @@ public:
     }
 
     TempSensorMock(temp_t initial)
-        : m_value(initial)
-        , m_valueWithFluctuations(initial)
+        : m_setting(initial)
+        , m_fluctuationsSum(0)
         , m_connected(true)
     {
     }
 
     void fluctuations(std::vector<Fluctuation>&& arg);
 
-    const std::vector<Fluctuation>& fluctuations();
+    const std::vector<Fluctuation>& fluctuations() const
+    {
+        return m_fluctuations;
+    }
 
     void connected(bool _connected)
     {
@@ -65,15 +68,19 @@ public:
         return m_connected;
     }
 
-    void value(temp_t val)
+    void setting(temp_t val)
     {
-        m_value = val;
-        m_valueWithFluctuations = val;
+        m_setting = val;
+    }
+
+    temp_t setting() const
+    {
+        return m_setting;
     }
 
     temp_t value() const override final
     {
-        return m_valueWithFluctuations;
+        return m_setting + m_fluctuationsSum;
     }
 
     virtual bool valid() const override final
@@ -83,7 +90,7 @@ public:
 
     void add(temp_t delta)
     {
-        m_value += delta;
+        m_setting += delta;
     }
 
     void update(ticks_millis_t now);

--- a/lib/inc/TempSensorMock.h
+++ b/lib/inc/TempSensorMock.h
@@ -21,11 +21,23 @@
 
 #include "TempSensor.h"
 #include "Temperature.h"
+#include "TicksTypes.h"
+#include <vector>
 
 class TempSensorMock final : public TempSensor {
 private:
     temp_t m_value = 0;
+    temp_t m_valueWithFluctuations = 0;
     bool m_connected = false;
+
+public:
+    struct Fluctuation {
+        temp_t amplitude;
+        duration_millis_t period;
+    };
+
+private:
+    std::vector<Fluctuation> m_fluctuations;
 
 public:
     TempSensorMock()
@@ -34,9 +46,14 @@ public:
 
     TempSensorMock(temp_t initial)
         : m_value(initial)
+        , m_valueWithFluctuations(initial)
         , m_connected(true)
     {
     }
+
+    void fluctuations(std::vector<Fluctuation>&& arg);
+
+    const std::vector<Fluctuation>& fluctuations();
 
     void connected(bool _connected)
     {
@@ -51,11 +68,12 @@ public:
     void value(temp_t val)
     {
         m_value = val;
+        m_valueWithFluctuations = val;
     }
 
     temp_t value() const override final
     {
-        return m_value;
+        return m_valueWithFluctuations;
     }
 
     virtual bool valid() const override final
@@ -67,4 +85,6 @@ public:
     {
         m_value += delta;
     }
+
+    void update(ticks_millis_t now);
 };

--- a/lib/src/ActuatorAnalogConstrained.cpp
+++ b/lib/src/ActuatorAnalogConstrained.cpp
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2018 BrewPi B.V.
+ *
+ * This file is part of the BrewBlox Control Library.
+ *
+ * BrewPi is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * BrewPi is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with BrewPi.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "ActuatorAnalogConstrained.h"
+#include <algorithm>
+
+using value_t = ActuatorAnalog::value_t;
+
+void
+ActuatorAnalogConstrained::addConstraint(std::unique_ptr<Constraint>&& newConstraint)
+{
+    if (constraints.size() < 8) {
+        constraints.push_back(std::move(newConstraint));
+    }
+
+    std::sort(constraints.begin(), constraints.end(),
+              [](const std::unique_ptr<Constraint>& a, const std::unique_ptr<Constraint>& b) { return a->order() < b->order(); });
+}
+
+void
+ActuatorAnalogConstrained::removeAllConstraints()
+{
+    constraints.clear();
+}
+
+value_t
+ActuatorAnalogConstrained::constrain(const value_t& val)
+{
+    // keep track of which constraints limit the setting in a bitfield
+    m_limiting = 0x00;
+    uint8_t bit = 0x01;
+
+    value_t result = val;
+
+    for (auto& c : constraints) {
+        auto constrained = c->constrain(result);
+        if (constrained != result) {
+            m_limiting = m_limiting | bit;
+            result = constrained;
+        }
+        bit = bit << 1;
+    }
+
+    return result;
+}
+
+void
+ActuatorAnalogConstrained::setting(const value_t& val)
+{
+    // first set actuator to requested value to check whether it constrains the setting itself
+    actuator.setting(val);
+    m_desiredSetting = actuator.setting();
+
+    // then set it to the constrained value
+    if (actuator.settingValid()) {
+        actuator.setting(constrain(m_desiredSetting));
+    } else {
+        constrain(0);
+    }
+}
+
+void
+ActuatorAnalogConstrained::settingValid(bool v)
+{
+    auto old = actuator.settingValid();
+    actuator.settingValid(v);
+    if (old != actuator.settingValid()) {
+        // update constraints state in case setting valid has changed the limits inside the actuator itself
+        constrain(actuator.setting());
+    }
+}

--- a/lib/src/Balancer.cpp
+++ b/lib/src/Balancer.cpp
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2018 BrewPi B.V.
+ *
+ * This file is part of the BrewBlox Control Library.
+ *
+ * BrewPi is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * BrewPi is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with BrewPi.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "Balancer.h"
+
+using value_t = ActuatorAnalog::value_t;
+
+uint8_t
+BalancerImpl::registerEntry()
+{
+    for (uint8_t id = 1; id < 255; id++) {
+        // find free id
+        auto match = find_if(requesters.begin(), requesters.end(), [&id](const Request& r) {
+            return r.id == id;
+        });
+
+        if (match == requesters.end()) {
+            requesters.push_back(Request{id, available, 0});
+            return id;
+        }
+    };
+    return 0;
+}
+
+void
+BalancerImpl::unregisterEntry(const uint8_t& requester_id)
+{
+    requesters.erase(std::remove_if(requesters.begin(), requesters.end(), [&requester_id](const Request& r) { return r.id == requester_id; }),
+                     requesters.end());
+}
+
+value_t
+BalancerImpl::constrain(uint8_t& requester_id, const value_t& val)
+{
+    auto match = find_if(requesters.begin(), requesters.end(), [&requester_id](const Request& r) {
+        return r.id == requester_id;
+    });
+
+    if (match != requesters.end()) {
+        match->requested = val;
+        return std::min(val, match->granted);
+    };
+
+    // not found. Could happen is actuator was created before the balancer.
+    // assign new requester id
+    requester_id = registerEntry();
+    return 0;
+}
+
+value_t
+BalancerImpl::granted(const uint8_t& requester_id) const
+{
+    auto match = find_if(requesters.begin(), requesters.end(), [&requester_id](const Request& r) {
+        return r.id == requester_id;
+    });
+
+    if (match == requesters.end()) {
+        return 0;
+    }
+
+    return match->granted;
+}
+
+void
+BalancerImpl::update()
+{
+    int8_t numActuators = requesters.size(); // signed, because value_t is signed too
+    if (numActuators == 0) {
+        return;
+    }
+
+    auto requestedTotal = value_t(0);
+    for (const auto& a : requesters) {
+        requestedTotal += a.requested;
+    }
+    auto budgetLeft = value_t(0);
+    if (available > requestedTotal) {
+        budgetLeft = available - requestedTotal;
+        requestedTotal = available;
+    }
+    auto budgetLeftPerActuator = value_t(cnl::quotient(budgetLeft, numActuators));
+
+    safe_elastic_fixed_point<10, 21> scale = cnl::quotient(available, requestedTotal);
+
+    for (auto& a : requesters) {
+        a.granted = a.requested * scale;
+        a.granted += budgetLeftPerActuator;
+    }
+}

--- a/lib/src/TempSensorMock.cpp
+++ b/lib/src/TempSensorMock.cpp
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2020 BrewPi B.V.
+ *
+ * This file is part of the BrewBlox Control Library.
+ *
+ * BrewPi is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * BrewPi is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with BrewPi.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "TempSensorMock.h"
+temp_t
+calcFluctuation(const TempSensorMock::Fluctuation& f, ticks_millis_t now)
+{
+    // use simple first order approximation of sinus for periodic signal, without using floats
+    // sin(x) -> x - x^3 / 3!
+    // This crosses zero at crosses -1/sqrt(6) and 1/sqrt(6), scale so -500 and 500 will cross zero:
+    // t / 240 - t^3 / 50937984, for -500 < t < 500, max amplitude still 1.
+    int32_t t = 500 - ((now * 1000 / f.period)) % 1000; // value -500 to 499
+    auto result = (t * f.amplitude) / 204 - (int32_t(t * t * t) * f.amplitude) / int32_t{50937984};
+    return result;
+}
+
+void
+TempSensorMock::update(ticks_millis_t now)
+{
+    m_valueWithFluctuations = m_value;
+    for (const auto& f : m_fluctuations) {
+        m_valueWithFluctuations += calcFluctuation(f, now);
+    }
+}
+
+void
+TempSensorMock::fluctuations(std::vector<Fluctuation>&& arg)
+{
+    m_fluctuations = arg;
+}

--- a/lib/src/TempSensorMock.cpp
+++ b/lib/src/TempSensorMock.cpp
@@ -21,6 +21,10 @@
 temp_t
 calcFluctuation(const TempSensorMock::Fluctuation& f, ticks_millis_t now)
 {
+    if (f.period == 0) {
+        return f.amplitude;
+    }
+
     // use simple first order approximation of sinus for periodic signal, without using floats
     // sin(x) -> x - x^3 / 3!
     // This crosses zero at crosses -1/sqrt(6) and 1/sqrt(6), scale so -500 and 500 will cross zero:

--- a/lib/src/TempSensorMock.cpp
+++ b/lib/src/TempSensorMock.cpp
@@ -30,7 +30,7 @@ calcFluctuation(const TempSensorMock::Fluctuation& f, ticks_millis_t now)
     // This crosses zero at crosses -1/sqrt(6) and 1/sqrt(6), scale so -500 and 500 will cross zero:
     // t / 240 - t^3 / 50937984, for -500 < t < 500, max amplitude still 1.
     int32_t t = 500 - ((now * 1000 / f.period)) % 1000; // value -500 to 499
-    auto result = (t * f.amplitude) / 204 - (int32_t(t * t * t) * f.amplitude) / int32_t{50937984};
+    temp_t result = temp_t{safe_elastic_fixed_point<2, 28>(cnl::quotient(t, int32_t{204})) * f.amplitude} - temp_t{safe_elastic_fixed_point<2, 28>(cnl::quotient(int32_t(t * t * t), int32_t{50937984})) * f.amplitude};
     return result;
 }
 

--- a/lib/src/TempSensorMock.cpp
+++ b/lib/src/TempSensorMock.cpp
@@ -33,9 +33,9 @@ calcFluctuation(const TempSensorMock::Fluctuation& f, ticks_millis_t now)
 void
 TempSensorMock::update(ticks_millis_t now)
 {
-    m_valueWithFluctuations = m_value;
+    m_fluctuationsSum = 0;
     for (const auto& f : m_fluctuations) {
-        m_valueWithFluctuations += calcFluctuation(f, now);
+        m_fluctuationsSum += calcFluctuation(f, now);
     }
 }
 

--- a/lib/test/ActuatorOffset_test.cpp
+++ b/lib/test/ActuatorOffset_test.cpp
@@ -51,7 +51,7 @@ SCENARIO("ActuatorOffset offsets one setpoint from another", "[ActuatorOffset]")
         CHECK(act->setting() == 10.0); // difference between setpoints is now 10
         CHECK(act->value() == 0.0);    // actual value is still zero, because targetSensor has not changed
 
-        targetSensor->value(30.0);
+        targetSensor->setting(30.0);
         target->resetFilter();
         act->update();
         CHECK(act->value() == 10.0); // actual value is 10 when sensor has reached setpoint
@@ -64,16 +64,16 @@ SCENARIO("ActuatorOffset offsets one setpoint from another", "[ActuatorOffset]")
 
         CHECK(act->value() == 10.0); // value is still 10, because targetSensor has not changed
 
-        targetSensor->value(10.0);
+        targetSensor->setting(10.0);
         target->resetFilter();
         act->update();
         CHECK(act->value() == -10.0); // value is -10 when sensor has reached setpoint
 
         reference->setting(10.0);
-        referenceSensor->value(15.0);
+        referenceSensor->setting(15.0);
         reference->resetFilter();
         target->setting(20.0);
-        targetSensor->value(20.0);
+        targetSensor->setting(20.0);
         target->resetFilter();
         act->setting(12.0);
 

--- a/lib/test/PidTest.cpp
+++ b/lib/test/PidTest.cpp
@@ -56,7 +56,7 @@ SCENARIO("PID Test with mock actuator", "[pid]")
 
         for (int32_t i = 0; i < 1000; ++i) {
             input->setting(21);
-            sensor->value(20);
+            sensor->setting(20);
         }
 
         input->update();
@@ -72,7 +72,7 @@ SCENARIO("PID Test with mock actuator", "[pid]")
         pid.td(100);
 
         input->setting(21);
-        sensor->value(20);
+        sensor->setting(20);
         input->resetFilter();
 
         for (int32_t i = 0; i < 1000; ++i) {
@@ -93,7 +93,7 @@ SCENARIO("PID Test with mock actuator", "[pid]")
         pid.td(0);
 
         input->setting(21);
-        sensor->value(20);
+        sensor->setting(20);
         input->resetFilter();
 
         for (int32_t i = 0; i < 1000; ++i) {
@@ -124,14 +124,14 @@ SCENARIO("PID Test with mock actuator", "[pid]")
         pid.td(200);
 
         input->setting(30);
-        sensor->value(20);
+        sensor->setting(20);
         input->resetFilter();
 
         fp12_t mockVal;
         double accumulatedError = 0;
         for (int32_t i = 0; i <= 900; ++i) {
             mockVal = fp12_t(20.0 + 9.0 * i / 900);
-            sensor->value(mockVal);
+            sensor->setting(mockVal);
             input->update();
             pid.update();
             accumulatedError += pid.error();
@@ -154,14 +154,14 @@ SCENARIO("PID Test with mock actuator", "[pid]")
         pid.td(200);
 
         input->setting(20);
-        sensor->value(30);
+        sensor->setting(30);
         input->resetFilter();
 
         fp12_t mockVal;
         double accumulatedError = 0;
         for (int32_t i = 0; i <= 900; ++i) {
             mockVal = fp12_t(30.0 - (9.0 * i) / 900);
-            sensor->value(mockVal);
+            sensor->setting(mockVal);
             input->update();
             pid.update();
             accumulatedError += pid.error();
@@ -184,7 +184,7 @@ SCENARIO("PID Test with mock actuator", "[pid]")
         pid.td(200);
 
         input->setting(21);
-        sensor->value(20);
+        sensor->setting(20);
         input->resetFilter();
         actuator->minSetting(0);
         actuator->maxSetting(20);
@@ -230,7 +230,7 @@ SCENARIO("PID Test with mock actuator", "[pid]")
         pid.td(200);
 
         input->setting(19);
-        sensor->value(20);
+        sensor->setting(20);
         input->resetFilter();
         actuator->minSetting(0);
         actuator->maxSetting(20);
@@ -275,7 +275,7 @@ SCENARIO("PID Test with mock actuator", "[pid]")
         pid.td(200);
 
         input->setting(21);
-        sensor->value(20);
+        sensor->setting(20);
         input->resetFilter();
         actuator->minValue(5);
         actuator->maxValue(20);
@@ -319,7 +319,7 @@ SCENARIO("PID Test with mock actuator", "[pid]")
         pid.td(200);
 
         input->setting(19);
-        sensor->value(20);
+        sensor->setting(20);
         input->resetFilter();
         actuator->minValue(5);
         actuator->maxValue(20);
@@ -363,7 +363,7 @@ SCENARIO("PID Test with mock actuator", "[pid]")
         pid.td(200);
 
         input->setting(21);
-        sensor->value(20);
+        sensor->setting(20);
         input->resetFilter();
 
         int32_t i = 0;
@@ -554,7 +554,7 @@ SCENARIO("PID Test with PWM actuator", "[pid]")
         pid.td(0);
 
         input->setting(21);
-        sensor->value(20);
+        sensor->setting(20);
         input->resetFilter();
 
         run1000seconds();
@@ -569,7 +569,7 @@ SCENARIO("PID Test with PWM actuator", "[pid]")
         pid.td(0);
 
         input->setting(21);
-        sensor->value(20);
+        sensor->setting(20);
         input->resetFilter();
 
         run1000seconds();
@@ -594,7 +594,7 @@ SCENARIO("PID Test with PWM actuator", "[pid]")
         pid.td(200);
 
         input->setting(30);
-        sensor->value(20);
+        sensor->setting(20);
         input->resetFilter();
 
         fp12_t mockVal;
@@ -607,7 +607,7 @@ SCENARIO("PID Test with PWM actuator", "[pid]")
             }
             if (now >= nextPidUpdate) {
                 mockVal = fp12_t(20.0 + 9.0 * (now - start) / 900'000);
-                sensor->value(mockVal);
+                sensor->setting(mockVal);
                 input->update();
                 pid.update();
                 actuator->update();
@@ -633,7 +633,7 @@ SCENARIO("PID Test with PWM actuator", "[pid]")
         pid.td(200);
 
         input->setting(20);
-        sensor->value(30);
+        sensor->setting(30);
         input->resetFilter();
 
         fp12_t mockVal;
@@ -646,7 +646,7 @@ SCENARIO("PID Test with PWM actuator", "[pid]")
             }
             if (now >= nextPidUpdate) {
                 mockVal = fp12_t(30.0 - 9.0 * (now - start) / 900'000);
-                sensor->value(mockVal);
+                sensor->setting(mockVal);
                 input->update();
                 pid.update();
                 actuator->update();
@@ -887,7 +887,7 @@ SCENARIO("PID Test with PWM actuator", "[pid]")
             pid.td(td);
             auto start = now;
             auto dMin = Pid::out_t(0);
-            sensor->value(20);
+            sensor->setting(20);
             input->resetFilter();
 
             while (now <= start + 2000'000) {
@@ -895,7 +895,7 @@ SCENARIO("PID Test with PWM actuator", "[pid]")
                     nextPwmUpdate = pwm.update(now);
                 }
                 if (now == start + 10'000) {
-                    sensor->value(30);
+                    sensor->setting(30);
                 }
                 if (now >= nextPidUpdate) {
                     input->update();
@@ -931,7 +931,7 @@ SCENARIO("PID Test with PWM actuator", "[pid]")
         AND_WHEN("The setpoint is 99 and the actual temp is 98")
         {
             input->setting(99);
-            sensor->value(98);
+            sensor->setting(98);
             input->update();
             pid.update();
 
@@ -946,7 +946,7 @@ SCENARIO("PID Test with PWM actuator", "[pid]")
         AND_WHEN("The setpoint is 100 and the actual temp is 99")
         {
             input->setting(100);
-            sensor->value(99);
+            sensor->setting(99);
             input->update();
             pid.update();
 
@@ -962,7 +962,7 @@ SCENARIO("PID Test with PWM actuator", "[pid]")
         AND_WHEN("The setpoint is 100 and the actual temp is 100")
         {
             input->setting(100);
-            sensor->value(100);
+            sensor->setting(100);
             input->resetFilter();
             input->update();
             pid.update();

--- a/lib/test/TempSensorMock_test.cpp
+++ b/lib/test/TempSensorMock_test.cpp
@@ -24,7 +24,7 @@
 
 #include <math.h>
 
-SCENARIO("TempSensorMockTest")
+SCENARIO("TempSensorMockTest", "[mocktest]")
 {
 
     WHEN("A mock sensor is initialized without providing an initial value, it reads as invalid and 0")

--- a/lib/test/TempSensorMock_test.cpp
+++ b/lib/test/TempSensorMock_test.cpp
@@ -59,14 +59,48 @@ SCENARIO("TempSensorMockTest")
         }
     }
 
-    WHEN("Fluctuation test, WIP")
+    WHEN("Mock sensor has 1 fluctuation configured")
     {
         auto mock = TempSensorMock(20.0);
-        mock.fluctuations({{temp_t{1}, 3000}});
+        mock.fluctuations({{temp_t{2}, 3000}});
+
+        auto min = temp_t{20};
+        auto max = temp_t{20};
 
         for (ticks_millis_t t = 0; t <= 3000; t += 100) {
             mock.update(t);
-            CHECK(mock.value() == 0);
+            auto val = mock.value();
+            min = std::min(min, val);
+            max = std::max(max, val);
+        }
+        THEN("Minimum and maximum are at configured amplitude")
+        {
+            CHECK(min == Approx(18).epsilon(0.01));
+            CHECK(max == Approx(22).epsilon(0.01));
+        }
+        THEN("Flucutation is zero at full period")
+        {
+            CHECK(mock.value() == Approx(20).epsilon(0.01));
+        }
+    }
+
+    WHEN("Mock sensor has 2 fluctuations configured")
+    {
+        auto mock1 = TempSensorMock(20.0);
+        auto mock2 = TempSensorMock(20.0);
+        auto mock3 = TempSensorMock(20.0);
+        mock1.fluctuations({{temp_t{2}, 5000}});
+        mock2.fluctuations({{temp_t{0.5}, 1000}});
+        mock3.fluctuations({{temp_t{2}, 5000}, {temp_t{0.5}, 1000}});
+
+        THEN("The result is a superposition of the fluctuations")
+        {
+            for (ticks_millis_t t = 0; t <= 5000; t += 100) {
+                mock1.update(t);
+                mock2.update(t);
+                mock3.update(t);
+                CHECK(mock3.value() == mock1.value() + mock2.value() - temp_t{20.0});
+            }
         }
     }
 }

--- a/lib/test/TempSensorMock_test.cpp
+++ b/lib/test/TempSensorMock_test.cpp
@@ -58,4 +58,15 @@ SCENARIO("TempSensorMockTest")
             CHECK(mock.value() == temp_t(20.0));
         }
     }
+
+    WHEN("Fluctuation test, WIP")
+    {
+        auto mock = TempSensorMock(20.0);
+        mock.fluctuations({{temp_t{1}, 3000}});
+
+        for (ticks_millis_t t = 0; t <= 3000; t += 100) {
+            mock.update(t);
+            CHECK(mock.value() == 0);
+        }
+    }
 }

--- a/lib/test/TempSensorMock_test.cpp
+++ b/lib/test/TempSensorMock_test.cpp
@@ -84,6 +84,20 @@ SCENARIO("TempSensorMockTest")
         }
     }
 
+    WHEN("Mock the fluctuation period is zero")
+    {
+        auto mock = TempSensorMock(20.0);
+        mock.fluctuations({{temp_t{2}, 0}});
+
+        for (ticks_millis_t t = 0; t <= 1000; t += 100) {
+            mock.update(t);
+        }
+        THEN("The amplitude is added as a constant value")
+        {
+            CHECK(mock.value() == temp_t{22});
+        }
+    }
+
     WHEN("Mock sensor has 2 fluctuations configured")
     {
         auto mock1 = TempSensorMock(20.0);

--- a/wrapped_make.sh
+++ b/wrapped_make.sh
@@ -2,16 +2,13 @@
 
 MY_DIR=$(dirname "$(readlink -f "$0")")
 shopt -s globstar
-if [ -x "$(command -v colormake)" ]; then
-    # shellcheck disable=SC2068,SC2086
-    python -m compiledb make --cmd colormake $MAKE_ARGS $@
-    else
-    python -m compiledb make $MAKE_ARGS $@
+
+if python -m compiledb make $MAKE_ARGS $@; then
+    rm -f "$MY_DIR/compile_commands.json"
+    pushd "$MY_DIR" > /dev/null
+    cat ./**/compile_commands.json > compile_commands.json
+    sed -i -e ':a;N;$!ba;s/\]\n\n\[/,/g' compile_commands.json
+    chmod 777 compile_commands.json
+    popd > /dev/null
+    rm -f "compile_commands.json"
 fi
-rm -f "$MY_DIR/compile_commands.json"
-pushd "$MY_DIR" > /dev/null
-cat ./**/compile_commands.json > compile_commands.json
-sed -i -e ':a;N;$!ba;s/\]\n\n\[/,/g' compile_commands.json
-chmod 777 compile_commands.json
-popd > /dev/null
-rm "compile_commands.json"


### PR DESCRIPTION
Adds the possibility to set fluctuations in mock temperature sensor.

Mock sensor now accepts a vector of {amplitude, period}, which each generates a periodic sinus like signal that is added to the mocked value.

Breaking changes:
- Value is no longer settable, it is now read-only.
- Base value is now set with setting field

Other small changes tagging along:
- start compiler now only does 'docker-compose down' when the -r argument is passed. It is only needed after DFU triggers usually.
- using colormake was removed
