### PR TITLE
closeAll only stops connections, they are destroyed later

### DIFF
--- a/controlbox/src/cbox/Connections.h
+++ b/controlbox/src/cbox/Connections.h
@@ -45,6 +45,7 @@ public:
     virtual DataOut& getDataOut() = 0;
     virtual DataIn& getDataIn() = 0;
     virtual bool isConnected() = 0;
+    virtual void stop() = 0;
 };
 
 class ConnectionSource {
@@ -269,7 +270,11 @@ public:
 
     void closeAll()
     {
-        connections.clear();
+        for (auto& c : connections) {
+            // don't delete connections here.
+            // stop them, and let updateConnections destroy them when they are disconnected.
+            c->stop();
+        }
         for (auto& source : connectionSources) {
             source.get().stop();
         }

--- a/controlbox/src/cbox/ConnectionsStringStream.h
+++ b/controlbox/src/cbox/ConnectionsStringStream.h
@@ -64,6 +64,12 @@ public:
     {
         return !(in->bad() || out->bad()); // use badbit of either stream to simulate disconnect
     }
+
+    virtual void stop() override final
+    {
+        in->setstate(std::istream::badbit);
+        out->setstate(std::ostream::badbit);
+    }
 };
 
 class StringStreamConnectionSource : public ConnectionSource {

--- a/controlbox/src/cbox/spark/ConnectionsSerial.h
+++ b/controlbox/src/cbox/spark/ConnectionsSerial.h
@@ -34,8 +34,13 @@ public:
     }
     virtual ~SerialConnection()
     {
-        SerialInUse = false;
+        stop();
     };
+
+    virtual void stop() override final
+    {
+        SerialInUse = false;
+    }
 };
 
 class SerialConnectionSource : public ConnectionSource {

--- a/controlbox/src/cbox/spark/ConnectionsTcp.h
+++ b/controlbox/src/cbox/spark/ConnectionsTcp.h
@@ -34,7 +34,10 @@ public:
     }
     ~TcpConnection()
     {
-        get().flush();
+    }
+
+    virtual void stop() override final
+    {
         get().stop();
     }
 };


### PR DESCRIPTION
updateConnections() already removed disconnected clients.

Before firmware update, we can just stop connections and let the update later remove disconnected ones.
If the hardfault when updating firmware over WiFi is because of the TCP client destruction, this might help.