### PR TITLE
Add delayed ON and delayed OFF constraints

### DIFF
--- a/app/brewblox/blox/ActuatorDigitalConstraintsProto.cpp
+++ b/app/brewblox/blox/ActuatorDigitalConstraintsProto.cpp
@@ -7,6 +7,8 @@
 
 using MinOff = ADConstraints::MinOffTime<blox_DigitalConstraint_minOff_tag>;
 using MinOn = ADConstraints::MinOnTime<blox_DigitalConstraint_minOn_tag>;
+using DelayedOn = ADConstraints::DelayedOn<blox_DigitalConstraint_delayedOn_tag>;
+using DelayedOff = ADConstraints::DelayedOff<blox_DigitalConstraint_delayedOff_tag>;
 using Mutex_t = ADConstraints::Mutex<blox_DigitalConstraint_mutexed_tag>;
 using Base_t = ADConstraints::Base;
 
@@ -114,6 +116,12 @@ setDigitalConstraints(const blox_DigitalConstraints& msg, ActuatorDigitalConstra
         case blox_DigitalConstraint_mutexed_tag:
             addMutex(constraintDfn.constraint.mutexed.mutexId, constraintDfn.constraint.mutexed.extraHoldTime, constraintDfn.constraint.mutexed.hasCustomHoldTime);
             break;
+        case blox_DigitalConstraint_delayedOn_tag:
+            act.addConstraint(std::make_unique<DelayedOn>(constraintDfn.constraint.delayedOn));
+            break;
+        case blox_DigitalConstraint_delayedOff_tag:
+            act.addConstraint(std::make_unique<DelayedOff>(constraintDfn.constraint.delayedOff));
+            break;
         }
     }
 }
@@ -146,6 +154,14 @@ getDigitalConstraints(blox_DigitalConstraints& msg, const ActuatorDigitalConstra
             msg.constraints[i].constraint.mutexed.extraHoldTime = obj->holdAfterTurnOff();
             msg.constraints[i].constraint.mutexed.hasCustomHoldTime = obj->useCustomHoldDuration();
             msg.constraints[i].constraint.mutexed.hasLock = obj->hasLock();
+        } break;
+        case blox_DigitalConstraint_delayedOn_tag: {
+            auto obj = reinterpret_cast<DelayedOn*>((*it).get());
+            msg.constraints[i].constraint.delayedOn = obj->limit();
+        } break;
+        case blox_DigitalConstraint_minOn_tag: {
+            auto obj = reinterpret_cast<DelayedOff*>((*it).get());
+            msg.constraints[i].constraint.delayedOff = obj->limit();
         } break;
         }
         msg.constraints[i].remaining = (*it)->timeRemaining();

--- a/app/brewblox/blox/ActuatorDigitalConstraintsProto.cpp
+++ b/app/brewblox/blox/ActuatorDigitalConstraintsProto.cpp
@@ -159,7 +159,7 @@ getDigitalConstraints(blox_DigitalConstraints& msg, const ActuatorDigitalConstra
             auto obj = reinterpret_cast<DelayedOn*>((*it).get());
             msg.constraints[i].constraint.delayedOn = obj->limit();
         } break;
-        case blox_DigitalConstraint_minOn_tag: {
+        case blox_DigitalConstraint_delayedOff_tag: {
             auto obj = reinterpret_cast<DelayedOff*>((*it).get());
             msg.constraints[i].constraint.delayedOff = obj->limit();
         } break;

--- a/lib/inc/ActuatorDigitalConstrained.h
+++ b/lib/inc/ActuatorDigitalConstrained.h
@@ -291,6 +291,92 @@ public:
 };
 
 template <uint8_t ID>
+class DelayedOn : public Base {
+private:
+    duration_millis_t m_limit;
+    ticks_millis_t m_time_requested = 0;
+
+public:
+    DelayedOn(const duration_millis_t& delay)
+        : m_limit(delay)
+    {
+    }
+
+    duration_millis_t allowedImpl(const State& newState, const ticks_millis_t& now, const ActuatorDigitalChangeLogged&) override final
+    {
+        if (newState == State::Active) {
+            if (m_time_requested == 0) {
+                m_time_requested = now != 0 ? now : -1;
+            }
+            auto elapsed = now - m_time_requested;
+            auto wait = (m_limit > elapsed) ? m_limit - elapsed : 0;
+            return wait;
+        }
+
+        m_time_requested = 0;
+        return 0;
+    }
+
+    virtual uint8_t id() const override final
+    {
+        return ID;
+    }
+
+    duration_millis_t limit()
+    {
+        return m_limit;
+    }
+
+    virtual uint8_t order() const override final
+    {
+        return 2;
+    }
+};
+
+template <uint8_t ID>
+class DelayedOff : public Base {
+private:
+    duration_millis_t m_limit;
+    ticks_millis_t m_time_requested = 0;
+
+public:
+    DelayedOff(const duration_millis_t& delay)
+        : m_limit(delay)
+    {
+    }
+
+    duration_millis_t allowedImpl(const State& newState, const ticks_millis_t& now, const ActuatorDigitalChangeLogged&) override final
+    {
+        if (newState == State::Inactive) {
+            if (m_time_requested == 0) {
+                m_time_requested = now != 0 ? now : -1;
+            }
+            auto elapsed = now - m_time_requested;
+            auto wait = (m_limit > elapsed) ? m_limit - elapsed : 0;
+            return wait;
+        }
+
+        m_time_requested = 0;
+        return 0;
+    }
+
+    virtual uint8_t id() const override final
+    {
+        return ID;
+    }
+
+    duration_millis_t limit()
+    {
+        return m_limit;
+    }
+
+    virtual uint8_t order() const override final
+    {
+        return 3;
+    }
+};
+
+template <uint8_t ID>
 class Mutex : public Base {
 private:
     const std::function<std::shared_ptr<MutexTarget>()> m_mutexTarget;
@@ -387,8 +473,7 @@ public:
     virtual uint8_t
     order() const override final
     {
-        return 2;
+        return 4;
     }
 };
-
 } // end namespace ADConstraints

--- a/lib/test/ActuatorDigitalConstrained_test.cpp
+++ b/lib/test/ActuatorDigitalConstrained_test.cpp
@@ -88,6 +88,46 @@ SCENARIO("ActuatorDigitalConstrained", "[constraints]")
         auto timesOn = constrained.getLastStartEndTime(State::Active, now);
         CHECK(timesOn.end - timesOn.start == 2000);
     }
+
+    WHEN("A delayed ON constraint is added, the actuator turns ON with a delay")
+    {
+        now = 1;
+        constrained.desiredState(State::Inactive, now);
+        constrained.addConstraint(std::make_unique<ADConstraints::DelayedOn<5>>(1500));
+        constrained.desiredState(State::Active, now);
+        CHECK(constrained.state() == State::Inactive);
+        CHECK(mock.state() == State::Inactive);
+
+        now += 1499;
+        constrained.desiredState(State::Active, now);
+        CHECK(constrained.state() == State::Inactive);
+        CHECK(mock.state() == State::Inactive);
+
+        now += 1;
+        constrained.desiredState(State::Active, now);
+        CHECK(constrained.state() == State::Active);
+        CHECK(mock.state() == State::Active);
+    }
+
+    WHEN("A delayed OFF constraint is added, the actuator turns OFF with a delay")
+    {
+        now = 1;
+        constrained.desiredState(State::Active, now);
+        constrained.addConstraint(std::make_unique<ADConstraints::DelayedOff<5>>(1500));
+        constrained.desiredState(State::Inactive, now);
+        CHECK(constrained.state() == State::Active);
+        CHECK(mock.state() == State::Active);
+
+        now += 1499;
+        constrained.desiredState(State::Inactive, now);
+        CHECK(constrained.state() == State::Active);
+        CHECK(mock.state() == State::Active);
+
+        now += 1;
+        constrained.desiredState(State::Inactive, now);
+        CHECK(constrained.state() == State::Inactive);
+        CHECK(mock.state() == State::Inactive);
+    }
 }
 
 SCENARIO("Mutex contraint", "[constraints]")


### PR DESCRIPTION
Added 2 new digital constraints: delayed ON and delayed OFF.
Both add a delay between desired state and allowed state.

Can be useful when the new logical actuator drives an output like a fan, when heater or cooler are ON.
Fan actuation can lag heater/cooler and can run for a while after they turn off.