### PR TITLE
Picked new limits for derivative filter selection

### DIFF
--- a/app/brewblox/blox/PidBlock.h
+++ b/app/brewblox/blox/PidBlock.h
@@ -111,7 +111,7 @@ public:
         message.boilPointAdjust = cnl::unwrap(pid.boilPointAdjust());
         message.boilMinOutput = cnl::unwrap(pid.boilMinOutput());
         message.boilModeActive = pid.boilModeActive();
-        message.derivativeFilter = blox_Pid_FilterChoice(pid.derivativeFilterIdx() + 1);
+        message.derivativeFilter = blox_Pid_FilterChoice(pid.derivativeFilterNr());
 
         stripped.copyToMessage(message.strippedFields, message.strippedFields_count, 4);
 

--- a/app/brewblox/test/PidBlock_test.cpp
+++ b/app/brewblox/test/PidBlock_test.cpp
@@ -151,7 +151,7 @@ SCENARIO("A Blox Pid object with mock analog actuator")
                                             "drivenOutputId: 102 "
                                             "boilPointAdjust: -2048 "
                                             "boilMinOutput: 102400 "
-                                            "derivativeFilter: FILT_90s");
+                                            "derivativeFilter: FILT_3m");
     }
 
     THEN("The integral value can be written externally to reset it trough the integralReset field")
@@ -180,7 +180,7 @@ SCENARIO("A Blox Pid object with mock analog actuator")
                                             "drivenOutputId: 102 "
                                             "boilPointAdjust: -2048 "
                                             "boilMinOutput: 102400 "
-                                            "derivativeFilter: FILT_90s");
+                                            "derivativeFilter: FILT_3m");
     }
 
     AND_WHEN("The setpoint is disabled")
@@ -269,7 +269,7 @@ SCENARIO("A Blox Pid object with mock analog actuator")
                                                 "boilPointAdjust: -2048 "
                                                 "boilMinOutput: 102400 "
                                                 "boilModeActive: true "
-                                                "derivativeFilter: FILT_90s");
+                                                "derivativeFilter: FILT_3m");
         }
     }
 }

--- a/lib/inc/FpFilterChain.h
+++ b/lib/inc/FpFilterChain.h
@@ -26,15 +26,13 @@ template <typename T>
 class FpFilterChain {
 private:
     FilterChain chain;
-    uint8_t readIdx; // 0 for no filtering, 1 - 6 for each filter stage
 
 public:
     using value_type = T;
 
-    FpFilterChain(uint8_t idx, uint8_t initStages = 0)
+    FpFilterChain(uint8_t initStages = 0)
         : chain({0, 2, 2, 2, 2, 2}, {2, 2, 2, 3, 3, 4}, initStages)
     {
-        setReadIdx(idx);
     }
     FpFilterChain(const FpFilterChain&) = delete;
     FpFilterChain& operator=(const FpFilterChain&) = delete;
@@ -46,36 +44,19 @@ public:
     }
     void add(int32_t val);
 
-    void setReadIdx(uint8_t idx)
-    {
-        readIdx = idx;
-        expandStages(readIdx);
-    }
-
-    uint8_t getReadIdx() const
-    {
-        return readIdx;
-    }
-
     void setStepThreshold(value_type stepThreshold)
     {
         chain.setStepThreshold(cnl::unwrap(stepThreshold));
     }
+
     value_type getStepThreshold() const
     {
         return cnl::wrap<value_type>(chain.getStepThreshold());
     }
-    value_type read(bool smooth = true) const
-    {
-        if (readIdx == 0) {
-            return cnl::wrap<value_type>(chain.readLastInput());
-        }
-        return cnl::wrap<value_type>(chain.read(readIdx - 1, smooth));
-    }
 
-    value_type read(uint8_t filterNr, bool smooth = true) const
+    value_type read(uint8_t filterIdx = 255, bool smooth = true) const
     {
-        return cnl::wrap<value_type>(chain.read(filterNr, smooth));
+        return cnl::wrap<value_type>(chain.read(filterIdx, smooth));
     }
 
     value_type readLastInput() const
@@ -90,12 +71,9 @@ public:
 
     // get the derivative from the chain with max precision and convert to the requested FP precision
     template <typename U>
-    U readDerivative(uint8_t idx = 255, bool smooth = true) const
+    U readDerivative(uint8_t filterIdx = 255, bool smooth = true) const
     {
-        if (idx == 255) {
-            idx = readIdx - 1;
-        }
-        auto derivative = chain.readDerivative(idx, smooth);
+        auto derivative = chain.readDerivative(filterIdx, smooth);
         uint8_t destFractionBits = cnl::_impl::fractional_digits<U>::value;
         uint8_t filterFactionBits = cnl::_impl::fractional_digits<T>::value + derivative.fractionBits;
         int64_t result;
@@ -108,7 +86,7 @@ public:
     }
 
     auto
-    intervalToFilterNr(uint16_t maxInterval)
+    intervalToFilterIdx(uint16_t maxInterval)
     {
         return chain.intervalToFilterNr(maxInterval);
     }

--- a/lib/inc/Pid.h
+++ b/lib/inc/Pid.h
@@ -42,7 +42,7 @@ private:
     out_t m_d = out_t{0};
     integral_t m_integral = integral_t{0};
     derivative_t m_derivative = derivative_t{0};
-    uint8_t m_derivativeFilterIdx = 0;
+    uint8_t m_derivativeFilterNr = 0;
 
     // settings
     in_t m_kp = in_t{0};    // proportional gain
@@ -170,9 +170,9 @@ public:
         m_boilMinOutput = v;
     }
 
-    uint8_t derivativeFilterIdx() const
+    uint8_t derivativeFilterNr() const
     {
-        return m_derivativeFilterIdx;
+        return m_derivativeFilterNr;
     }
 
 private:


### PR DESCRIPTION
In testing I saw that for very slow processes, the new derivative filter selection caused a bit too much derivative when a OneWire sensor has a bit flip.

I hand picked new limits that work better in typical fermentation scenarios.
A bit more filtering than the previous release.