### PR TITLE
Dynamically allocate filter stages as needed

### DIFF
--- a/lib/inc/FilterChain.h
+++ b/lib/inc/FilterChain.h
@@ -27,7 +27,8 @@
 class FilterChain {
 private:
     struct Stage {
-        IirFilter filter;
+        std::unique_ptr<IirFilter> filter;
+        uint8_t param;
         uint8_t interval;
     };
     std::vector<Stage> stages;
@@ -35,8 +36,8 @@ private:
     uint32_t counter = 0;
 
 public:
-    FilterChain(const std::vector<uint8_t>& params, const int32_t& stepThreshold = std::numeric_limits<int32_t>::max());
-    FilterChain(const std::vector<uint8_t>& params, const std::vector<uint8_t>& intervals, const int32_t& stepThreshold = std::numeric_limits<int32_t>::max());
+    FilterChain(std::vector<uint8_t> params);
+    FilterChain(std::vector<uint8_t> params, std::vector<uint8_t> intervals, uint8_t initStages = 0, int32_t stepThreshold = std::numeric_limits<int32_t>::max());
 
     FilterChain(const FilterChain&) = delete;
     FilterChain(FilterChain&&) = default;
@@ -44,9 +45,9 @@ public:
 
     ~FilterChain() = default;
 
-    void add(const int32_t& val);
-    void setParams(const std::vector<uint8_t>& params, const std::vector<uint8_t>& intervals, const int32_t& stepThreshold);
-    void setStepThreshold(const int32_t& threshold); // set the step detection threshold
+    void add(int32_t val);
+    void expandStages(size_t numStages);
+    void setStepThreshold(int32_t threshold);        // set the step detection threshold
     int32_t getStepThreshold() const;                // get the step detection threshold of last filter
     int32_t read(uint8_t filterNr) const;            // read from specified filter
     int32_t read() const;                            // read from last filter
@@ -65,7 +66,7 @@ public:
     } // return count for a specific filter
     uint8_t length() const
     {
-        return stages.size();
+        return selectStage(stages.size() - 1) - stages.cbegin() + 1;
     }
     uint8_t fractionBits(uint8_t idx) const;
     uint8_t fractionBits() const;
@@ -73,5 +74,10 @@ public:
     int64_t readWithNFractionBits(uint8_t bits) const;
     int32_t readLastInput() const;
     IirFilter::DerivativeResult readDerivative(uint8_t filterNr) const;
-    void reset(const int32_t& value);
+    void reset(int32_t value);
+
+private:
+    uint32_t sampleInterval(std::vector<Stage>::const_iterator stage) const;
+    std::vector<FilterChain::Stage>::iterator selectStage(uint8_t filterNr);
+    std::vector<FilterChain::Stage>::const_iterator selectStage(uint8_t filterNr) const;
 };

--- a/lib/inc/Pid.h
+++ b/lib/inc/Pid.h
@@ -42,6 +42,7 @@ private:
     out_t m_d = out_t{0};
     integral_t m_integral = integral_t{0};
     derivative_t m_derivative = derivative_t{0};
+    uint8_t m_derivativeFilterIdx = 0;
 
     // settings
     in_t m_kp = in_t{0};    // proportional gain
@@ -128,6 +129,8 @@ public:
     void td(const uint16_t& arg)
     {
         m_td = arg;
+        m_derivativeFilterIdx = 0; // trigger automatic filter selection
+        checkFilterLength();
     }
 
     void enabled(bool state)
@@ -183,4 +186,5 @@ private:
         }
         m_active = state;
     }
+    void checkFilterLength();
 };

--- a/lib/inc/SetpointSensorPair.h
+++ b/lib/inc/SetpointSensorPair.h
@@ -45,7 +45,7 @@ public:
     explicit SetpointSensorPair(
         std::function<std::shared_ptr<TempSensor>()>&& _sensor)
         : m_sensor(_sensor)
-        , m_filter(1)
+        , m_filter(1, 1)
     {
         update();
     }
@@ -146,9 +146,24 @@ public:
         return setting() - value();
     }
 
-    auto derivative(uint32_t period)
+    auto readDerivative(uint8_t filterNr)
     {
-        return m_filter.readDerivativeForInterval<derivative_t>(period);
+        return m_filter.readDerivative<derivative_t>(filterNr);
+    }
+
+    auto intervalToFilterNr(uint16_t interval)
+    {
+        return m_filter.intervalToFilterNr(interval);
+    }
+
+    auto filterLength()
+    {
+        return m_filter.length();
+    }
+
+    auto resizeFilterIfNeeded(uint8_t filterIdx)
+    {
+        m_filter.expandStages(filterIdx + 1);
     }
 
     void resetFilter()

--- a/lib/test/FilterChainTest.cpp
+++ b/lib/test/FilterChainTest.cpp
@@ -423,3 +423,28 @@ SCENARIO("Filters chain output matches manually cascaded filters", "[filterchain
         }
     }
 }
+
+SCENARIO("A filter chain can be only initalized with short length, but expanded as specced later", "[filterchain][length]")
+{
+    WHEN("A filter chain is created with initially only 1 stage")
+    {
+        FilterChain chain({2, 2, 2, 2, 2, 2}, {1, 1, 1, 1, 1, 1}, 1);
+        THEN("It is created with length 1")
+        {
+            CHECK(chain.length() == 1);
+
+            AND_THEN("It can be expanded to length 3 on demand")
+            {
+
+                chain.expandStages(3);
+                CHECK(chain.length() == 3);
+            }
+
+            AND_THEN("It can will not become longer than the spec")
+            {
+                chain.expandStages(10);
+                CHECK(chain.length() == 6);
+            }
+        }
+    }
+}

--- a/lib/test/FpFilterChainTest.cpp
+++ b/lib/test/FpFilterChainTest.cpp
@@ -184,7 +184,7 @@ SCENARIO("Fixed point filterchain using temp_t")
             CHECK(findStepResponseDelay(chain, 0.9) == 1368);
         }
 
-        AND_WHEN("The derivative is requested with a certain period")
+        AND_WHEN("The derivative can be get from a different filter, selected by the max interval")
         {
             using derivative_t = safe_elastic_fixed_point<1, 23>;
             uint32_t period = 200;
@@ -199,16 +199,16 @@ SCENARIO("Fixed point filterchain using temp_t")
                 auto wave = sine(t, period, amplIn);
                 c.add(wave);
 
-                auto derivative = c.readDerivativeForInterval<derivative_t>(12);
+                auto derivative = c.readDerivative<derivative_t>(c.intervalToFilterNr(12));
                 if (derivative > maxDerivative12) {
                     maxDerivative12 = derivative;
                 }
-                derivative = c.readDerivativeForInterval<derivative_t>(25);
+                derivative = c.readDerivative<derivative_t>(c.intervalToFilterNr(25));
                 if (derivative > maxDerivative25) {
                     maxDerivative25 = derivative;
                 }
 
-                derivative = c.readDerivativeForInterval<derivative_t>(100);
+                derivative = c.readDerivative<derivative_t>(c.intervalToFilterNr(100));
                 if (derivative > maxDerivative100) {
                     maxDerivative100 = derivative;
                 }

--- a/lib/test/PidTest.cpp
+++ b/lib/test/PidTest.cpp
@@ -121,7 +121,13 @@ SCENARIO("PID Test with mock actuator", "[pid]")
     {
         pid.kp(10);
         pid.ti(2000);
+        CHECK(input->filterLength() == 1);
         pid.td(200);
+
+        THEN("The PID will ensure the filter of the input is long enough for td")
+        {
+            CHECK(input->filterLength() == 5);
+        }
 
         input->setting(30);
         sensor->setting(20);
@@ -915,7 +921,6 @@ SCENARIO("PID Test with PWM actuator", "[pid]")
         {
             for (uint16_t td = 20; td < 1200; td = td * 5 / 4) {
                 // INFO("td=" + std::to_string(td));
-
                 CHECK(testStep(td) >= -150);
                 CHECK(testStep(td) <= -30);
             }

--- a/tools/hardware-debugging.md
+++ b/tools/hardware-debugging.md
@@ -1,58 +1,12 @@
-# Hardware debugging in NetBeans
-On-target hardware debugging requires a hardware debugger (ST-Link V2) and a 
-small board to connect the ST-Link to the Spark Core.
-You can find details on how to setup NetBeans for debugging here:
-https://community.spark.io/t/local-development-and-debugging-a-step-by-step-guide/7829
+# Hardware debugging in vscode
+Check configuration in launch.json for correct paths of tools
+Check whehther the GDB launch has no errors by running it manually:
+`Launching GDB: "/home/elco/source/gcc-arm-none-eabi-5_3-2016q1/bin/arm-none-eabi-gdb-py" "-q" "--interpreter=mi2" "-command=./tools/system.gdbinit" "-command=./tools/arm-pretty.gdbinit"`
 
+If you get this error: `error while loading shared libraries: libncurses.so.5: cannot open shared object file: No such file or directory` 
+Fix it by simlinking the newer version:
+`sudo ln -s /lib/i386-linux-gnu/libncurses.so.6 /lib/i386-linux-gnu/libncurses.so.5`
 
-##
-To recompile the project with SWD enabled append this to the make command in Netbeans:
-
-```
-USE_SWD=y
-```
-
-and do a clean build.
-
-Upload SWD enabled build result via DFU. Put core in DFU mode, run:
-
-```
-make program-dfu
-```
-This should find brewpi.dfu and upload it over USB.
-
-When starting st-util, you should now see this line:
-
-```
-Chip ID is 00000410, Core ID is 1ba01477.
-```
-If the chip ID comes back as 00000000 you do not have SWD enabled.
-
-# Uploading with with 1 button click
-
-A script is available to do all steps needed.
-Run ```program-via-gdb.sh``` from a shell (terminal window in Netbeans).
-
-This will start a gdb server with st-util, connect to it with arm gdb and then load the .elf file.
-Make sure st-util is in the PATH.
-
-To be able to upload via the Run button in Netbeans, set the Run command to:
-```
-./program-via-gdb.sh
-```
-And the run directory to
-```
-tools
-```
-
-# Hardware debugging
-To step debug on target, you will have to:
-
-- set the Gdb Init File in the projects Debug settings to gdb-attach.txt
-- load your .elf to the core the Run button (see above)
-- start st-util listening on port 9025: st-util -p 9025
-- set a breakpoint that you are sure you will hit (pause is not working yet)
-- attach to to the debugger in Netbeans with the gdbserver plugin with target ```remote localhost:9025```
 
 
 ## Cloning eeprom data for debugging


### PR DESCRIPTION
Setpoints include a deep filter that takes up a lot of memory.
There are 6 filter stages with each 7 older input and 7 older output values of 64 bits.
If the deeper stages are never read (because only shorter filter periods are used), this is wasted memory and computations.

With the changes from this PR. filter stages are only allocated when needed.
The filter stages are created when the filter choice is changed or when the Td setting of a PID is changed.

Filter chains can only grow, not shrink. That way we don't have to keep track of the clients of the filter.