### PR TITLE
Fix/copy bin script

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -185,17 +185,19 @@ jobs:
 
       # cp SimulatorBinARM/brewblox ${SRC}/brewblox-arm
       - bash: |
+          set -e
           mkdir ${SRC}
           cp "$(Pipeline.Workspace)"/SimulatorBinAMD/brewblox ${SRC}/brewblox-amd
         displayName: Copy to firmware-simulator context
         env:
           SRC: docker/firmware-simulator/source
 
+      # cp "$(Pipeline.Workspace)"/SimulatorBinARM/brewblox ${SRC}/brewblox-arm
       - bash: |
+          set -e
           echo "$(Pipeline.Workspace)"/FirmwareBinPhoton/
           mkdir -p ${SRC}
           bash docker/copy-bin.sh
-          cp "$(Pipeline.Workspace)"/SimulatorBinARM/brewblox ${SRC}/brewblox-arm
           cp "$(Pipeline.Workspace)"/SimulatorBinAMD/brewblox ${SRC}/brewblox-amd
           cp "$(Pipeline.Workspace)"/FirmwareBinP1/brewblox.bin ${SRC}/brewblox-p1.bin
           cp "$(Pipeline.Workspace)"/FirmwareBinPhoton/brewblox.bin ${SRC}/brewblox-photon.bin

--- a/docker/copy-bin.sh
+++ b/docker/copy-bin.sh
@@ -1,15 +1,15 @@
 #! /usr/bin/env bash
 set -e
 
-PARTICLE_TAG=$(git --git-dir ../platform/spark/device-os/.git describe --tags)
-PARTICLE_RELEASES=https://github.com/particle-iot/device-os/releases/download/${PARTICLE_TAG}
-PARTICLE_VERSION=${PARTICLE_TAG:1} # remove the 'v' prefix
-
 SCRIPT_DIR=$(dirname "$(readlink -f "$0")")
 pushd "$SCRIPT_DIR/.." > /dev/null # Run from repo root
 
 git submodule update --init app/brewblox/proto
 echo "proto_version=$(cd app/brewblox/proto; git rev-parse --short HEAD)"
+
+PARTICLE_TAG=$(git --git-dir app/platform/spark/device-os/.git describe --tags)
+PARTICLE_RELEASES=https://github.com/particle-iot/device-os/releases/download/${PARTICLE_TAG}
+PARTICLE_VERSION=${PARTICLE_TAG:1} # remove the 'v' prefix
 
 OUT_DIR=docker/firmware-bin/source
 mkdir -p ${OUT_DIR}

--- a/docker/copy-bin.sh
+++ b/docker/copy-bin.sh
@@ -5,11 +5,13 @@ SCRIPT_DIR=$(dirname "$(readlink -f "$0")")
 pushd "$SCRIPT_DIR/.." > /dev/null # Run from repo root
 
 git submodule update --init app/brewblox/proto
-echo "proto_version=$(cd app/brewblox/proto; git rev-parse --short HEAD)"
+git submodule update --init platform/spark/device-os
+echo "proto_version=$(cd app/brewblox/proto && git rev-parse --short HEAD)"
 
-PARTICLE_TAG=$(git --git-dir app/platform/spark/device-os/.git describe --tags)
+PARTICLE_TAG=$(cd platform/spark/device-os && git describe --tags)
 PARTICLE_RELEASES=https://github.com/particle-iot/device-os/releases/download/${PARTICLE_TAG}
 PARTICLE_VERSION=${PARTICLE_TAG:1} # remove the 'v' prefix
+echo "particle_tag=$PARTICLE_TAG"
 
 OUT_DIR=docker/firmware-bin/source
 mkdir -p ${OUT_DIR}
@@ -26,8 +28,8 @@ curl -fL -o ${OUT_DIR}/system-part2-photon.bin "${PARTICLE_RELEASES}/photon-syst
     echo "[FIRMWARE]"
     echo "firmware_version=$(git rev-parse --short HEAD)"
     echo "firmware_date=$(git show -s --format=%ci)"
-    echo "proto_version=$(cd app/brewblox/proto; git rev-parse --short HEAD)"
-    echo "proto_date=$(cd app/brewblox/proto; git show -s --format=%ci)"
+    echo "proto_version=$(cd app/brewblox/proto && git rev-parse --short HEAD)"
+    echo "proto_date=$(cd app/brewblox/proto && git show -s --format=%ci)"
     echo "system_version=${PARTICLE_VERSION}"
 } | tee ${OUT_DIR}/firmware.ini
 


### PR DESCRIPTION
Fix bugs in copy-bin script
- call to relative path before the pushd of repo root was done
- subcommands now properly bubble their errors