### PR TITLE
Fix losing EEPROM objects if they need to be reallocated but space is not available

### DIFF
--- a/controlbox/src/cbox/EepromObjectStorage.h
+++ b/controlbox/src/cbox/EepromObjectStorage.h
@@ -125,7 +125,8 @@ public:
                 objectEepromData = newObjectWriter(id, requestedSize);
                 dataLocation = writer.offset();
                 if (objectEepromData.availableForWrite() < requestedSize) {
-                    return CboxError::INSUFFICIENT_PERSISTENT_STORAGE; // still not enough free space
+                    // LCOV_EXCL_LINE still not enough free space, exclude from coverage, because this should not be possible with the check above
+                    return CboxError::INSUFFICIENT_PERSISTENT_STORAGE; // LCOV_EXCL_LINE
                 }
             }
             // looks like we can relocate the object, remove the old and write the new block


### PR DESCRIPTION
When an existing object is stored to EEPROM, it is written in the same place. Unless it does not fit.

The implementation was:
1. Try to write in place
2. If this fails because the reserved block is too small, delete the existing object from EEPROM
3. Write the object again

When 3 fails due to EEPROM being full, the block has already been deleted from EEPROM.
Fixed by changing implementation to:
1. Get new size of block
2. If it fits the existing block, write in place
3. Else delete and write object again (which will write to a new location)

The result is that if an updated block doesn't fit, the old version is kept. This is not perfect, but better than deletion.