### PR TITLE
Fix jumps in mock sensor fluctuations due to calculation overflow

### DIFF
--- a/app/brewblox/blox/TempSensorMockBlock.h
+++ b/app/brewblox/blox/TempSensorMockBlock.h
@@ -101,8 +101,7 @@ public:
 
     virtual cbox::update_t update(const cbox::update_t& now) override final
     {
-        sensor.update(now);
-        return now + 100; // every 100ms
+        return sensor.update(now);
     }
 
     virtual void* implements(const cbox::obj_type_t& iface) override final

--- a/app/brewblox/test/TempSensorMockBlock_test.cpp
+++ b/app/brewblox/test/TempSensorMockBlock_test.cpp
@@ -123,7 +123,7 @@ SCENARIO("A TempSensorMock block")
             testBox.processInputToProto(decoded);
 
             CHECK(testBox.lastReplyHasStatusOk());
-            CHECK(decoded.ShortDebugString() == "value: 90856 connected: true setting: 81920 fluctuations { amplitude: 8192 period: 2000 } fluctuations { amplitude: 12288 period: 3000 }");
+            CHECK(decoded.ShortDebugString() == "value: 91627 connected: true setting: 81920 fluctuations { amplitude: 8192 period: 2000 } fluctuations { amplitude: 12288 period: 3000 }");
         }
     }
 }

--- a/lib/inc/TempSensorMock.h
+++ b/lib/inc/TempSensorMock.h
@@ -29,6 +29,7 @@ private:
     temp_t m_setting = 0;
     temp_t m_fluctuationsSum = 0;
     bool m_connected = false;
+    duration_millis_t m_updateInterval = 1000;
 
 public:
     struct Fluctuation {
@@ -96,5 +97,5 @@ public:
         m_setting += delta;
     }
 
-    void update(ticks_millis_t now);
+    duration_millis_t update(ticks_millis_t now);
 };


### PR DESCRIPTION
The mock sensor used now*1000 in its calculation, which overflowed every 71.5 minutes.

Calculations are changed to only overflow when now itself overflows, every 49 days.
Calculations are also more efficient and take less program memory.

Mock sensor now returns the desired update rate for max precision, with a minimal update interval of 10ms and max 1000ms.
