### PR TITLE
remove accidental use of floating point math

### DIFF
--- a/lib/inc/FpFilterChain.h
+++ b/lib/inc/FpFilterChain.h
@@ -94,8 +94,8 @@ public:
     U readDerivative(uint8_t idx) const
     {
         auto derivative = chain.readDerivative(idx);
-        uint8_t destFractionBits = cnl::_impl::fractional_digits<U>();
-        uint8_t filterFactionBits = cnl::_impl::fractional_digits<T>() + derivative.fractionBits;
+        uint8_t destFractionBits = cnl::_impl::fractional_digits<U>::value;
+        uint8_t filterFactionBits = cnl::_impl::fractional_digits<T>::value + derivative.fractionBits;
         int64_t result;
         if (destFractionBits >= filterFactionBits) {
             result = derivative.result << (destFractionBits - filterFactionBits);

--- a/lib/src/FixedPoint.cpp
+++ b/lib/src/FixedPoint.cpp
@@ -25,15 +25,18 @@
 std::string
 to_string_dec(const fp12_t& t, uint8_t decimals)
 {
-    using calc_t = cnl::set_rounding_t<safe_elastic_fixed_point<14, 16>, cnl::native_rounding_tag>;
+    static constexpr const int32_t one = cnl::unwrap(fp12_t{1});
+    static constexpr const int32_t rounder_up = cnl::unwrap(fp12_t{0.5});
+    static constexpr const int32_t rounder_down = cnl::unwrap(fp12_t{-0.5});
 
-    int scale = 10;
+    int32_t scale = 10;
     for (uint8_t i = decimals; i > 1; --i) {
         scale *= 10;
     }
 
-    auto rounder = (t >= 0) ? calc_t{0.5} : calc_t{-0.5};
-    auto asInt = static_cast<int32_t>(scale * calc_t{t} + rounder);
+    int32_t unwrapped = cnl::unwrap(t);
+    int32_t rounder = (unwrapped >= 0) ? rounder_up : rounder_down;
+    int32_t asInt = (scale * unwrapped + rounder) / one;
 
     std::string s;
     s << asInt;

--- a/lib/src/TempSensorOneWire.cpp
+++ b/lib/src/TempSensorOneWire.cpp
@@ -79,7 +79,9 @@ TempSensorOneWire::update()
 temp_t
 TempSensorOneWire::readAndConstrainTemp()
 {
-    int16_t tempRaw;
+    // difference in precision between DS18B20 format and temperature format
+    static constexpr const uint8_t shift = cnl::_impl::fractional_digits<temp_t>::value - ONEWIRE_TEMP_SENSOR_PRECISION;
+    int32_t tempRaw;
     bool success;
 
     tempRaw = m_sensor.getTempRaw(getDeviceAddress().asUint8ptr());
@@ -96,8 +98,7 @@ TempSensorOneWire::readAndConstrainTemp()
         return 0;
     }
 
-    // difference in precision between DS18B20 format and temperature format
-    constexpr auto shift = cnl::_impl::fractional_digits<temp_t>{} - ONEWIRE_TEMP_SENSOR_PRECISION;
-    temp_t temp = cnl::wrap<temp_t>(tempRaw << shift);
-    return temp + m_calibrationOffset;
+    temp_t temp = cnl::wrap<temp_t>(tempRaw << shift) + m_calibrationOffset;
+
+    return temp;
 }

--- a/lib/src/Temperature.cpp
+++ b/lib/src/Temperature.cpp
@@ -19,18 +19,14 @@
 
 #include "../inc/Temperature.h"
 
-constexpr fp12_t
-scale()
-{
-    return 9.0 / 5.0;
-}
+static constexpr const fp12_t scale = fp12_t{1.8};
 
 std::string
 tempDiff_to_string(const temp_t& t, uint8_t decimals, const TempUnit& unit)
 {
     fp12_t val = t;
     if (unit == TempUnit::Fahrenheit) {
-        val = t * scale();
+        val = t * scale;
     }
     return to_string_dec(val, decimals);
 }
@@ -40,7 +36,7 @@ temp_to_string(const temp_t& t, uint8_t decimals, const TempUnit& unit)
 {
     fp12_t val = t;
     if (unit == TempUnit::Fahrenheit) {
-        val = fp12_t(cnl::quotient(t, scale())) + fp12_t(32);
+        val = fp12_t(cnl::quotient(t, scale)) + fp12_t(32);
     }
     return to_string_dec(val, decimals);
 }


### PR DESCRIPTION
FixedPoint to_string_dec compiled into some floating point functions, rewritten to avoid that.

Reduced code size, increased speed. Fixed Point FTW.