### PR TITLE
Reduced filtering on PID derivative, only apply derivative when it counteracts P

### DIFF
--- a/app/brewblox/blox/PidBlock.h
+++ b/app/brewblox/blox/PidBlock.h
@@ -111,6 +111,7 @@ public:
         message.boilPointAdjust = cnl::unwrap(pid.boilPointAdjust());
         message.boilMinOutput = cnl::unwrap(pid.boilMinOutput());
         message.boilModeActive = pid.boilModeActive();
+        message.derivativeFilter = blox_Pid_FilterChoice(pid.derivativeFilterIdx() + 1);
 
         stripped.copyToMessage(message.strippedFields, message.strippedFields_count, 4);
 

--- a/app/brewblox/main.cpp
+++ b/app/brewblox/main.cpp
@@ -39,8 +39,10 @@
 
 SYSTEM_THREAD(ENABLED);
 SYSTEM_MODE(SEMI_AUTOMATIC);
-STARTUP(System.enableFeature(FEATURE_RESET_INFO));
-STARTUP(System.enableFeature(FEATURE_RETAINED_MEMORY));
+STARTUP(
+    System.enableFeature(FEATURE_RESET_INFO);
+    System.enableFeature(FEATURE_RETAINED_MEMORY);
+    System.disableFeature(FEATURE_WIFI_POWERSAVE_CLOCK););
 
 #if PLATFORM_ID == PLATFORM_GCC
 #include <csignal>

--- a/app/brewblox/test/PidBlock_test.cpp
+++ b/app/brewblox/test/PidBlock_test.cpp
@@ -150,7 +150,8 @@ SCENARIO("A Blox Pid object with mock analog actuator")
                                             "error: 4096 integral: 4096000 "
                                             "drivenOutputId: 102 "
                                             "boilPointAdjust: -2048 "
-                                            "boilMinOutput: 102400");
+                                            "boilMinOutput: 102400 "
+                                            "derivativeFilter: FILT_3m");
     }
 
     THEN("The integral value can be written externally to reset it trough the integralReset field")
@@ -178,7 +179,8 @@ SCENARIO("A Blox Pid object with mock analog actuator")
                                             "error: 4096 integral: 16388096 "
                                             "drivenOutputId: 102 "
                                             "boilPointAdjust: -2048 "
-                                            "boilMinOutput: 102400");
+                                            "boilMinOutput: 102400 "
+                                            "derivativeFilter: FILT_3m");
     }
 
     AND_WHEN("The setpoint is disabled")
@@ -266,7 +268,8 @@ SCENARIO("A Blox Pid object with mock analog actuator")
                                                 "drivenOutputId: 102 "
                                                 "boilPointAdjust: -2048 "
                                                 "boilMinOutput: 102400 "
-                                                "boilModeActive: true");
+                                                "boilModeActive: true "
+                                                "derivativeFilter: FILT_3m");
         }
     }
 }

--- a/app/brewblox/test/PidBlock_test.cpp
+++ b/app/brewblox/test/PidBlock_test.cpp
@@ -151,7 +151,7 @@ SCENARIO("A Blox Pid object with mock analog actuator")
                                             "drivenOutputId: 102 "
                                             "boilPointAdjust: -2048 "
                                             "boilMinOutput: 102400 "
-                                            "derivativeFilter: FILT_3m");
+                                            "derivativeFilter: FILT_90s");
     }
 
     THEN("The integral value can be written externally to reset it trough the integralReset field")
@@ -180,7 +180,7 @@ SCENARIO("A Blox Pid object with mock analog actuator")
                                             "drivenOutputId: 102 "
                                             "boilPointAdjust: -2048 "
                                             "boilMinOutput: 102400 "
-                                            "derivativeFilter: FILT_3m");
+                                            "derivativeFilter: FILT_90s");
     }
 
     AND_WHEN("The setpoint is disabled")
@@ -269,7 +269,7 @@ SCENARIO("A Blox Pid object with mock analog actuator")
                                                 "boilPointAdjust: -2048 "
                                                 "boilMinOutput: 102400 "
                                                 "boilModeActive: true "
-                                                "derivativeFilter: FILT_3m");
+                                                "derivativeFilter: FILT_90s");
         }
     }
 }

--- a/lib/inc/Pid.h
+++ b/lib/inc/Pid.h
@@ -126,12 +126,7 @@ public:
         return m_td;
     }
 
-    void td(const uint16_t& arg)
-    {
-        m_td = arg;
-        m_derivativeFilterIdx = 0; // trigger automatic filter selection
-        checkFilterLength();
-    }
+    void td(const uint16_t& arg);
 
     void enabled(bool state)
     {
@@ -173,6 +168,11 @@ public:
     void boilMinOutput(const out_t& v)
     {
         m_boilMinOutput = v;
+    }
+
+    uint8_t derivativeFilterIdx() const
+    {
+        return m_derivativeFilterIdx;
     }
 
 private:

--- a/lib/src/Pid.cpp
+++ b/lib/src/Pid.cpp
@@ -174,7 +174,9 @@ Pid::checkFilterLength()
 {
     if (!m_derivativeFilterIdx) {
         if (auto input = m_inputPtr()) {
-            m_derivativeFilterIdx = input->intervalToFilterNr(m_td / 8);
+            // selected filter must an update interval a lot faster than Td to be meaningful
+            // The filter delay is roughly 6x the update rate.
+            m_derivativeFilterIdx = input->intervalToFilterNr(m_td / 32);
             input->resizeFilterIfNeeded(m_derivativeFilterIdx);
         }
     }

--- a/lib/src/Pid.cpp
+++ b/lib/src/Pid.cpp
@@ -58,8 +58,12 @@ Pid::update()
     } else {
         m_i = 0;
     }
-
-    m_d = -m_kp * fp12_t(m_derivative * m_td);
+    auto m_d_temp = fp12_t(m_derivative * m_td);
+    if ((m_d_temp >= m_error && m_error >= 0)
+        || (m_d_temp <= m_error && m_error <= 0)) {
+        m_d_temp = m_error;
+    }
+    m_d = -m_kp * m_d_temp;
 
     auto pidResult = m_p + m_i + m_d;
 
@@ -71,7 +75,6 @@ Pid::update()
 
     // try to set the output to the desired setting
     if (m_enabled) {
-
         if (auto output = m_outputPtr()) {
             output->settingValid(true);
             output->setting(outputValue);

--- a/lib/src/Pid.cpp
+++ b/lib/src/Pid.cpp
@@ -153,6 +153,14 @@ Pid::ti(const uint16_t& arg)
 }
 
 void
+Pid::td(const uint16_t& arg)
+{
+    m_td = arg;
+    m_derivativeFilterIdx = 0; // trigger automatic filter selection
+    checkFilterLength();
+}
+
+void
 Pid::setIntegral(const out_t& newIntegratorPart)
 {
     if (m_kp == 0) {
@@ -166,8 +174,7 @@ Pid::checkFilterLength()
 {
     if (!m_derivativeFilterIdx) {
         if (auto input = m_inputPtr()) {
-            // still need to get filter Idx. Done in update because it needs the input Ptr
-            m_derivativeFilterIdx = input->intervalToFilterNr(m_td / 2);
+            m_derivativeFilterIdx = input->intervalToFilterNr(m_td / 8);
             input->resizeFilterIfNeeded(m_derivativeFilterIdx);
         }
     }

--- a/lib/src/Pid.cpp
+++ b/lib/src/Pid.cpp
@@ -58,12 +58,22 @@ Pid::update()
     } else {
         m_i = 0;
     }
-    auto m_d_temp = fp12_t(m_derivative * m_td);
-    if ((m_d_temp >= m_error && m_error >= 0)
-        || (m_d_temp <= m_error && m_error <= 0)) {
-        m_d_temp = m_error;
+    m_d = -m_kp * fp12_t(m_derivative * m_td);
+    if (m_p >= 0) {
+        if (m_d > 0) {
+            m_d = 0; // only counteract p
+        }
+        if (m_d < -m_p) {
+            m_d = -m_p; // limit to inverse of p
+        }
+    } else {
+        if (m_d < 0) {
+            m_d = 0;
+        }
+        if (m_d > -m_p) {
+            m_d = -m_p;
+        }
     }
-    m_d = -m_kp * m_d_temp;
 
     auto pidResult = m_p + m_i + m_d;
 

--- a/lib/src/Pid.cpp
+++ b/lib/src/Pid.cpp
@@ -32,12 +32,10 @@ Pid::update()
         setpoint = input->setting();
         m_boilModeActive = setpoint >= in_t{100} + m_boilPointAdjust;
         m_error = input->error();
-        if (m_td) {
-            checkFilterLength();
-            m_derivative = input->readDerivative(m_derivativeFilterIdx);
-        } else {
-            m_derivativeFilterIdx = 0;
-        }
+
+        checkFilterLength();
+        m_derivative = input->readDerivative(m_derivativeFilterIdx);
+
         m_integral = (m_ti != 0 && !m_boilModeActive) ? integral_t(m_integral + m_error) : integral_t(0);
     } else {
         if (active()) {
@@ -190,6 +188,10 @@ Pid::checkFilterLength()
             // selected filter must an update interval a lot faster than Td to be meaningful
             // The filter delay is roughly 6x the update rate.
             m_derivativeFilterIdx = input->intervalToFilterNr(m_td / 32);
+            if (m_derivativeFilterIdx < 1) {
+                m_derivativeFilterIdx = 1;
+            };
+
             input->resizeFilterIfNeeded(m_derivativeFilterIdx);
         }
     }

--- a/lib/test/PidTest.cpp
+++ b/lib/test/PidTest.cpp
@@ -126,7 +126,7 @@ SCENARIO("PID Test with mock actuator", "[pid]")
 
         THEN("The PID will ensure the filter of the input is long enough for td")
         {
-            CHECK(input->filterLength() == 5);
+            CHECK(input->filterLength() == 4);
         }
 
         input->setting(30);
@@ -949,12 +949,13 @@ SCENARIO("PID Test with PWM actuator", "[pid]")
             return dMin;
         };
 
-        THEN("A derivative filter is selected so that derivative output is max 30%-150% of proportional gain")
+        THEN("A derivative filter is selected so that derivative output is at least 100% and max 250% of proportional gain for a step")
         {
-            for (uint16_t td = 20; td < 1200; td = td * 5 / 4) {
-                // INFO("td=" + std::to_string(td));
-                CHECK(testStep(td) >= -150);
-                CHECK(testStep(td) <= -30);
+            std::vector<uint16_t> tds{10, 30, 60, 120, 300, 600, 1200};
+            for (auto td : tds) {
+                CAPTURE(td);
+                CHECK(testStep(td) >= -250);
+                CHECK(testStep(td) <= -100);
             }
         }
     }

--- a/lib/test/PidTest.cpp
+++ b/lib/test/PidTest.cpp
@@ -932,8 +932,8 @@ SCENARIO("PID Test with PWM actuator", "[pid]")
         auto testStep = [&](uint16_t td) {
             pid.td(td);
             auto start = now;
-            auto dMin = Pid::out_t(0);
-            auto dMinTime = now;
+            auto dMax = Pid::derivative_t(0);
+            auto dMaxTime = now;
             sensor->setting(20);
             input->resetFilter();
 
@@ -942,21 +942,21 @@ SCENARIO("PID Test with PWM actuator", "[pid]")
                     nextPwmUpdate = pwm.update(now);
                 }
                 if (now == start + 10'000) {
-                    sensor->setting(30);
+                    sensor->setting(25);
                 }
                 if (now >= nextPidUpdate) {
                     input->update();
                     pid.update();
-                    if (pid.d() < dMin) {
-                        dMin = pid.d();
-                        dMinTime = now;
+                    if (pid.derivative() > dMax) {
+                        dMax = pid.derivative();
+                        dMaxTime = now;
                     }
                     actuator->update();
                     nextPidUpdate = now + 1000;
                 }
                 ++now;
             }
-            auto lag = (dMinTime - start) / 1000; // return lag in seconds
+            auto lag = (dMaxTime - start) / 1000; // return lag in seconds
             return lag;
         };
 

--- a/lib/test/PidTest.cpp
+++ b/lib/test/PidTest.cpp
@@ -62,6 +62,11 @@ SCENARIO("PID Test with mock actuator", "[pid]")
         input->update();
         pid.update();
 
+        THEN("With Td zero, the derivative filter is 1")
+        {
+            CHECK(pid.derivativeFilterIdx() == 1);
+        }
+
         CHECK(actuator->setting() == Approx(10).margin(0.01));
     }
 
@@ -962,7 +967,8 @@ SCENARIO("PID Test with PWM actuator", "[pid]")
 
         THEN("A derivative filter is selected so that the lag between value and max derivative between 1/4 td and 1/2 Td")
         {
-            std::vector<uint16_t> tds{60, 120, 300, 600, 1200};
+            // minimum filtering is filter idx 1, so values under 90 will have delay of 43.
+            std::vector<uint16_t> tds{90, 120, 300, 600, 1200};
             for (auto td : tds) {
                 CAPTURE(td);
                 auto selectedFilter = pid.derivativeFilterIdx();


### PR DESCRIPTION
The filtering on the derivative was too much, making it less useful to reduce overshoot.
With the updates for interpolating filter stages, we can use a much faster filter.

I also added some limits to only apply the derivative when it would reduce the actuator output.

Finally, I have changed the time unit for the derivative, because degC/h was too big and dominated the chart. Sensible values for Td are in minutes, so having the derivative unit in minutes makes much more sense.

Required changes in service/UI:
- Update units for renames and new per minute / multiplied by minutes unit
- Add a subtle note to expanded PID widget to show which filter is selected for the derivative.