### PR TITLE
Fix/remove out of memory handler

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -9,3 +9,6 @@
 [submodule "app/brewblox/proto"]
 	path = app/brewblox/proto
 	url = https://github.com/BrewBlox/brewblox-proto.git
+[submodule "wiced-history"]
+	path = wiced-history
+	url = https://github.com/amlweems/wiced-history.git

--- a/app/brewblox/connectivity.cpp
+++ b/app/brewblox/connectivity.cpp
@@ -123,7 +123,7 @@ manageConnections(uint32_t now)
         if (http_started) {
             TCPClient client = httpserver.available();
             if (client) {
-                client.setTimeout(0);
+                client.setTimeout(100);
                 while (client.read() != -1) {
                 }
                 const uint8_t start[] = "HTTP/1.1 200 Ok\n\n<html><body>"

--- a/app/brewblox/connectivity.cpp
+++ b/app/brewblox/connectivity.cpp
@@ -21,7 +21,7 @@
 #include "Board.h"
 #include "BrewBlox.h"
 #include "MDNS.h"
-#include "spark_wiring_system.h"
+#include "deviceid_hal.h"
 #include "spark_wiring_tcpclient.h"
 #include "spark_wiring_tcpserver.h"
 #include "spark_wiring_usbserial.h"
@@ -96,6 +96,12 @@ listeningModeEnabled()
     return spark::WiFi.listening();
 }
 
+inline uint8_t
+d2h(uint8_t bin)
+{
+    return uint8_t(bin + (bin > 9 ? 'A' - 10 : '0'));
+}
+
 void
 manageConnections(uint32_t now)
 {
@@ -117,16 +123,38 @@ manageConnections(uint32_t now)
         if (http_started) {
             TCPClient client = httpserver.available();
             if (client) {
+                client.setTimeout(0);
                 while (client.read() != -1) {
                 }
+                const uint8_t start[] = "HTTP/1.1 200 Ok\n\n<html><body>"
+                                        "<p>Your BrewBlox Spark is online but it does not run its own web server. "
+                                        "Please install a BrewBlox server to connect to it using the BrewBlox protocol.</p>"
+                                        "<p>Device ID = ";
 
-                client.write("HTTP/1.1 200 Ok\n\n<html><body>"
-                             "<p>Your BrewBlox Spark is online but it does not run its own web server. "
-                             "Please install a BrewBlox server to connect to it using the BrewBlox protocol.</p>"
-                             "<p>Device ID = ");
-                client.write(System.deviceID());
-                client.write("</p></body></html>\n\n");
-                client.flush();
+                uint8_t id[12];
+                uint8_t hex[24];
+                HAL_device_ID(id, 12);
+
+                uint8_t end[] = "</p></body></html>\n\n";
+
+                uint8_t* pId = id;
+                uint8_t* hId = hex;
+                while (hId < hex + 24) {
+                    *hId++ = d2h(uint8_t(*pId & 0xF0) >> 4);
+                    *hId++ = d2h(uint8_t(*pId++ & 0xF));
+                }
+
+                client.write(start, sizeof(start), 0);
+                if (!client.getWriteError()) {
+                    client.write(hex, sizeof(hex), 0);
+                }
+                if (!client.getWriteError()) {
+                    client.write(end, sizeof(end), 0);
+                }
+
+                if (!client.getWriteError()) {
+                    client.flush();
+                }
                 HAL_Delay_Milliseconds(5);
                 client.stop();
             }

--- a/app/brewblox/main.cpp
+++ b/app/brewblox/main.cpp
@@ -88,12 +88,6 @@ displayTick()
 }
 
 void
-onOutOfMemory(system_event_t event, int param)
-{
-    logEvent("OUT_OF_MEMORY");
-}
-
-void
 onSetupModeBegin()
 {
     logEvent("SETUP_MODE");
@@ -124,7 +118,6 @@ setup()
 #endif
     Buzzer.beep(2, 50);
 
-    System.on(out_of_memory, onOutOfMemory);
     System.on(setup_update, watchdogCheckin);
     System.on(setup_begin, onSetupModeBegin);
     System.on(setup_end, onSetupModeEnd);

--- a/controlbox/src/cbox/Connections.h
+++ b/controlbox/src/cbox/Connections.h
@@ -125,7 +125,7 @@ public:
     {
     }
 
-    bool write(uint8_t data) override
+    virtual bool write(uint8_t data) override final
     {
         return stream.write(data) != 0;
     }

--- a/controlbox/src/cbox/spark/ConnectionsTcp.h
+++ b/controlbox/src/cbox/spark/ConnectionsTcp.h
@@ -61,7 +61,8 @@ public:
             }
 
             TCPClient newClient = server.available();
-            if (newClient.connected()) {
+            if (newClient) {
+                newClient.setTimeout(0);
                 return std::make_unique<TcpConnection>(std::move(newClient));
             }
         } else {

--- a/controlbox/src/cbox/spark/ConnectionsTcp.h
+++ b/controlbox/src/cbox/spark/ConnectionsTcp.h
@@ -62,7 +62,7 @@ public:
 
             TCPClient newClient = server.available();
             if (newClient) {
-                newClient.setTimeout(0);
+                newClient.setTimeout(100);
                 return std::make_unique<TcpConnection>(std::move(newClient));
             }
         } else {

--- a/lib/src/spark/DS248x.cpp
+++ b/lib/src/spark/DS248x.cpp
@@ -82,7 +82,9 @@ DS248x::busyWait(bool setReadPtr)
 bool
 DS248x::init()
 {
+    Wire.setTimeout(0); // non-blocking mode
     Wire.begin();
+
     resetMaster();
     return configure(DS248X_CONFIG_APU);
 }

--- a/lib/src/spark/DS248x.cpp
+++ b/lib/src/spark/DS248x.cpp
@@ -82,7 +82,7 @@ DS248x::busyWait(bool setReadPtr)
 bool
 DS248x::init()
 {
-    Wire.setTimeout(0); // non-blocking mode
+    Wire.setTimeout(1);
     Wire.begin();
 
     resetMaster();

--- a/tools/hardware-debugging.md
+++ b/tools/hardware-debugging.md
@@ -53,3 +53,16 @@ To step debug on target, you will have to:
 - start st-util listening on port 9025: st-util -p 9025
 - set a breakpoint that you are sure you will hit (pause is not working yet)
 - attach to to the debugger in Netbeans with the gdbserver plugin with target ```remote localhost:9025```
+
+
+## Cloning eeprom data for debugging
+On problem Spark:
+```
+docker pull brewblox/firmware-flasher:edge
+docker run --privileged -it --rm -v /dev:/dev brewblox/firmware-flasher:edge trigger-dfu
+docker run --privileged -it --rm -v /dev:/dev -v /home/pi/brewblox/:/dump -v /dev:/dev brewblox/firmware-flasher:edge -c "dfu-util -d 2b04:d006 -a 0 -s 0x800C000:0x18000 -U /dump/eeprom.bin"
+curl https://bashupload.com/eeprom.bin --data-binary @/home/pi/brewblox/eeprom.bin
+```
+
+On a test spark with a hardware debugger:
+st-flash write eeprom.bin 0x800c000


### PR DESCRIPTION
I recently added a callback for handling out of memory.
This callback actually caused a deadlock, probably because the handler needed more memory.

With the handler removed, some communication might fail, but at least not a deadlock.