### PR TITLE
Show memory use on screen and some memory optimizations

### DIFF
--- a/app/brewblox/BrewBlox.cpp
+++ b/app/brewblox/BrewBlox.cpp
@@ -173,9 +173,9 @@ makeBrewBloxBox()
 
     std::vector<std::unique_ptr<cbox::ScanningFactory>> scanningFactories;
 #if PLATFORM_ID == 3
-    scanningFactories.push_back(std::unique_ptr<cbox::ScanningFactory>(new MockOneWireScanningFactory(objects, theOneWire())));
+    scanningFactories.push_back(std::make_unique<MockOneWireScanningFactory>(objects, theOneWire()));
 #else
-    scanningFactories.push_back(std::unique_ptr<cbox::ScanningFactory>(new OneWireScanningFactory(objects, theOneWire())));
+    scanningFactories.push_back(std::make_unique<OneWireScanningFactory>(objects, theOneWire()));
 #endif
 
     static cbox::Box box(objectFactory, objects, objectStore, connections, std::move(scanningFactories));

--- a/app/brewblox/blox/ActuatorPwmBlock.h
+++ b/app/brewblox/blox/ActuatorPwmBlock.h
@@ -100,8 +100,9 @@ public:
             if (auto ptr = actuator.lock()) {
                 ptr->desiredState(ActuatorDigitalBase::State::Inactive);
                 brewbloxBox().storeUpdatedObject(actuator.getId());
-                previousSettingValid = settingValid;
             }
+            previousSettingValid = settingValid;
+
             return now;
         }
         return nextUpdate;

--- a/app/brewblox/display/fonts/icons.cpp
+++ b/app/brewblox/display/fonts/icons.cpp
@@ -2492,7 +2492,8 @@ constexpr auto myTable = IconTable<
     0x20f, // 0x28 plug disconnected
     0x0cf, // 0x29 thermometer
     0x13e, // 0x2A arrow left
-    0x0b3  // 0x2B exclamation mark
+    0x0b3, // 0x2B exclamation mark
+    0x0c5  // 0x2C memory
     >();
 
 const D4D_FONT_DESCRIPTOR d4dfnt_icons_desc = {

--- a/app/brewblox/display/screens/WidgetWrapper.cpp
+++ b/app/brewblox/display/screens/WidgetWrapper.cpp
@@ -87,11 +87,11 @@ WidgetWrapper::resetClickHandler()
 }
 
 void
-WidgetWrapper::addChildren(std::vector<D4D_OBJECT*> children)
+WidgetWrapper::addChildren(std::vector<D4D_OBJECT*>&& children)
 {
     objects.reserve(objects.size() + children.size());
     objects.pop_back(); // remove nullptr
-    objects.insert(objects.end(), children.cbegin(), children.cend());
+    objects.insert(objects.end(), std::make_move_iterator(children.begin()), std::make_move_iterator(children.end()));
     objects.push_back(nullptr);
     wrapperObject.pRelations = objects.data();
     // ensure new children and their children have the correct screen pointer

--- a/app/brewblox/display/screens/WidgetWrapper.cpp
+++ b/app/brewblox/display/screens/WidgetWrapper.cpp
@@ -89,7 +89,10 @@ WidgetWrapper::resetClickHandler()
 void
 WidgetWrapper::addChildren(std::vector<D4D_OBJECT*> children)
 {
-    objects.insert(objects.end() - 1, children.cbegin(), children.cend());
+    objects.reserve(objects.size() + children.size());
+    objects.pop_back(); // remove nullptr
+    objects.insert(objects.end(), children.cbegin(), children.cend());
+    objects.push_back(nullptr);
     wrapperObject.pRelations = objects.data();
     // ensure new children and their children have the correct screen pointer
     D4D_SetObjectScreenPointer(&wrapperObject, wrapperObject.pData->pScreen);

--- a/app/brewblox/display/screens/WidgetWrapper.h
+++ b/app/brewblox/display/screens/WidgetWrapper.h
@@ -104,7 +104,7 @@ public:
     void setColor(uint8_t r, uint8_t g, uint8_t b);
     void setClickHandler(void* obj, void (*func)(void*));
     void resetClickHandler();
-    void addChildren(std::vector<D4D_OBJECT*> children);
+    void addChildren(std::vector<D4D_OBJECT*>&& children);
     void resetChildren();
     void invalidate();
     void setEnabled(bool enabled);

--- a/app/brewblox/display/screens/WidgetsScreen.cpp
+++ b/app/brewblox/display/screens/WidgetsScreen.cpp
@@ -56,13 +56,18 @@ SmallColorScheme TOP_BAR_SCHEME = {
 char icon_str[2] = "\x21";
 char usb_str[4] = "USB";
 D4D_DECLARE_LABEL(scrWidgets_usb_icon, icon_str, 0, 0, 20, 20, D4D_LBL_F_DEFAULT, AS_D4D_COLOR_SCHEME(&TOP_BAR_SCHEME), FONT_ICON, nullptr, nullptr);
-D4D_DECLARE_LABEL(scrWidgets_usb_text, usb_str, 20, 0, 20, 20, D4D_LBL_F_DEFAULT, AS_D4D_COLOR_SCHEME(&TOP_BAR_SCHEME), FONT_REGULAR, nullptr, nullptr);
+D4D_DECLARE_LABEL(scrWidgets_usb_text, usb_str, 18, 0, 20, 20, D4D_LBL_F_DEFAULT, AS_D4D_COLOR_SCHEME(&TOP_BAR_SCHEME), FONT_REGULAR, nullptr, nullptr);
 
 D4D_DECLARE_LABEL(scrWidgets_wifi_icon, wifi_icon, 40, 0, 20, 20, D4D_LBL_F_DEFAULT, AS_D4D_COLOR_SCHEME(&TOP_BAR_SCHEME), FONT_ICON, nullptr, nullptr);
 
 #undef D4D_LBL_TXT_PRTY_DEFAULT
 #define D4D_LBL_TXT_PRTY_DEFAULT (D4D_TXT_PRTY_ALIGN_H_LEFT_MASK | D4D_TXT_PRTY_ALIGN_V_CENTER_MASK)
-D4D_DECLARE_LABEL(scrWidgets_wifi_ip, wifi_ip, 60, 0, 15 * 6, 20, D4D_LBL_F_DEFAULT, AS_D4D_COLOR_SCHEME(&TOP_BAR_SCHEME), FONT_REGULAR, nullptr, nullptr);
+D4D_DECLARE_LABEL(scrWidgets_wifi_ip, wifi_ip, 58, 0, 15 * 6, 20, D4D_LBL_F_DEFAULT, AS_D4D_COLOR_SCHEME(&TOP_BAR_SCHEME), FONT_REGULAR, nullptr, nullptr);
+
+char mem_icon_str[2] = "\x2c";
+char mem_val_str[10] = "";
+D4D_DECLARE_LABEL(scrWidgets_mem_icon, mem_icon_str, 256, 0, 20, 20, D4D_LBL_F_DEFAULT, AS_D4D_COLOR_SCHEME(&TOP_BAR_SCHEME), FONT_ICON, nullptr, nullptr);
+D4D_DECLARE_LABEL(scrWidgets_mem_text, mem_val_str, 270, 0, 50, 20, D4D_LBL_F_DEFAULT, AS_D4D_COLOR_SCHEME(&TOP_BAR_SCHEME), FONT_REGULAR, nullptr, nullptr);
 
 #undef D4D_LBL_TXT_PRTY_DEFAULT
 #define D4D_LBL_TXT_PRTY_DEFAULT (D4D_TXT_PRTY_ALIGN_H_CENTER_MASK | D4D_TXT_PRTY_ALIGN_V_CENTER_MASK)
@@ -83,6 +88,8 @@ D4D_DECLARE_STD_SCREEN_BEGIN(widgets_screen, scrWidgets_)
     &scrWidgets_usb_text,
     &scrWidgets_wifi_icon,
     &scrWidgets_wifi_ip,
+    &scrWidgets_mem_icon,
+    &scrWidgets_mem_text,
     &scrWidgets_title,
     widgetWrappers[0].pObj(),
     widgetWrappers[1].pObj(),
@@ -161,6 +168,24 @@ WidgetsScreen::updateUsb()
 }
 
 void
+WidgetsScreen::updateRam()
+{
+    // bodfy of System::freeMemory copied here to prevent extra includes
+
+    runtime_info_t info;
+    memset(&info, 0, sizeof(info));
+    info.size = sizeof(info);
+    HAL_Core_Runtime_Info(&info, NULL);
+    uint8_t freePct = info.total_heap ? (100 * info.freeheap) / info.total_heap : 0;
+    uint8_t usedPct = 100 - freePct;
+    uint8_t maxPct = info.total_heap ? (100 * info.max_used_heap) / info.total_heap : 0;
+
+    snprintf(mem_val_str, 10, "%2d%% %2d%%", usedPct, maxPct);
+
+    D4D_InvalidateObject(&scrWidgets_mem_text, D4D_TRUE);
+}
+
+void
 WidgetsScreen::updateWiFi()
 {
     auto signal = wifiSignal();
@@ -204,6 +229,7 @@ scrWidgets_OnMain()
     }
     WidgetsScreen::updateUsb();
     WidgetsScreen::updateWiFi();
+    WidgetsScreen::updateRam();
     WidgetsScreen::updateWidgets();
 }
 

--- a/app/brewblox/display/screens/WidgetsScreen.cpp
+++ b/app/brewblox/display/screens/WidgetsScreen.cpp
@@ -26,6 +26,7 @@
 #include "TempSensorWidget.h"
 #include "blox/DisplaySettingsBlock.h"
 #include "connectivity.h"
+#include "memory_info.h"
 #include <algorithm>
 #include <array>
 #include <vector>
@@ -170,17 +171,8 @@ WidgetsScreen::updateUsb()
 void
 WidgetsScreen::updateRam()
 {
-    // bodfy of System::freeMemory copied here to prevent extra includes
-
-    runtime_info_t info;
-    memset(&info, 0, sizeof(info));
-    info.size = sizeof(info);
-    HAL_Core_Runtime_Info(&info, NULL);
-    uint8_t freePct = info.total_heap ? (100 * info.freeheap) / info.total_heap : 0;
-    uint8_t usedPct = 100 - freePct;
-    uint8_t maxPct = info.total_heap ? (100 * info.max_used_heap) / info.total_heap : 0;
-
-    snprintf(mem_val_str, 10, "%2d%% %2d%%", usedPct, maxPct);
+    HeapInfo heapInfo;
+    heapInfo.print(mem_val_str, 10);
 
     D4D_InvalidateObject(&scrWidgets_mem_text, D4D_TRUE);
 }

--- a/app/brewblox/display/screens/WidgetsScreen.cpp
+++ b/app/brewblox/display/screens/WidgetsScreen.cpp
@@ -108,6 +108,7 @@ WidgetsScreen::loadSettings()
 
     widgets.clear();
     pb_size_t numWidgets = std::min(settings.widgets_count, pb_size_t(sizeof(settings.widgets) / sizeof(settings.widgets[0])));
+    widgets.reserve(numWidgets);
     for (pb_size_t i = 0; i < numWidgets; ++i) {
         blox_DisplaySettings_Widget widgetDfn = settings.widgets[i];
         auto pos = widgetDfn.pos;

--- a/app/brewblox/display/screens/WidgetsScreen.h
+++ b/app/brewblox/display/screens/WidgetsScreen.h
@@ -33,6 +33,7 @@ public:
     static void activate();
     static void updateUsb();
     static void updateWiFi();
+    static void updateRam();
     static void updateWidgets();
 };
 

--- a/app/brewblox/display/screens/startup_screen.cpp
+++ b/app/brewblox/display/screens/startup_screen.cpp
@@ -22,8 +22,8 @@
 #include "../logo/brewblox_logo.h"
 #include "BrewBlox.h"
 #include "blox/stringify.h"
-#include "core_hal.h"
 #include "d4d.hpp"
+#include "memory_info.h"
 #include "spark_wiring_ticks.h"
 #include "spark_wiring_timer.h"
 #include "stdio.h"
@@ -64,6 +64,8 @@ D4D_DECLARE_SCREEN_END()
 void
 StartupScreen::activate()
 {
+    D4D_EnableObject(&scrStartup_mem_icon, D4D_FALSE); // disable for darker color
+    D4D_EnableObject(&scrStartup_mem_text, D4D_FALSE);
     D4D_EnableObject(&scrStartup_version, D4D_FALSE);
     D4D_ActivateScreen(&screen_startup, D4D_TRUE);
 }
@@ -110,18 +112,8 @@ StartupScreen::calibrateTouch()
 void
 StartupScreen::updateRam()
 {
-    // bodfy of System::freeMemory copied here to prevent extra includes
-
-    runtime_info_t info;
-    memset(&info, 0, sizeof(info));
-    info.size = sizeof(info);
-    HAL_Core_Runtime_Info(&info, NULL);
-    uint8_t freePct = info.total_heap ? (100 * info.freeheap) / info.total_heap : 0;
-    uint8_t usedPct = 100 - freePct;
-    uint8_t maxPct = info.total_heap ? (100 * info.max_used_heap) / info.total_heap : 0;
-
-    snprintf(startup_mem_val_str, 10, "%2d%% %2d%%", usedPct, maxPct);
-
+    HeapInfo heapInfo;
+    heapInfo.print(startup_mem_val_str, 10);
     D4D_InvalidateObject(&scrStartup_mem_text, D4D_TRUE);
 }
 

--- a/app/brewblox/display/screens/startup_screen.cpp
+++ b/app/brewblox/display/screens/startup_screen.cpp
@@ -22,9 +22,11 @@
 #include "../logo/brewblox_logo.h"
 #include "BrewBlox.h"
 #include "blox/stringify.h"
+#include "core_hal.h"
 #include "d4d.hpp"
 #include "spark_wiring_ticks.h"
 #include "spark_wiring_timer.h"
+#include "stdio.h"
 
 #if PLATFORM_ID != 3
 #include "BrewPiTouch.h"
@@ -39,17 +41,24 @@ extern BrewPiTouch touch;
 #endif
 char stepTxt[32] = "Init board";
 char versionString[] = "version: " stringify(GIT_VERSION) " (" stringify(GIT_DATE) ")";
+char startup_mem_icon_str[2] = "\x2c";
+char startup_mem_val_str[10] = "";
 
 D4D_DECLARE_STD_PICTURE(scrStartup_logo, 70, 100, 180, 34, &bmp_brewblox_logo)
 D4D_DECLARE_STD_LABEL(scrStartup_step, stepTxt, 0, 193, 320, 15, FONT_REGULAR)
 D4D_DECLARE_STD_PROGRESS_BAR(scrStartup_progress, 0, 212, 320, 12, 0)
 D4D_DECLARE_STD_LABEL(scrStartup_version, versionString, 0, 224, 320, 15, FONT_REGULAR)
+D4D_DECLARE_STD_LABEL(scrStartup_mem_icon, startup_mem_icon_str, 256, 0, 20, 20, FONT_ICON);
+D4D_DECLARE_STD_LABEL(scrStartup_mem_text, startup_mem_val_str, 270, 0, 50, 20, FONT_REGULAR);
 
 D4D_DECLARE_SCREEN_BEGIN(screen_startup, ScrStartup_, 0, 0, (D4D_COOR)(D4D_SCREEN_SIZE_LONGER_SIDE), (D4D_COOR)(D4D_SCREEN_SIZE_SHORTER_SIDE), nullptr, 0, nullptr, (D4D_SCR_F_DEFAULT | D4D_SCR_F_TOUCHENABLE), nullptr)
 D4D_DECLARE_SCREEN_OBJECT(scrStartup_logo)
 D4D_DECLARE_SCREEN_OBJECT(scrStartup_version)
 D4D_DECLARE_SCREEN_OBJECT(scrStartup_progress)
+D4D_DECLARE_SCREEN_OBJECT(scrStartup_mem_icon)
+D4D_DECLARE_SCREEN_OBJECT(scrStartup_mem_text)
 D4D_DECLARE_SCREEN_OBJECT(scrStartup_step)
+
 D4D_DECLARE_SCREEN_END()
 
 void
@@ -80,6 +89,7 @@ StartupScreen::setStep(std::string&& txt)
 {
     auto s = txt;
     D4D_LabelSetText(&scrStartup_step, txt.c_str());
+    updateRam();
     D4D_Poll();
 }
 
@@ -95,6 +105,24 @@ StartupScreen::calibrateTouch()
     if (D4D_TCH_GetCalibrationStatus()) {
         brewbloxBox().storeUpdatedObject(2); // save system object
     }
+}
+
+void
+StartupScreen::updateRam()
+{
+    // bodfy of System::freeMemory copied here to prevent extra includes
+
+    runtime_info_t info;
+    memset(&info, 0, sizeof(info));
+    info.size = sizeof(info);
+    HAL_Core_Runtime_Info(&info, NULL);
+    uint8_t freePct = info.total_heap ? (100 * info.freeheap) / info.total_heap : 0;
+    uint8_t usedPct = 100 - freePct;
+    uint8_t maxPct = info.total_heap ? (100 * info.max_used_heap) / info.total_heap : 0;
+
+    snprintf(startup_mem_val_str, 10, "%2d%% %2d%%", usedPct, maxPct);
+
+    D4D_InvalidateObject(&scrStartup_mem_text, D4D_TRUE);
 }
 
 void

--- a/app/brewblox/display/screens/startup_screen.h
+++ b/app/brewblox/display/screens/startup_screen.h
@@ -27,4 +27,5 @@ public:
     static void calibrateTouch();
     static void setProgress(uint8_t v);
     static void setStep(std::string&& txt);
+    static void updateRam();
 };

--- a/app/brewblox/main.cpp
+++ b/app/brewblox/main.cpp
@@ -155,17 +155,24 @@ setup()
     brewbloxBox();
 
     HAL_Delay_Milliseconds(1);
-    StartupScreen::setProgress(80);
+    StartupScreen::setProgress(50);
     StartupScreen::setStep("Loading objects");
     brewbloxBox().loadObjectsFromStorage(); // load stored objects
     HAL_Delay_Milliseconds(1);
-    StartupScreen::setProgress(100);
+    StartupScreen::setProgress(70);
+
+    StartupScreen::setStep("Init WiFi and mDNS");
+    wifiInit();
+    StartupScreen::setProgress(80);
 
     // perform pending EEPROM erase while we're waiting. Can take up to 500ms and stalls all code execution
     // This avoids having to do it later when writing to EEPROM
     HAL_EEPROM_Perform_Pending_Erase();
 
-    StartupScreen::setStep("Ready!");
+    StartupScreen::setStep("Starting connections");
+    brewbloxBox().startConnections();
+
+    StartupScreen::setProgress(90);
 
     while (ticks.millis() < 5000) {
         displayTick();
@@ -177,8 +184,6 @@ setup()
     TimerInterrupts::init();
 #endif
 
-    wifiInit();
-    brewbloxBox().startConnections();
     HAL_Delay_Milliseconds(1);
 }
 

--- a/app/brewblox/main.cpp
+++ b/app/brewblox/main.cpp
@@ -133,13 +133,13 @@ setup()
     StartupScreen::setStep("Power cycling peripherals");
 
     do {
+        StartupScreen::setProgress(ticks.millis() / 40); // up to 50
         displayTick();
     } while (ticks.millis() < ((PLATFORM_ID != PLATFORM_GCC) ? 2000 : 0));
 
     enablePheripheral5V(true);
     HAL_Delay_Milliseconds(1);
 
-    StartupScreen::setProgress(50);
     StartupScreen::setStep("Init OneWire");
     theOneWire();
 

--- a/app/brewblox/main.cpp
+++ b/app/brewblox/main.cpp
@@ -157,7 +157,7 @@ setup()
     HAL_Delay_Milliseconds(1);
     StartupScreen::setProgress(80);
     StartupScreen::setStep("Loading objects");
-    brewbloxBox().loadObjectsFromStorage(); // init box and load stored objects
+    brewbloxBox().loadObjectsFromStorage(); // load stored objects
     HAL_Delay_Milliseconds(1);
     StartupScreen::setProgress(100);
 

--- a/app/brewblox/memory_info.cpp
+++ b/app/brewblox/memory_info.cpp
@@ -1,0 +1,25 @@
+#include "memory_info.h"
+#include <cstdint>
+#include <stdio.h>
+
+HeapInfo::HeapInfo()
+    : info({0})
+{
+    info.size = sizeof(info);
+}
+
+void
+HeapInfo::update()
+{
+    HAL_Core_Runtime_Info(&info, NULL);
+}
+
+void
+HeapInfo::print(char* dest, uint8_t maxLen)
+{
+    update();
+    uint8_t freePct = info.total_heap ? (100 * info.freeheap) / info.total_heap : 0;
+    uint8_t usedPct = 100 - freePct;
+    uint8_t maxPct = info.total_heap ? (100 * info.max_used_heap) / info.total_heap : 0;
+    snprintf(dest, maxLen, "%2d%% %2d%%", usedPct, maxPct);
+}

--- a/app/brewblox/memory_info.h
+++ b/app/brewblox/memory_info.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include "core_hal.h"
+#include <cstdint>
+
+class HeapInfo {
+private:
+    runtime_info_t info;
+
+public:
+    HeapInfo();
+    ~HeapInfo() = default;
+
+    void update();
+    void print(char* dest, uint8_t maxLen); // also updates
+};

--- a/build/run-simulator-callgrind.sh
+++ b/build/run-simulator-callgrind.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+MY_DIR=$(dirname $(readlink -f $0))
+BUILD_DIR="$MY_DIR/target/user/platform-3/firmware/brewblox"
+EXECUTABLE_DIR="$MY_DIR/target/brewblox-gcc"
+EXECUTABLE="$EXECUTABLE_DIR/brewblox"
+OUTPUT_DIR="$MY_DIR/coverage"
+DEVICE_KEY="$EXECUTABLE_DIR/device_key.der"
+SERVER_KEY="$EXECUTABLE_DIR/server_key.der"
+STATE_DIR="$EXECUTABLE_DIR/state"
+EEPROM_FILE="$EXECUTABLE_DIR/eeprom.bin"
+
+ls "$EXECUTABLE" 
+if [ ! -f "$EXECUTABLE" ]; then
+    echo "brewblox executable not found!"
+    exit 1
+fi
+
+pushd "$EXECUTABLE_DIR" || exit
+
+touch "$DEVICE_KEY" "$SERVER_KEY" "$EEPROM_FILE"
+mkdir -p "$STATE_DIR"
+mkdir -p "$OUTPUT_DIR"
+
+valgrind --suppressions=/usr --tool=callgrind --callgrind-out-file="$EXECUTABLE_DIR/callgrind.out" "$EXECUTABLE" --device_id 123456789012345678901234 --device_key="$DEVICE_KEY" --server_key="$SERVER_KEY"
+
+popd || exit
+
+# open result.kcg with kcachegrind
+kcachegrind "$EXECUTABLE_DIR/callgrind.out" &

--- a/build/run-simulator-massif.sh
+++ b/build/run-simulator-massif.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+MY_DIR=$(dirname $(readlink -f $0))
+BUILD_DIR="$MY_DIR/target/user/platform-3/firmware/brewblox"
+EXECUTABLE_DIR="$MY_DIR/target/brewblox-gcc"
+EXECUTABLE="$EXECUTABLE_DIR/brewblox"
+OUTPUT_DIR="$MY_DIR/coverage"
+DEVICE_KEY="$EXECUTABLE_DIR/device_key.der"
+SERVER_KEY="$EXECUTABLE_DIR/server_key.der"
+STATE_DIR="$EXECUTABLE_DIR/state"
+EEPROM_FILE="$EXECUTABLE_DIR/eeprom.bin"
+
+ls "$EXECUTABLE" 
+if [ ! -f "$EXECUTABLE" ]; then
+    echo "brewblox executable not found!"
+    exit 1
+fi
+
+pushd "$EXECUTABLE_DIR" || exit
+
+# eeprom file writes cause a lot of memory allocation. Import blocks manually after start for a less polluted
+touch "$DEVICE_KEY" "$SERVER_KEY" "$EEPROM_FILE"
+mkdir -p "$STATE_DIR"
+mkdir -p "$OUTPUT_DIR"
+
+rm "$EXECUTABLE_DIR/massif.out"
+rm "$EXECUTABLE_DIR/xtmemory.kcg"
+
+valgrind --tool=massif --threshold=0.1 \
+--xtree-memory=full --xtree-memory-file="$EXECUTABLE_DIR/xtmemory.kcg" \
+--ignore-fn=call_init.part.0 \
+--ignore-fn=_IO_file_doallocate \
+--massif-out-file="$EXECUTABLE_DIR/massif.out" "$EXECUTABLE" --device_id 123456789012345678901234 --device_key="$DEVICE_KEY" --server_key="$SERVER_KEY"
+
+popd || exit
+
+# open massif.out with massif-visualizer
+massif-visualizer "$EXECUTABLE_DIR/massif.out" &
+# open xtmemory.kcg with kcachegrind
+kcachegrind "$EXECUTABLE_DIR/xtmemory.kcg" 

--- a/controlbox/src/cbox/Box.cpp
+++ b/controlbox/src/cbox/Box.cpp
@@ -202,9 +202,10 @@ Box::createObjectFromStream(DataIn& in)
         return std::make_tuple(CboxError::INPUT_STREAM_READ_ERROR, std::shared_ptr<Object>(), uint8_t(0)); // LCOV_EXCL_LINE
     }
 
-    CboxError result;
-    std::shared_ptr<Object> obj;
-    std::tie(result, obj) = factory.make(typeId);
+    auto retv = factory.make(typeId);
+    auto result = std::get<0>(retv);
+    auto obj = std::get<1>(retv);
+
     if (obj) {
         obj->streamFrom(in);
     }
@@ -439,7 +440,7 @@ Box::loadObjectsFromStorage()
     // then they can take an ID that is in use by an object loader later
     std::vector<obj_id_t> deprecatedList;
 
-    const auto objectLoader = [this, &deprecatedList](const storage_id_t& id, RegionDataIn& objInStorage) -> CboxError {
+    const auto objectLoader = [this, &deprecatedList](storage_id_t id, RegionDataIn& objInStorage) -> CboxError {
         obj_id_t objId = obj_id_t(id);
         CboxError status = CboxError::OK;
 

--- a/controlbox/src/cbox/ObjectContainer.h
+++ b/controlbox/src/cbox/ObjectContainer.h
@@ -21,8 +21,8 @@
 
 #include "ContainedObject.h"
 #include "Object.h"
-#include <functional>
 #include <cstdint>
+#include <functional>
 #include <vector>
 
 namespace cbox {
@@ -46,15 +46,10 @@ public:
     {
     }
 
-    ObjectContainer(std::vector<ContainedObject>&& systemObjects)
-        : objects(systemObjects)
-    {
-    }
-
     virtual ~ObjectContainer() = default;
 
 private:
-    auto findPosition(const obj_id_t& id)
+    auto findPosition(obj_id_t id)
     {
         // equal_range is used instead of find, because it is faster for a sorted container
         // the returned pair can be used as follows:
@@ -85,7 +80,7 @@ public:
      * @return pointer to the entry.
      *
      */
-    ContainedObject* fetchContained(const obj_id_t id)
+    ContainedObject* fetchContained(obj_id_t id)
     {
         auto p = findPosition(id);
         if (p.first == p.second) {
@@ -95,7 +90,7 @@ public:
         }
     }
 
-    const std::weak_ptr<Object> fetch(const obj_id_t id)
+    const std::weak_ptr<Object> fetch(obj_id_t id)
     {
         auto p = findPosition(id);
         if (p.first == p.second) {
@@ -108,19 +103,19 @@ public:
      * set start ID for user objects.
      * ID's smaller than the start ID are  assumed to be system objects and considered undeletable.
      **/
-    void setObjectsStartId(const obj_id_t& id)
+    void setObjectsStartId(obj_id_t id)
     {
         startId = id;
     }
 
     // create a new object and let box assign id
-    obj_id_t add(std::shared_ptr<Object> obj, const uint8_t active_in_groups)
+    obj_id_t add(std::shared_ptr<Object>&& obj, uint8_t active_in_groups)
     {
         return add(std::move(obj), active_in_groups, obj_id_t::invalid());
     }
 
     // create a new object with specific id, optionally replacing an existing object
-    obj_id_t add(std::shared_ptr<Object> obj, const uint8_t active_in_groups, const obj_id_t& id, bool replace = false)
+    obj_id_t add(std::shared_ptr<Object>&& obj, uint8_t active_in_groups, obj_id_t id, bool replace = false)
     {
         obj_id_t newId;
         Iterator position;
@@ -188,7 +183,7 @@ public:
     }
 
     // replace an object with an inactive object by id
-    void deactivate(const obj_id_t& id)
+    void deactivate(obj_id_t id)
     {
         auto p = findPosition(id);
         if (p.first != p.second) {
@@ -202,14 +197,14 @@ public:
         objects.erase(userbegin(), cend());
     }
 
-    void update(const update_t& now)
+    void update(update_t now)
     {
         for (auto& cobj : objects) {
             cobj.update(now);
         }
     }
 
-    void forcedUpdate(const update_t& now)
+    void forcedUpdate(update_t now)
     {
         for (auto& cobj : objects) {
             cobj.forcedUpdate(now);

--- a/controlbox/src/cbox/ScanningFactory.h
+++ b/controlbox/src/cbox/ScanningFactory.h
@@ -47,7 +47,7 @@ public:
     obj_id_t scanAndAdd()
     {
         if (auto newObj = scan()) {
-            return objectsRef.add(newObj, uint8_t(0x01)); // default to first profile
+            return objectsRef.add(std::move(newObj), uint8_t(0x01)); // default to first profile
         }
         return 0;
     }

--- a/lib/src/FilterChain.cpp
+++ b/lib/src/FilterChain.cpp
@@ -71,6 +71,8 @@ FilterChain::setParams(const std::vector<uint8_t>& params, const std::vector<uin
     if (params.size() < 1) {
         return;
     }
+
+    stages.reserve(params.size());
     auto itP = params.begin();
     auto itS = stages.begin();
     auto itI = intervals.begin();
@@ -102,7 +104,9 @@ FilterChain::setParams(const std::vector<uint8_t>& params, const std::vector<uin
         auto newStage = FilterChain::Stage{std::move(newFilter), interval};
         stages.push_back(std::move(newStage));
     }
-    stages.shrink_to_fit(); // remove filters if params is shorter than before
+    if (params.size() < stages.size()) {
+        stages.shrink_to_fit(); // remove filters if params is shorter than before
+    }
     reset(newFilterInitVal);
 }
 

--- a/lib/src/spark/DS248x.cpp
+++ b/lib/src/spark/DS248x.cpp
@@ -40,10 +40,16 @@ Updates:
 void
 DS248x::setReadPtr(uint8_t readPtr)
 {
+    static uint8_t failCount = 0;
     Wire.beginTransmission(mAddress);
     Wire.write(DS248X_SRP);
     Wire.write(readPtr);
-    Wire.endTransmission(false);
+    if (Wire.endTransmission(false) != 0) {
+        ++failCount;
+        if (failCount > 10) {
+            init(); // re-init I2C and master
+        }
+    };
 }
 
 uint8_t
@@ -82,6 +88,7 @@ DS248x::busyWait(bool setReadPtr)
 bool
 DS248x::init()
 {
+    Wire.reset();
     Wire.setTimeout(1);
     Wire.begin();
 


### PR DESCRIPTION
After we discovered recently that running out of memory causes strange hangups and thread blocks, it seemed useful to show it on the display.

I added scripts to run the simulator with valgrind + massif, to analyze when and how much memory is allocated.

I noticed two small bugs that I also fixed in this PR:
- When the I2C class has a hangup, reset it
- The PWM sets its target to inactive in EEPROM when it takes control, but when the target was not found, this was retried continuously. Now it only tries once.