### PR TITLE
always use amd-latest / arm-latest for compiler tag

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -3,7 +3,7 @@ resources:
     - repository: self
   containers: 
     - container: compiler
-      image: brewblox/firmware-compiler:latest
+      image: brewblox/firmware-compiler:amd-latest
 
 pool:
   vmImage: "Ubuntu-18.04"

--- a/build/build-sim-arm.sh
+++ b/build/build-sim-arm.sh
@@ -18,14 +18,14 @@ sed -i 's/-m64//g' platform/spark/device-os/build/gcc-tools.mk
 # Make sure compiler is up-to-date
 docker pull \
     --platform=linux/arm/v7 \
-    brewblox/firmware-compiler:latest
+    brewblox/firmware-compiler:arm-latest
 
 # build
 docker run \
     -it --rm \
     --platform=linux/arm/v7 \
     -v "$(pwd)/":/firmware/ \
-    brewblox/firmware-compiler:latest \
+    brewblox/firmware-compiler:arm-latest \
     make APP=brewblox PLATFORM=gcc
 
 # reset modified file

--- a/docker/build-compiler.sh
+++ b/docker/build-compiler.sh
@@ -28,10 +28,4 @@ docker buildx build \
     --push \
     firmware-compiler/arm
 
-docker manifest create "$IMAGE":"$TAG" \
-    --amend "$IMAGE":amd-"$TAG" \
-    --amend "$IMAGE":arm-"$TAG"
-
-docker manifest push "$IMAGE":"$TAG"
-
 popd > /dev/null

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3.7"
 services:
     compiler:
-        image: brewblox/firmware-compiler:latest
+        image: brewblox/firmware-compiler:amd-latest
         container_name: firmware-compiler
         init: true
         privileged: true
@@ -28,7 +28,7 @@ services:
             - "8380:80"
 
     coverage-simulator:
-        image: brewblox/firmware-compiler
+        image: brewblox/firmware-compiler:amd-latest
         container_name: firmware-coverage-simulator
         environment:
             - MOUNTDIR=/firmware


### PR DESCRIPTION
brewblox/firmware-compiler should have been a multi-arch image, but somehow failed to build.

In this scenario, explicit is deemed better than automatic.
- brewblox/firmware-compiler:latest is no longer built, and removed from docker hub
- CI and build scripts always use amd-latest or arm-latest tags