### PR TITLE
PWM calculations look ahead and limit influence of the past

### DIFF
--- a/lib/inc/ActuatorDigitalConstrained.h
+++ b/lib/inc/ActuatorDigitalConstrained.h
@@ -145,6 +145,12 @@ public:
         return ActuatorDigitalChangeLogged::state();
     }
 
+    void setStateUnlogged(const State& val)
+    {
+        m_desiredState = val;
+        ActuatorDigitalChangeLogged::state(val);
+    }
+
     duration_millis_t update(const ticks_millis_t& now)
     {
         // re-apply constraints for new update time

--- a/lib/src/ActuatorPwm.cpp
+++ b/lib/src/ActuatorPwm.cpp
@@ -167,7 +167,11 @@ ActuatorPwm::slowPwmUpdate(const update_t& now)
         if (lastHistoricState == State::Active) {
             if (m_dutySetting == maxDuty()) {
                 actPtr->desiredState(State::Active, now); // ensure desired state is correct
-                wait = std::max(duration_millis_t(1000), m_period - currentPeriod);
+                if (currentPeriod <= m_period + 1000) {
+                    wait = m_period - currentPeriod;
+                } else {
+                    wait = 1000;
+                }
             } else if (m_dutySetting <= (maxDuty() >> 1)) {
                 // high period is fixed, low period adapts
                 if (currentHighTime < m_dutyTime) {
@@ -207,7 +211,11 @@ ActuatorPwm::slowPwmUpdate(const update_t& now)
             auto currentLowTime = currentPeriod - currentHighTime;
             if (m_dutySetting == value_t{0}) {
                 actPtr->desiredState(State::Inactive, now); // ensure desired state is correct
-                wait = std::max(duration_millis_t(1000), m_period - currentPeriod);
+                if (currentPeriod <= m_period + 1000) {
+                    wait = m_period - currentPeriod;
+                } else {
+                    wait = 1000;
+                }
             } else if (m_dutySetting > (maxDuty() >> 1)) {
                 // low period is fixed, high period adapts
                 if (currentLowTime < invDutyTime) {

--- a/lib/test/ActuatorPwm_test.cpp
+++ b/lib/test/ActuatorPwm_test.cpp
@@ -497,11 +497,12 @@ SCENARIO("ActuatorPWM driving mock actuator", "[pwm]")
         pwm.update(now + 1);
         CHECK(mock.state() == State::Inactive);
     }
-    WHEN("the PWM actuator is set to 40%, the duty cycle it reports doesn't overshoot more than 10%")
+    WHEN("the PWM actuator is set to 40% at startup, the duty cycle it reports doesn't overshoot more than 10%")
     {
         // some overshoot is acceptable, because we only know of the high time after startup, so the history is a bit higher actually
         pwm.setting(40);
         bool reached = false;
+        auto previous = pwm.value();
         while (now < 5 * pwm.period()) {
             now = pwm.update(now);
             if (pwm.value() >= 40.0) {
@@ -509,6 +510,10 @@ SCENARIO("ActuatorPWM driving mock actuator", "[pwm]")
             }
             if (reached) {
                 CHECK(pwm.value() == Approx(40.0).epsilon(0.1));
+            } else {
+                auto current = pwm.value();
+                CHECK(current >= previous); // strictly rising
+                previous = current;
             }
         }
     }

--- a/lib/test/PidTest.cpp
+++ b/lib/test/PidTest.cpp
@@ -620,7 +620,7 @@ SCENARIO("PID Test with PWM actuator", "[pid]")
         CHECK(mockVal == 29);
         CHECK(pid.error() == Approx(1).epsilon(0.1)); // the filter introduces some delay, which is why this is not 1.0
         CHECK(pid.p() == Approx(10).epsilon(0.1));
-        CHECK(pid.i() == Approx(accumulatedError * (10.0 / 2000) * 0.87).epsilon(0.02)); // some integral anti-windup will occur at the start
+        CHECK(pid.i() == Approx(accumulatedError * (10.0 / 2000)).epsilon(0.02)); // some integral anti-windup will occur at the start
         CHECK(pid.d() == Approx(-10 * 9.0 / 900 * 200).epsilon(0.01));
 
         CHECK(actuator->setting() == pid.p() + pid.i() + pid.d());
@@ -659,7 +659,7 @@ SCENARIO("PID Test with PWM actuator", "[pid]")
         CHECK(mockVal == 21);
         CHECK(pid.error() == Approx(-1).epsilon(0.1)); // the filter introduces some delay, which is why this is not 1.0
         CHECK(pid.p() == Approx(10).epsilon(0.1));
-        CHECK(pid.i() == Approx(accumulatedError * (-10.0 / 2000) * 0.87).epsilon(0.02)); // some integral anti-windup will occur at the start
+        CHECK(pid.i() == Approx(accumulatedError * (-10.0 / 2000)).epsilon(0.02)); // some integral anti-windup will occur at the start
         CHECK(pid.d() == Approx(-10 * 9.0 / 900 * 200).epsilon(0.02));
 
         CHECK(actuator->setting() == pid.p() + pid.i() + pid.d());


### PR DESCRIPTION
These changes improve a few issues in the PWM calculation.
The main improvement is that the PWM looks ahead more and dwells less on the past.

The length of the history taken into account is limited to 2,5 normal periods. If the length is longer, the previous period will have less influence.

When at 100% or 0%, the achieved value is not set to 0 or 100 immediately, but slowly approaches it.

A minimum high/low time of 75% the normal duration is applied. This prevents a quick change in duty cycle to generate two short pulses after a period of inactivity.

When actuator target is blocked, update wait time to void useless PWM updates

I also reduced made the fast PWM interrupt faster and ensured that for fast pwm, the desired state of the constrained actuator is also updated.

