### PR TITLE
Error when two comparisons or operators in a row in logic actuator

### DIFF
--- a/app/brewblox/blox/ActuatorLogicBlock.h
+++ b/app/brewblox/blox/ActuatorLogicBlock.h
@@ -275,12 +275,18 @@ private:
             auto c = *it;
             ++it;
             if ('a' <= c && c <= 'z') {
+                if (res != blox_ActuatorLogic_Result_EMPTY_SUBSTRING) {
+                    return blox_ActuatorLogic_Result_UNEXPECTED_COMPARISON;
+                }
                 auto compare = digitals.cbegin() + (c - 'a');
                 if (compare >= digitals.cend()) {
                     return blox_ActuatorLogic_Result_INVALID_DIG_COMPARE_IDX;
                 }
                 res = compare->result();
             } else if ('A' <= c && c <= 'Z') {
+                if (res != blox_ActuatorLogic_Result_EMPTY_SUBSTRING) {
+                    return blox_ActuatorLogic_Result_UNEXPECTED_COMPARISON;
+                }
                 auto compare = analogs.cbegin() + (c - 'A');
                 if (compare >= analogs.cend()) {
                     return blox_ActuatorLogic_Result_INVALID_ANA_COMPARE_IDX;
@@ -296,6 +302,9 @@ private:
                 }
                 return blox_ActuatorLogic_Result_TRUE;
             } else if (c == '|') {
+                if (res == blox_ActuatorLogic_Result_EMPTY_SUBSTRING) {
+                    return blox_ActuatorLogic_Result_UNEXPECTED_OPERATOR;
+                }
                 auto rhs = eval(it, level);
                 if (rhs > blox_ActuatorLogic_Result_TRUE) {
                     return rhs; // error
@@ -305,6 +314,9 @@ private:
                 }
                 return rhs;
             } else if (c == '&') {
+                if (res == blox_ActuatorLogic_Result_EMPTY_SUBSTRING) {
+                    return blox_ActuatorLogic_Result_UNEXPECTED_OPERATOR;
+                }
                 auto rhs = eval(it, level);
                 if (rhs > blox_ActuatorLogic_Result_TRUE) {
                     return rhs; // error
@@ -314,6 +326,9 @@ private:
                 }
                 return res;
             } else if (c == '^') {
+                if (res == blox_ActuatorLogic_Result_EMPTY_SUBSTRING) {
+                    return blox_ActuatorLogic_Result_UNEXPECTED_OPERATOR;
+                }
                 auto rhs = eval(it, level);
                 if (rhs != blox_ActuatorLogic_Result_TRUE && rhs != blox_ActuatorLogic_Result_FALSE) {
                     return rhs; // error

--- a/app/brewblox/test/ActuatorLogicBlock_test.cpp
+++ b/app/brewblox/test/ActuatorLogicBlock_test.cpp
@@ -309,6 +309,41 @@ SCENARIO("Test", "[maklogicblock]")
             CHECK(result.result() == blox::ActuatorLogic_Result_EMPTY_SUBSTRING);
             CHECK(result.errorpos() == 5);
 
+            message.set_expression("a|&b");
+            result = setLogic(message);
+            CHECK(result.result() == blox::ActuatorLogic_Result_UNEXPECTED_OPERATOR);
+            CHECK(result.errorpos() == 2);
+
+            message.set_expression("a||b");
+            result = setLogic(message);
+            CHECK(result.result() == blox::ActuatorLogic_Result_UNEXPECTED_OPERATOR);
+            CHECK(result.errorpos() == 2);
+
+            message.set_expression("a&|b");
+            result = setLogic(message);
+            CHECK(result.result() == blox::ActuatorLogic_Result_UNEXPECTED_OPERATOR);
+            CHECK(result.errorpos() == 2);
+
+            message.set_expression("a^|b");
+            result = setLogic(message);
+            CHECK(result.result() == blox::ActuatorLogic_Result_UNEXPECTED_OPERATOR);
+            CHECK(result.errorpos() == 2);
+
+            message.set_expression("a!&b");
+            result = setLogic(message);
+            CHECK(result.result() == blox::ActuatorLogic_Result_UNEXPECTED_OPERATOR);
+            CHECK(result.errorpos() == 2);
+
+            message.set_expression("ab");
+            result = setLogic(message);
+            CHECK(result.result() == blox::ActuatorLogic_Result_UNEXPECTED_COMPARISON);
+            CHECK(result.errorpos() == 1);
+
+            message.set_expression("a(");
+            result = setLogic(message);
+            CHECK(result.result() == blox::ActuatorLogic_Result_UNEXPECTED_OPENING_BRACKET);
+            CHECK(result.errorpos() == 1);
+
             testBox.put(uint16_t(0)); // msg id
             testBox.put(commands::DELETE_OBJECT);
             testBox.put(cbox::obj_id_t(102));


### PR DESCRIPTION
Add extra errors for having two operators or two operands in a row: ab, a&&b, a|&b