### PR TITLE
Interpolation for filter stages with slower update rate

### DIFF
--- a/lib/inc/FilterChain.h
+++ b/lib/inc/FilterChain.h
@@ -50,6 +50,8 @@ public:
     void setStepThreshold(int32_t threshold);        // set the step detection threshold
     int32_t getStepThreshold() const;                // get the step detection threshold of last filter
     int32_t read(uint8_t filterNr) const;            // read from specified filter
+    int32_t readSmooth(uint8_t filterNr) const;      // read from specified filter with interpolation to smooth output
+    int32_t readSmooth() const;                      // read filter with interpolation to smooth output
     int32_t read() const;                            // read from last filter
     uint32_t sampleInterval(uint8_t filterNr) const; // get minimum sample interval of filter at index i
     uint32_t sampleInterval() const;                 // get minimum sample interval of filter at last filter

--- a/lib/inc/FilterChain.h
+++ b/lib/inc/FilterChain.h
@@ -47,16 +47,11 @@ public:
 
     void add(int32_t val);
     void expandStages(size_t numStages);
-    void setStepThreshold(int32_t threshold);        // set the step detection threshold
-    int32_t getStepThreshold() const;                // get the step detection threshold of last filter
-    int32_t read(uint8_t filterNr) const;            // read from specified filter
-    int32_t readSmooth(uint8_t filterNr) const;      // read from specified filter with interpolation to smooth output
-    int32_t readSmooth() const;                      // read filter with interpolation to smooth output
-    int32_t read() const;                            // read from last filter
-    uint32_t sampleInterval(uint8_t filterNr) const; // get minimum sample interval of filter at index i
-    uint32_t sampleInterval() const;                 // get minimum sample interval of filter at last filter
-
-    uint8_t intervalToFilterNr(uint32_t maxInterval) const; // get slowest filter number with interval faster than argument
+    void setStepThreshold(int32_t threshold);                       // set the step detection threshold
+    int32_t getStepThreshold() const;                               // get the step detection threshold of last filter
+    int32_t read(uint8_t filterNr = 255, bool smooth = true) const; // read from specified filter, default to last
+    uint32_t sampleInterval(uint8_t filterNr = 255) const;          // get minimum sample interval of filter at index i
+    uint8_t intervalToFilterNr(uint32_t maxInterval) const;         // get slowest filter number with interval faster than argument
 
     uint32_t getCount() const
     {
@@ -70,12 +65,11 @@ public:
     {
         return selectStage(stages.size() - 1) - stages.cbegin() + 1;
     }
-    uint8_t fractionBits(uint8_t idx) const;
-    uint8_t fractionBits() const;
-    int64_t readWithNFractionBits(uint8_t filterNr, uint8_t bits) const;
-    int64_t readWithNFractionBits(uint8_t bits) const;
+    uint8_t fractionBits(uint8_t idx = 255) const;
+    int64_t readWithNFractionBits(uint8_t bits, uint8_t filterNr = 255) const;
     int32_t readLastInput() const;
-    IirFilter::DerivativeResult readDerivative(uint8_t filterNr) const;
+    IirFilter::DerivativeResult readDerivative(uint8_t filterNr, bool smooth = true) const;
+
     void reset(int32_t value);
 
 private:

--- a/lib/inc/FpFilterChain.h
+++ b/lib/inc/FpFilterChain.h
@@ -65,17 +65,17 @@ public:
     {
         return cnl::wrap<value_type>(chain.getStepThreshold());
     }
-    value_type read() const
+    value_type read(bool smooth = true) const
     {
         if (readIdx == 0) {
             return cnl::wrap<value_type>(chain.readLastInput());
         }
-        return cnl::wrap<value_type>(chain.read(readIdx - 1));
+        return cnl::wrap<value_type>(chain.read(readIdx - 1, smooth));
     }
 
-    value_type read(uint8_t filterNr) const
+    value_type read(uint8_t filterNr, bool smooth = true) const
     {
-        return cnl::wrap<value_type>(chain.read(filterNr));
+        return cnl::wrap<value_type>(chain.read(filterNr, smooth));
     }
 
     value_type readLastInput() const
@@ -90,9 +90,12 @@ public:
 
     // get the derivative from the chain with max precision and convert to the requested FP precision
     template <typename U>
-    U readDerivative(uint8_t idx) const
+    U readDerivative(uint8_t idx = 255, bool smooth = true) const
     {
-        auto derivative = chain.readDerivative(idx);
+        if (idx == 255) {
+            idx = readIdx - 1;
+        }
+        auto derivative = chain.readDerivative(idx, smooth);
         uint8_t destFractionBits = cnl::_impl::fractional_digits<U>::value;
         uint8_t filterFactionBits = cnl::_impl::fractional_digits<T>::value + derivative.fractionBits;
         int64_t result;
@@ -104,23 +107,20 @@ public:
         return cnl::wrap<U>(result);
     }
 
-    template <typename U>
-    U readDerivative() const
-    {
-        return readDerivative<U>(readIdx > 0 ? readIdx - 1 : 0);
-    }
-
-    auto intervalToFilterNr(uint16_t maxInterval)
+    auto
+    intervalToFilterNr(uint16_t maxInterval)
     {
         return chain.intervalToFilterNr(maxInterval);
     }
 
-    void reset(value_type value)
+    void
+    reset(value_type value)
     {
         chain.reset(cnl::unwrap(value));
     }
 
-    void expandStages(size_t numStages)
+    void
+    expandStages(size_t numStages)
     {
         chain.expandStages(numStages);
     }

--- a/lib/inc/IirFilter.h
+++ b/lib/inc/IirFilter.h
@@ -64,6 +64,11 @@ public:
         return {yv[0] - yv[1], fractionBits()};
     }
 
+    DerivativeResult readPreviousDerivative() const // returns unshifted derivative
+    {
+        return {yv[1] - yv[2], fractionBits()};
+    }
+
     int32_t unityStepDerivative() const
     {
         return params().maxDerivative;

--- a/lib/inc/IirFilter.h
+++ b/lib/inc/IirFilter.h
@@ -42,6 +42,7 @@ public:
     void setStepThreshold(const int32_t);
     int32_t getStepThreshold() const;
     int32_t read(void) const;
+    int32_t readPrevious(void) const;
     int64_t readWithNFractionBits(uint8_t bits) const;
     uint8_t downsamplePeriod() const;
     uint8_t fractionBits() const

--- a/lib/src/FilterChain.cpp
+++ b/lib/src/FilterChain.cpp
@@ -158,9 +158,29 @@ FilterChain::read(uint8_t filterNr) const
 }
 
 int32_t
+FilterChain::readSmooth(uint8_t filterNr) const
+{
+
+    auto stage = selectStage(filterNr);
+    auto updateInterval = sampleInterval(stage - 1);
+    auto elapsed = counter % updateInterval;
+    int64_t latest = stage->filter->read();
+    int64_t previous = stage->filter->readPrevious();
+
+    int32_t interpolated = (latest * elapsed + previous * (updateInterval - elapsed)) / updateInterval;
+    return interpolated;
+}
+
+int32_t
 FilterChain::read() const
 {
     return read(stages.size() - 1);
+}
+
+int32_t
+FilterChain::readSmooth() const
+{
+    return readSmooth(stages.size() - 1);
 }
 
 int64_t

--- a/lib/src/FilterChain.cpp
+++ b/lib/src/FilterChain.cpp
@@ -124,7 +124,7 @@ FilterChain::expandStages(size_t numStages)
         return;
     }
     auto threshold = getStepThreshold();
-    auto currentOutput = read();
+    auto currentOutput = read(255, false);
     for (auto it = stages.begin(); it < stages.end() && it < stages.begin() + numStages; it++) {
         if (!it->filter) {
             it->filter = std::make_unique<IirFilter>(it->param, threshold);
@@ -152,47 +152,26 @@ FilterChain::getStepThreshold() const
 }
 
 int32_t
-FilterChain::read(uint8_t filterNr) const
-{
-    return selectStage(filterNr)->filter->read();
-}
-
-int32_t
-FilterChain::readSmooth(uint8_t filterNr) const
+FilterChain::read(uint8_t filterNr, bool smooth) const
 {
 
     auto stage = selectStage(filterNr);
+    int64_t latest = stage->filter->read();
+    if (!smooth) {
+        return latest;
+    }
     auto updateInterval = sampleInterval(stage - 1);
     auto elapsed = counter % updateInterval;
-    int64_t latest = stage->filter->read();
     int64_t previous = stage->filter->readPrevious();
 
     int32_t interpolated = (latest * elapsed + previous * (updateInterval - elapsed)) / updateInterval;
     return interpolated;
 }
 
-int32_t
-FilterChain::read() const
-{
-    return read(stages.size() - 1);
-}
-
-int32_t
-FilterChain::readSmooth() const
-{
-    return readSmooth(stages.size() - 1);
-}
-
 int64_t
-FilterChain::readWithNFractionBits(uint8_t filterNr, uint8_t bits) const
+FilterChain::readWithNFractionBits(uint8_t bits, uint8_t filterNr) const
 {
     return selectStage(filterNr)->filter->readWithNFractionBits(bits);
-}
-
-int64_t
-FilterChain::readWithNFractionBits(uint8_t bits) const
-{
-    return selectStage(stages.size() - 1)->filter->readWithNFractionBits(bits);
 }
 
 uint32_t
@@ -230,23 +209,11 @@ FilterChain::intervalToFilterNr(uint32_t maxInterval) const
     return filterNr;
 }
 
-uint32_t
-FilterChain::sampleInterval() const
-{
-    return sampleInterval(stages.size() - 1);
-}
-
 uint8_t
 FilterChain::fractionBits(uint8_t filterNr) const
 {
 
     return selectStage(filterNr)->filter->fractionBits();
-}
-
-uint8_t
-FilterChain::fractionBits() const
-{
-    return fractionBits(stages.size() - 1);
 }
 
 int32_t
@@ -256,11 +223,20 @@ FilterChain::readLastInput() const
 }
 
 IirFilter::DerivativeResult
-FilterChain::readDerivative(uint8_t filterNr) const
+FilterChain::readDerivative(uint8_t filterNr, bool smooth) const
 {
     auto stage = selectStage(filterNr);
-    auto retv = stage->filter->readDerivative();
-    // Scale back derivative to account for sample interval in slower updating stages
-    retv.result = retv.result / sampleInterval(stage - 1);
-    return retv;
+    auto updateInterval = sampleInterval(stage - 1);
+    auto latest = stage->filter->readDerivative();
+    latest.result = latest.result / updateInterval;
+    if (smooth) {
+        auto elapsed = counter % updateInterval;
+        auto previous = stage->filter->readPreviousDerivative();
+        previous.result = previous.result / updateInterval;
+        int64_t interpolated = (latest.result * elapsed + previous.result * (updateInterval - elapsed)) / updateInterval;
+        latest.result = interpolated;
+        return latest;
+    } else {
+        return latest;
+    }
 }

--- a/lib/src/IirFilter.cpp
+++ b/lib/src/IirFilter.cpp
@@ -90,6 +90,12 @@ IirFilter::read(void) const
     return unshift(yv[0]);
 }
 
+int32_t
+IirFilter::readPrevious(void) const
+{
+    return unshift(yv[1]);
+}
+
 int64_t
 IirFilter::readWithNFractionBits(uint8_t bits) const
 {

--- a/lib/test/FilterChainTest.cpp
+++ b/lib/test/FilterChainTest.cpp
@@ -185,11 +185,11 @@ SCENARIO("Basic test of chain of filters")
                 return t;
             };
 
-            CHECK(findStepResponseDelay(chains[6], 100000) == 2496);
-            CHECK(findStepResponseDelay(chains[6], 900) == 2496);
+            CHECK(findStepResponseDelay(chains[6], 100000) == 2641);
+            CHECK(findStepResponseDelay(chains[6], 900) == 2641);
             chains[6].setStepThreshold(1000);
-            CHECK(findStepResponseDelay(chains[6], 100000) < 400);
-            CHECK(findStepResponseDelay(chains[6], 900) == 2496);
+            CHECK(findStepResponseDelay(chains[6], 100000) < 500);
+            CHECK(findStepResponseDelay(chains[6], 900) == 2641);
         }
 
         THEN("The smoothed output is continuous and lags the non-smoothed output by the interval of the last filter")
@@ -197,23 +197,32 @@ SCENARIO("Basic test of chain of filters")
             struct SmoothTestResult {
                 int32_t max;
                 int32_t maxS;
+
+                int64_t maxD;
+
+                int64_t maxDS;
                 int32_t lag;
             };
 
             auto testSmooth = [&sine](FilterChain& c, const uint32_t& period) {
                 int32_t amplIn = 100000;
                 int32_t max = 0;
+                auto maxD = c.readDerivative(c.length());
                 int32_t maxSmooth = 0;
+                auto maxDSmooth = c.readDerivative(c.length());
                 c.reset(0);
 
                 int32_t zero_cross1 = 0;
                 int32_t zero_cross2 = 0;
-                for (uint32_t t = 0; t < period * 10; ++t) {
-                    int32_t wave = sine(t, period, amplIn);
+                for (uint32_t t = 0; t < period * 6; ++t) {
+                    auto wave = sine(t, period, amplIn);
                     c.add(wave);
-                    int32_t filterOutput = c.read();
-                    int32_t filterOutputSmooth = c.readSmooth();
-                    if (t > 4 * period) { // ignore start
+                    auto filterOutput = c.read(255, false);
+                    auto filterOutputSmooth = c.read(255, true);
+
+                    auto derivative = c.readDerivative(255, false);
+                    auto derivativeSmooth = c.readDerivative(255, true);
+                    if (t > 3 * period) { // ignore start
                         if (filterOutput > max) {
                             max = filterOutput;
                             zero_cross1 = t; // get time of first maximum
@@ -223,19 +232,35 @@ SCENARIO("Basic test of chain of filters")
                             maxSmooth = filterOutputSmooth;
                             zero_cross2 = t; // get time of first maximum
                         }
+
+                        if (derivative.result > maxD.result) {
+                            maxD = derivative;
+                        }
+
+                        if (derivativeSmooth.result > maxDSmooth.result) {
+                            maxDSmooth = derivativeSmooth;
+                        }
                     }
                 }
 
-                return SmoothTestResult{max, maxSmooth, zero_cross2 - zero_cross1};
+                return SmoothTestResult{
+                    max,
+                    maxSmooth,
+                    maxD.result,
+                    maxDSmooth.result,
+                    zero_cross2 - zero_cross1};
             };
 
-            auto result = testSmooth(chains[6], 30000);
+            auto result = testSmooth(chains[2], 200);
             CHECK(result.max == result.maxS);
-            CHECK(result.lag == chains[6].sampleInterval());
+            CHECK(result.maxD == result.maxDS);
+            CHECK(result.lag < chains[2].sampleInterval());
 
-            result = testSmooth(chains[3], 2000);
+            result = testSmooth(chains[5], 1000);
             CHECK(result.max == result.maxS);
-            CHECK(result.lag == chains[3].sampleInterval());
+
+            CHECK(result.maxD == result.maxDS);
+            CHECK(result.lag == chains[5].sampleInterval());
         }
     }
 }
@@ -299,7 +324,7 @@ countSameValueAtOutPut(FilterChain& chain, uint32_t sameSampleCount, uint32_t co
     uint32_t counterMaxSeen = 0;
     for (uint32_t i = 0; i < 1000; i++) {
         chain.add(100000);
-        out.push_back(chain.read());
+        out.push_back(chain.read(255, false));
         counterMaxSeen = std::max(counterMaxSeen, chain.getCount());
     }
     uint32_t count = 1;
@@ -330,9 +355,9 @@ isUpdatedAtCounts(FilterChain& chain, uint8_t filterIndex, std::vector<uint32_t>
         chain.add(step); // ensure the filter output is a rising slope (skip the flat start)
     }
     while (ticks.size() < counts.size() && count < 10000) {
-        int32_t previousFilterVal = chain.read(filterIndex);
+        int32_t previousFilterVal = chain.read(filterIndex, false);
         chain.add(step);
-        int32_t filterVal = chain.read(filterIndex);
+        int32_t filterVal = chain.read(filterIndex, false);
         if (filterVal != previousFilterVal) {
             ticks.push_back(count);
         }
@@ -447,7 +472,7 @@ SCENARIO("Filters chain output matches manually cascaded filters", "[filterchain
                 f2.add(f1.readWithNFractionBits(f1.fractionBits()), f1.fractionBits());
                 f3.add(f2.readWithNFractionBits(f2.fractionBits()), f2.fractionBits());
                 CAPTURE(i);
-                REQUIRE(chain.read() == f3.read());
+                REQUIRE(chain.read(255, false) == f3.read());
             }
         }
         THEN("the output is almost same if separate filters are read with normal precision")
@@ -464,13 +489,13 @@ SCENARIO("Filters chain output matches manually cascaded filters", "[filterchain
                 f2.add(f1.read());
                 f3.add(f2.read());
                 CAPTURE(i);
-                REQUIRE_THAT(chain.read(), IsWithinOf(50, f3.read()));
+                REQUIRE_THAT(chain.read(255, false), IsWithinOf(50, f3.read()));
             }
         }
     }
 }
 
-SCENARIO("A filter chain can be only initalized with short length, but expanded as specced later", "[filterchain][length]")
+SCENARIO("A filter chain can be only initalized with short length but expanded as specced later", "[filterchain]")
 {
     WHEN("A filter chain is created with initially only 1 stage")
     {

--- a/lib/test/PidTest.cpp
+++ b/lib/test/PidTest.cpp
@@ -658,7 +658,7 @@ SCENARIO("PID Test with PWM actuator", "[pid]")
         CHECK(mockVal == 29);
         CHECK(pid.error() == Approx(1).epsilon(0.1)); // the filter introduces some delay, which is why this is not 1.0
         CHECK(pid.p() == Approx(10).epsilon(0.1));
-        CHECK(pid.i() == Approx(accumulatedError * (10.0 / 2000)).epsilon(0.02)); // some integral anti-windup will occur at the start
+        CHECK(pid.i() == Approx(accumulatedError * (10.0 / 2000)).epsilon(0.03)); // some integral anti-windup will occur due to filtering at the start
         CHECK(pid.d() == Approx(-10 * 9.0 / 900 * 200).epsilon(0.01));
 
         CHECK(actuator->setting() == pid.p() + pid.i() + pid.d());
@@ -697,7 +697,7 @@ SCENARIO("PID Test with PWM actuator", "[pid]")
         CHECK(mockVal == 21);
         CHECK(pid.error() == Approx(-1).epsilon(0.1)); // the filter introduces some delay, which is why this is not 1.0
         CHECK(pid.p() == Approx(10).epsilon(0.1));
-        CHECK(pid.i() == Approx(accumulatedError * (-10.0 / 2000)).epsilon(0.02)); // some integral anti-windup will occur at the start
+        CHECK(pid.i() == Approx(accumulatedError * (-10.0 / 2000)).epsilon(0.03)); // some integral anti-windup will occur due to filtering at the start
         CHECK(pid.d() == Approx(-10 * 9.0 / 900 * 200).epsilon(0.02));
 
         CHECK(actuator->setting() == pid.p() + pid.i() + pid.d());


### PR DESCRIPTION
Sensor input is filtered by 6 cascaded second-order IIR filters. Depending on the amount of filtering desired, one of the 6 stages is read.

Each filter subsamples the previous at an interval: {2, 2, 2, 3, 3, 4}
This means that the last filter updates very infrequently, which results in a blocky output.
The update rate of this filter is 72 seconds (2*2*2*3*3).

This PR implements linear interpolation between output values of the stage, at the cost of some extra delay. This delay is small compared to the delay of the filter itself at each tap.
For the strongest filter, the delay of the filter itself is 30 minutes. The extra 72 second delay is no issue at all.

The PID often uses heavy filtering for the derivative. As you can see below, the interpolated output is much nicer.

![image](https://user-images.githubusercontent.com/1708921/80886065-04c64900-8cbe-11ea-8319-8139ffee9e34.png)
