### PR TITLE
Trace last performed actions in backup RAM to help debug watchdog resets

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -16,7 +16,7 @@ AllowShortIfStatementsOnASingleLine: false
 AllowShortLoopsOnASingleLine: false
 AlwaysBreakAfterDefinitionReturnType: None
 AlwaysBreakAfterReturnType: TopLevel
-AlwaysBreakBeforeMultilineStrings: false
+AlwaysBreakBeforeMultilineStrings: true
 AlwaysBreakTemplateDeclarations: false
 BinPackArguments: true
 BinPackParameters: true

--- a/app/brewblox/BrewBlox.cpp
+++ b/app/brewblox/BrewBlox.cpp
@@ -49,6 +49,7 @@
 #include "cbox/EepromObjectStorage.h"
 #include "cbox/ObjectContainer.h"
 #include "cbox/ObjectFactory.h"
+#include "cbox/Tracing.h"
 #include "cbox/spark/SparkEepromAccess.h"
 #include "deviceid_hal.h"
 #include "platforms.h"
@@ -111,7 +112,10 @@ using PinsBlock = Spark2PinsBlock;
 using PinsBlock = Spark3PinsBlock;
 #endif
 
+__attribute__((section(".retained_user"))) cbox::Tracing::trace_t cbox::Tracing::trace;
+
 cbox::ConnectionPool&
+
 theConnectionPool()
 {
 #if defined(SPARK)
@@ -305,6 +309,7 @@ connectionStarted(DataOut& out)
 #endif
     hexOut.write(resetData);
     out.write(',');
+
     uint8_t deviceId[12];
     HAL_device_ID(deviceId, 12);
     hexOut.writeBuffer(deviceId, 12);

--- a/app/brewblox/blox/SysInfoBlock.cpp
+++ b/app/brewblox/blox/SysInfoBlock.cpp
@@ -41,10 +41,7 @@ SysInfoBlock::streamTo(cbox::DataOut& out) const
 
     message.platform = blox_SysInfo_Platform(PLATFORM_ID);
 
-    switch (command) {
-    case Command::NONE:
-        break;
-    case Command::READ_TRACE: {
+    if (command == Command::READ_TRACE || command == Command::READ_AND_RESUME_TRACE) {
         // circular buffer, idx - 1 has most recent action
         auto history = cbox::Tracing::history();
         auto it = history.cbegin();
@@ -55,9 +52,11 @@ SysInfoBlock::streamTo(cbox::DataOut& out) const
             message.trace[i].type = it->type;
         }
         message.trace_count = 10;
-        cbox::Tracing::unpause();
-    } break;
     }
+    if (command == Command::RESUME_TRACE || command == Command::READ_AND_RESUME_TRACE) {
+        cbox::Tracing::unpause();
+    }
+
     command = Command::NONE;
 
     return streamProtoTo(out, &message, blox_SysInfo_fields, blox_SysInfo_size);

--- a/app/brewblox/blox/SysInfoBlock.h
+++ b/app/brewblox/blox/SysInfoBlock.h
@@ -35,4 +35,11 @@ class SysInfoBlock : public cbox::ObjectBase<BrewBloxTypes_BlockType_SysInfo> {
     {
         return update_never(now);
     }
+
+    enum class Command : uint8_t {
+        NONE = 0,
+        READ_TRACE = 1,
+    };
+
+    mutable Command command = Command::NONE;
 };

--- a/app/brewblox/blox/SysInfoBlock.h
+++ b/app/brewblox/blox/SysInfoBlock.h
@@ -39,6 +39,8 @@ class SysInfoBlock : public cbox::ObjectBase<BrewBloxTypes_BlockType_SysInfo> {
     enum class Command : uint8_t {
         NONE = 0,
         READ_TRACE = 1,
+        RESUME_TRACE = 2,
+        READ_AND_RESUME_TRACE = 3,
     };
 
     mutable Command command = Command::NONE;

--- a/app/brewblox/main.cpp
+++ b/app/brewblox/main.cpp
@@ -193,18 +193,22 @@ void
 loop()
 {
     ticks.switchTaskTimer(TicksClass::TaskId::DisplayUpdate);
+    cbox::Tracing::add(cbox::Tracing::Action::UPDATE_DISPLAY, 0, 0);
     displayTick();
     if (!listeningModeEnabled()) {
 
         ticks.switchTaskTimer(TicksClass::TaskId::Communication);
+        cbox::Tracing::add(cbox::Tracing::Action::UPDATE_CONNECTIONS, 0, 0);
         manageConnections(ticks.millis());
         brewbloxBox().hexCommunicate();
 
+        cbox::Tracing::add(cbox::Tracing::Action::UPDATE_BLOCKS, 0, 0);
         ticks.switchTaskTimer(TicksClass::TaskId::BlocksUpdate);
         updateBrewbloxBox();
 
         watchdogCheckin(); // not done while listening, so 60s timeout for stuck listening mode
     }
+    cbox::Tracing::add(cbox::Tracing::Action::SYSTEM_TASKS, 0, 0);
     ticks.switchTaskTimer(TicksClass::TaskId::System);
     HAL_Delay_Milliseconds(1);
 }

--- a/app/brewblox/main.cpp
+++ b/app/brewblox/main.cpp
@@ -132,6 +132,8 @@ setup()
     HAL_Delay_Milliseconds(1);
 #endif
 
+    cbox::Tracing::pause(); // ensure tracing is paused until service resumes it
+
     // init display
     D4D_Init(nullptr);
     D4D_TOUCHSCREEN_CALIB defaultCalib = {1, 0, 0, 64, 64};

--- a/app/brewblox/main.cpp
+++ b/app/brewblox/main.cpp
@@ -208,8 +208,8 @@ loop()
 
         watchdogCheckin(); // not done while listening, so 60s timeout for stuck listening mode
     }
-    cbox::Tracing::add(cbox::Tracing::Action::SYSTEM_TASKS, 0, 0);
     ticks.switchTaskTimer(TicksClass::TaskId::System);
+    cbox::Tracing::add(cbox::Tracing::Action::SYSTEM_TASKS, 0, 0);
     HAL_Delay_Milliseconds(1);
 }
 

--- a/controlbox/src/cbox/Box.h
+++ b/controlbox/src/cbox/Box.h
@@ -133,8 +133,8 @@ public:
         WRITE_OBJECT = 2,             // stream new data into an object from the data in
         CREATE_OBJECT = 3,            // add a new object
         DELETE_OBJECT = 4,            // delete an object by id
-        LIST_ACTIVE_OBJECTS = 5,      // list objects saved to persistent storage
-        READ_STORED_OBJECT = 6,       // list objects saved to persistent storage
+        LIST_ACTIVE_OBJECTS = 5,      // list active objects
+        READ_STORED_OBJECT = 6,       // list single object from persistent storage
         LIST_STORED_OBJECTS = 7,      // list objects saved to persistent storage
         CLEAR_OBJECTS = 8,            // remove all user objects
         REBOOT = 9,                   // reboot the system

--- a/controlbox/src/cbox/ContainedObject.h
+++ b/controlbox/src/cbox/ContainedObject.h
@@ -22,6 +22,7 @@
 #include "DataStream.h"
 #include "InactiveObject.h"
 #include "Object.h"
+#include "Tracing.h"
 #include <limits>
 #include <memory>
 
@@ -70,6 +71,7 @@ public:
 
     void update(const update_t& now)
     {
+        Tracing::add(Tracing::Action::UPDATE_OBJECT, _id, _obj->typeId());
         const update_t overflowGuard = std::numeric_limits<update_t>::max() / 2;
         if (overflowGuard - now + _nextUpdateTime <= overflowGuard) {
             _nextUpdateTime = _obj->update(now);
@@ -83,6 +85,7 @@ public:
 
     CboxError streamTo(DataOut& out) const
     {
+        Tracing::add(Tracing::Action::SEND_OBJECT, _id, _obj->typeId());
         if (!out.put(_id)) {
             return CboxError::OUTPUT_STREAM_WRITE_ERROR; // LCOV_EXCL_LINE
         }
@@ -98,7 +101,7 @@ public:
     CboxError streamFrom(DataIn& in)
     {
         // id is not streamed in. It is immutable and assumed to be already read to find this entry
-
+        Tracing::add(Tracing::Action::RECEIVE_OBJECT, _id, _obj->typeId());
         uint8_t newGroups;
         obj_type_t expectedType;
         if (!in.get(newGroups)) {
@@ -124,6 +127,7 @@ public:
 
     CboxError streamPersistedTo(DataOut& out) const
     {
+        Tracing::add(Tracing::Action::PERSIST_OBJECT, _id, _obj->typeId());
         // id is not streamed out. It is passed to storage separately
         if (_obj->typeId() == InactiveObject::staticTypeId()) {
             // inactive objects are not persisted, but no error is returned

--- a/controlbox/src/cbox/ContainedObject.h
+++ b/controlbox/src/cbox/ContainedObject.h
@@ -39,6 +39,7 @@ public:
         , _obj(std::move(obj))
         , _nextUpdateTime(0)
     {
+        Tracing::add(Tracing::Action::CREATE_OBJECT, _id, _obj->typeId());
     }
 
 private:

--- a/controlbox/src/cbox/ContainedObject.h
+++ b/controlbox/src/cbox/ContainedObject.h
@@ -42,6 +42,11 @@ public:
         Tracing::add(Tracing::Action::CREATE_OBJECT, _id, _obj->typeId());
     }
 
+    virtual ~ContainedObject()
+    {
+        Tracing::add(Tracing::Action::DELETE_OBJECT, _id, _obj->typeId());
+    }
+
 private:
     obj_id_t _id;                 // unique id of object
     uint8_t _groups;              // active in these groups

--- a/controlbox/src/cbox/ObjectIds.h
+++ b/controlbox/src/cbox/ObjectIds.h
@@ -33,9 +33,6 @@ public:
         : id(rhs)
     {
     }
-    obj_type_t(const obj_type_t& rhs) = default;
-    obj_type_t(obj_type_t& rhs) = default;
-    obj_type_t(obj_type_t&& rhs) = default;
 
     obj_type_t& operator=(const uint16_t& rhs)
     {

--- a/controlbox/src/cbox/Tracing.h
+++ b/controlbox/src/cbox/Tracing.h
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2020 Elco Jacobs / BrewBlox
+ *
+ * This file is part of ControlBox
+ *
+ * Controlbox is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Controlbox.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+#include "ObjectIds.h"
+#include <array>
+#include <cstdint>
+
+namespace cbox {
+
+class Tracing {
+public:
+    enum class Action : uint8_t {
+        NONE = 0,
+        SEND_OBJECT = 1,
+        RECEIVE_OBJECT = 2,
+        PERSIST_OBJECT = 3,
+        UPDATE_OBJECT = 4,
+    };
+
+    struct TraceEvent {
+        Action action = Action::NONE;
+        obj_id_t id = 0;
+        obj_type_t type = 0;
+    };
+    static void unpause()
+    {
+        trace.writeEnabled = true;
+    }
+
+    class trace_t {
+    public:
+        trace_t()
+            : idx(0)
+            , writeEnabled(false)
+        {
+        }
+
+        std::array<TraceEvent, 10> history;
+        uint8_t idx;
+        bool writeEnabled;
+
+        void add(Action a, obj_id_t i, obj_type_t t)
+        {
+            if (writeEnabled) {
+                history[idx] = TraceEvent{a, i, t};
+                idx = idx + 1;
+                if (idx >= history.size()) {
+                    idx = 0;
+                }
+            }
+        }
+        friend class Tracing;
+    };
+
+    static trace_t trace; // place this array in backup RAM that is not reset on reboot
+
+    static void add(Action a, obj_id_t i, obj_type_t t)
+    {
+        trace.add(a, i, t);
+    }
+};
+}

--- a/controlbox/src/cbox/Tracing.h
+++ b/controlbox/src/cbox/Tracing.h
@@ -34,10 +34,11 @@ public:
         PERSIST_OBJECT = 3,
         UPDATE_OBJECT = 4,
         CREATE_OBJECT = 5,
-        UPDATE_DISPLAY = 6,
-        UPDATE_CONNECTIONS = 7,
-        UPDATE_BLOCKS = 8,
-        SYSTEM_TASKS = 9,
+        DELETE_OBJECT = 6,
+        UPDATE_DISPLAY = 10,
+        UPDATE_CONNECTIONS = 11,
+        UPDATE_BLOCKS = 12,
+        SYSTEM_TASKS = 13,
     };
 
     struct TraceEvent {

--- a/controlbox/src/cbox/Tracing.h
+++ b/controlbox/src/cbox/Tracing.h
@@ -99,5 +99,10 @@ public:
     {
         trace.writeEnabled = true;
     }
+
+    static void pause()
+    {
+        trace.writeEnabled = false;
+    }
 };
 }

--- a/controlbox/src/cbox/Tracing.h
+++ b/controlbox/src/cbox/Tracing.h
@@ -34,6 +34,10 @@ public:
         PERSIST_OBJECT = 3,
         UPDATE_OBJECT = 4,
         CREATE_OBJECT = 5,
+        UPDATE_DISPLAY = 6,
+        UPDATE_CONNECTIONS = 7,
+        UPDATE_BLOCKS = 8,
+        SYSTEM_TASKS = 9,
     };
 
     struct TraceEvent {

--- a/controlbox/test/Box_test.cpp
+++ b/controlbox/test/Box_test.cpp
@@ -15,6 +15,7 @@
 #include "ObjectContainer.h"
 #include "ObjectFactory.h"
 #include "TestObjects.h"
+#include "Tracing.h"
 
 using namespace cbox;
 
@@ -858,6 +859,21 @@ SCENARIO("A controlbox Box")
 
             CHECK(counter1->count() == count + 20000 / counter1->interval());
         }
+
+        WHEN("Tracing is enabled")
+        {
+            cbox::Tracing::unpause();
+            box.update(100000);
+            box.update(110000);
+            box.update(120000);
+
+            THEN("The last 10 actions are logged")
+            {
+                for (auto& t : cbox::Tracing::trace.history) {
+                    CHECK(t.action == cbox::Tracing::Action::UPDATE_OBJECT);
+                }
+            }
+        }
     }
 
     WHEN("An object with links to other objects is created, it can use data from those other objects")
@@ -1059,7 +1075,7 @@ SCENARIO("A controlbox Box")
             CHECK(out->str() == expected.str());
         }
 
-        THEN("The newly discoverd objects are persisted")
+        THEN("The newly discovered objects are persisted")
         {
             clearStreams();
             *in << "000007"; // list stored objects

--- a/controlbox/test/runner.cpp
+++ b/controlbox/test/runner.cpp
@@ -4,6 +4,7 @@
 #include "CboxError.h"
 #include "Connections.h"
 #include "DataStream.h"
+#include "Tracing.h"
 #include "testinfo.h"
 #include <catch.hpp>
 
@@ -44,4 +45,6 @@ applicationCommand(uint8_t cmdId, DataIn& in, EncodedDataOut& out)
         return false;
     }
 }
+
+Tracing::trace_t cbox::Tracing::trace;
 } // end namespace cbox


### PR DESCRIPTION
Add last 10 performed actions, including block type and block id.

When a watchdog reset occurs, the cause of the reset was lost, we didn't have an execution trace.
This PR adds some high-level tracing. On each block READ/WRITE/UPDATE/CREATE/DELETE and on global system task, the action is logged to a FIFO of 10 entries.

On reboot, tracing is paused to not overwrite the last events of the previous run. When the trace is read, tracing is unpaused.

