### PR TITLE
Fixes for PWM calculation when target is constrained

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ compile_commands.json
 
 .vscode/.cortex-debug.peripherals.state.json
 core
+build/coverage
+*.pyc

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -118,6 +118,7 @@
       "executable": "./build/target/brewblox-p1/brewblox.elf",
       "debuggerArgs": [
         "-command=./tools/system.gdbinit",
+        "-command=./tools/pretty.gdbinit",
       ],
       "rtos": "FreeRTOS",
       "device": "STM32F205RG",
@@ -126,8 +127,10 @@
         "/usr/local/share/openocd/scripts/target/stm32f2x.cfg"
       ],
       "armToolchainPath": "/home/elco/source/gcc-arm-none-eabi-5_3-2016q1/bin",
-      //      "showDevDebugOutput": true,
-      "svdFile": "./tools/STM32F215.svd"
+      // sudo apt-get install libpython2.7:i386 for the line below to work
+      "gdbpath": "/home/elco/source/gcc-arm-none-eabi-5_3-2016q1/bin/arm-none-eabi-gdb-py", // hidden setting
+      "showDevDebugOutput": true,
+      "svdFile": "./tools/STM32F215.svd",
     },
     {
       "name": "wifi-test p1 openocd debug",
@@ -144,7 +147,8 @@
         "/home/elco/opt/openocd/tcl/interface/stlink.cfg",
         "/home/elco/opt/openocd/tcl/target/stm32f2x.cfg"
       ],
-      "armToolchainPath": "/home/elco/source/gcc-arm-none-eabi-5_3-2016q1/bin",
+      "armToolchainPath": "/home/elco/source/gcc-arm-none-eabi-_3-2016q1/bin",
+      "gdbpath": "/home/elco/source/gcc-arm-none-eabi-_3-2016q1/bin/arm-none-eabi-gdb-py", // hidden setting
       "showDevDebugOutput": true,
       "svdFile": "./tools/STM32F215.svd",
       "rtos": "FreeRTOS",

--- a/app/brewblox/display/screens/memory_info.cpp
+++ b/app/brewblox/display/screens/memory_info.cpp
@@ -32,7 +32,7 @@ printHeapUse(char* dest, uint8_t maxLen)
 
     uint8_t usedPct = 100 - freePct;
     uint8_t maxPct = info.total_heap ? (100 * info.max_used_heap) / info.total_heap : 0;
-    snprintf(scr_mem_val_str, maxLen, "%2d%% %2d%%", usedPct, maxPct);
+    snprintf(dest, maxLen, "%2d%% %2d%%", usedPct, maxPct);
     return true;
 }
 

--- a/app/brewblox/test/AcutatorPwmBlock_test.cpp
+++ b/app/brewblox/test/AcutatorPwmBlock_test.cpp
@@ -83,7 +83,7 @@ SCENARIO("A Blox ActuatorPwm object can be created from streamed protobuf data")
 
     CHECK(testBox.lastReplyHasStatusOk());
     CHECK(decoded.ShortDebugString() == "actuatorId: 100 "
-                                        "period: 4000 setting: 81920 value: 81899 "
+                                        "period: 4000 setting: 81920 "
                                         "constrainedBy { constraints { min: 40960 } } "
                                         "drivenActuatorId: 100 "
                                         "enabled: true "

--- a/app/brewblox/test/BalancerAndMutexBlock_test.cpp
+++ b/app/brewblox/test/BalancerAndMutexBlock_test.cpp
@@ -308,7 +308,7 @@ SCENARIO("Two pin actuators are constrained by a mutex", "[balancer, mutex]")
             testBox.processInputToProto(decoded);
             CHECK(testBox.lastReplyHasStatusOk());
             CHECK(decoded.ShortDebugString() == "actuatorId: 102 "
-                                                "period: 4000 setting: 204800 value: 163840 "
+                                                "period: 4000 setting: 204800 "
                                                 "constrainedBy { "
                                                 "constraints { "
                                                 "balanced { balancerId: 200 granted: 204800 id: 1 } "

--- a/lib/inc/ActuatorDigitalChangeLogged.h
+++ b/lib/inc/ActuatorDigitalChangeLogged.h
@@ -117,12 +117,14 @@ public:
             ticks_millis_t currentPeriod;
             ticks_millis_t previousActive;
             ticks_millis_t previousPeriod;
+            State lastState;
         } result;
 
         result.currentActive = 0;
         result.currentPeriod = 0;
         result.previousActive = 0;
         result.previousPeriod = 0;
+        result.lastState = history[0].newState;
         auto end = now;
         auto start = ticks_millis_t(0);
         //auto minStartTime = now - maxHistory;

--- a/lib/test/PidTest.cpp
+++ b/lib/test/PidTest.cpp
@@ -620,7 +620,7 @@ SCENARIO("PID Test with PWM actuator", "[pid]")
         CHECK(mockVal == 29);
         CHECK(pid.error() == Approx(1).epsilon(0.1)); // the filter introduces some delay, which is why this is not 1.0
         CHECK(pid.p() == Approx(10).epsilon(0.1));
-        CHECK(pid.i() == Approx(accumulatedError * (10.0 / 2000) * 0.92).epsilon(0.01)); // some integral anti-windup will occur at the start
+        CHECK(pid.i() == Approx(accumulatedError * (10.0 / 2000) * 0.87).epsilon(0.02)); // some integral anti-windup will occur at the start
         CHECK(pid.d() == Approx(-10 * 9.0 / 900 * 200).epsilon(0.01));
 
         CHECK(actuator->setting() == pid.p() + pid.i() + pid.d());
@@ -659,8 +659,8 @@ SCENARIO("PID Test with PWM actuator", "[pid]")
         CHECK(mockVal == 21);
         CHECK(pid.error() == Approx(-1).epsilon(0.1)); // the filter introduces some delay, which is why this is not 1.0
         CHECK(pid.p() == Approx(10).epsilon(0.1));
-        CHECK(pid.i() == Approx(accumulatedError * (-10.0 / 2000) * 0.92).epsilon(0.01)); // some integral anti-windup will occur at the start
-        CHECK(pid.d() == Approx(-10 * 9.0 / 900 * 200).epsilon(0.01));
+        CHECK(pid.i() == Approx(accumulatedError * (-10.0 / 2000) * 0.87).epsilon(0.02)); // some integral anti-windup will occur at the start
+        CHECK(pid.d() == Approx(-10 * 9.0 / 900 * 200).epsilon(0.02));
 
         CHECK(actuator->setting() == pid.p() + pid.i() + pid.d());
     }
@@ -699,11 +699,11 @@ SCENARIO("PID Test with PWM actuator", "[pid]")
 
         THEN("The integral action is unchanged")
         {
-            CHECK(pid.i() == Approx(10.0 * 1000 / 2000).epsilon(0.01));
+            CHECK(pid.i() == Approx(10.0 * 1000 / 2000).epsilon(0.2));
         }
         THEN("The integral is scaled with the inverse factor of the change")
         {
-            CHECK(pid.integral() == Approx(-500).epsilon(0.01));
+            CHECK(pid.integral() == Approx(-500).epsilon(0.02));
         }
     }
 
@@ -741,7 +741,7 @@ SCENARIO("PID Test with PWM actuator", "[pid]")
 
         THEN("The integral action is unchanged")
         {
-            CHECK(pid.i() == Approx(10.0 * 1000 / 2000).epsilon(0.01));
+            CHECK(pid.i() == Approx(10.0 * 1000 / 2000).epsilon(0.02));
         }
         THEN("The integral is scaled with the inverse factor of the change")
         {

--- a/lib/test/PidTest.cpp
+++ b/lib/test/PidTest.cpp
@@ -575,14 +575,14 @@ SCENARIO("PID Test with PWM actuator", "[pid]")
         run1000seconds();
 
         CHECK(pid.p() == Approx(10).epsilon(0.001));
-        CHECK(pid.i() == Approx(5).epsilon(0.01));
+        CHECK(pid.i() == Approx(5).epsilon(0.02));
         CHECK(pid.d() == 0);
         CHECK(actuator->setting() == Approx(10.0 * (1.0 + 1000 * 1.0 / 2000)).epsilon(0.02));
 
         run1000seconds();
 
         CHECK(pid.p() == Approx(10).epsilon(0.001));
-        CHECK(pid.i() == Approx(10).epsilon(0.01));
+        CHECK(pid.i() == Approx(10).epsilon(0.02)); // more margin for anti-windup due to PWM lag
         CHECK(pid.d() == 0);
         CHECK(actuator->setting() == Approx(10.0 * (1.0 + 2000 * 1.0 / 2000)).epsilon(0.02));
     }
@@ -620,7 +620,7 @@ SCENARIO("PID Test with PWM actuator", "[pid]")
         CHECK(mockVal == 29);
         CHECK(pid.error() == Approx(1).epsilon(0.1)); // the filter introduces some delay, which is why this is not 1.0
         CHECK(pid.p() == Approx(10).epsilon(0.1));
-        CHECK(pid.i() == Approx(accumulatedError * (10.0 / 2000)).epsilon(0.05)); // some integral anti-windup will occur at the start
+        CHECK(pid.i() == Approx(accumulatedError * (10.0 / 2000) * 0.92).epsilon(0.01)); // some integral anti-windup will occur at the start
         CHECK(pid.d() == Approx(-10 * 9.0 / 900 * 200).epsilon(0.01));
 
         CHECK(actuator->setting() == pid.p() + pid.i() + pid.d());
@@ -659,7 +659,7 @@ SCENARIO("PID Test with PWM actuator", "[pid]")
         CHECK(mockVal == 21);
         CHECK(pid.error() == Approx(-1).epsilon(0.1)); // the filter introduces some delay, which is why this is not 1.0
         CHECK(pid.p() == Approx(10).epsilon(0.1));
-        CHECK(pid.i() == Approx(accumulatedError * (-10.0 / 2000)).epsilon(0.05)); // some integral anti-windup will occur at the start
+        CHECK(pid.i() == Approx(accumulatedError * (-10.0 / 2000) * 0.92).epsilon(0.01)); // some integral anti-windup will occur at the start
         CHECK(pid.d() == Approx(-10 * 9.0 / 900 * 200).epsilon(0.01));
 
         CHECK(actuator->setting() == pid.p() + pid.i() + pid.d());
@@ -690,7 +690,7 @@ SCENARIO("PID Test with PWM actuator", "[pid]")
 
         CHECK(pid.error() == Approx(-1).epsilon(0.01));
         CHECK(pid.p() == Approx(10).epsilon(0.01));
-        CHECK(pid.i() == Approx(10.0 * 1000 / 2000).epsilon(0.01));
+        CHECK(pid.i() == Approx(10.0 * 1000 / 2000).epsilon(0.02)); // more margin for anti-windup due to PWM lag
         CHECK(pid.d() == Approx(0.0).margin(0.01));
 
         pid.ti(1000);
@@ -732,7 +732,7 @@ SCENARIO("PID Test with PWM actuator", "[pid]")
 
         CHECK(pid.error() == Approx(-1).epsilon(0.01));
         CHECK(pid.p() == Approx(10).epsilon(0.01));
-        CHECK(pid.i() == Approx(10.0 * 1000 / 2000).epsilon(0.01));
+        CHECK(pid.i() == Approx(10.0 * 1000 / 2000).epsilon(0.02)); // more margin for anti-windup due to PWM lag
         CHECK(pid.d() == Approx(0.0).margin(0.01));
 
         pid.kp(-20);
@@ -745,7 +745,7 @@ SCENARIO("PID Test with PWM actuator", "[pid]")
         }
         THEN("The integral is scaled with the inverse factor of the change")
         {
-            CHECK(pid.integral() == Approx(-500).epsilon(0.01));
+            CHECK(pid.integral() == Approx(-500).epsilon(0.02));
         }
     }
 
@@ -773,7 +773,7 @@ SCENARIO("PID Test with PWM actuator", "[pid]")
         }
 
         CHECK(pid.p() == Approx(50).epsilon(0.01));
-        CHECK(pid.i() == Approx(50.0 * 1000 / 2000).epsilon(0.01));
+        CHECK(pid.i() == Approx(50.0 * 1000 / 2000).epsilon(0.02)); // more margin for anti-windup due to PWM lag
         CHECK(pid.d() == Approx(0.0).margin(0.01));
 
         CHECK(pid.p() + pid.i() + pid.d() == actuator->setting());

--- a/tools/pretty.gdbinit
+++ b/tools/pretty.gdbinit
@@ -1,10 +1,16 @@
 python 
 import sys 
+import gdb
 
-sys.path.insert(0, '/home/elco/repos/firmware/tools')
-from prettyprinters import printers
+# sys.path.append('/home/elco/repos/firmware/tools')
+# from prettyprinters import printers
 
-# sys.path.insert(0, 'C:/repos/libstdc++-v3-python/python')
-# from libstdcxx.v6.printers import register_libstdcxx_printers
+sys.path.append('/home/elco/source/gcc-arm-none-eabi-5_3-2016q1/share/gcc-arm-none-eabi')
+
+# Load the pretty-printers.
+from libstdcxx.v6.printers import register_libstdcxx_printers
+register_libstdcxx_printers (gdb.current_objfile ())
 
 end
+
+set print pretty on


### PR DESCRIPTION
This PR fixes 3 issues with PWM calculations:

### 1. Not toggling correctly after constraints prevented toggles

The PWM now uses the last logged state instead of the desired state to check if it needs to toggle. This fixes this bug: when the target was constrained, the desired state would be changed but the actual state would not change. In the next update, the desired state would be toggled back again, repeat.

### 2. Achieved value is reported too high
I also changed how and when the achieved value is updated, so it doesn't report a higher value when the previous period was shortened or just after startup. It now also transitions to the new value if the PWM setting changes from a low to a high value suddenly. The achieved value will now transition between old and new and will not overshoot and overcompensate

### 3. Unnecessary period stretching after a long period of inactivity
After a long low period, the high period could be stretched too long to overcompensate afterwards. Stretching is now only permitted if the previous period had at least normal length


