### PR TITLE
Reset integral when Ti is zero

### DIFF
--- a/lib/src/Pid.cpp
+++ b/lib/src/Pid.cpp
@@ -50,6 +50,8 @@ Pid::update()
 
     if (m_ti != 0) {
         m_i = m_integral * safe_elastic_fixed_point<4, 27>(cnl::quotient(m_kp, m_ti));
+    } else {
+        m_i = 0;
     }
 
     m_d = -m_kp * fp12_t(m_derivative * m_td);


### PR DESCRIPTION
As reported on the forum here: https://community.brewpi.com/t/bug-with-ti-not-disabled-with-zero-setting/4277

Setting Ti to zero disabled increasing the integral, but it did not reset the already accumulated value.