### PR TITLE
Keep system objects out of eeprom if they store no settings

### DIFF
--- a/app/brewblox/blox/OneWireBusBlock.h
+++ b/app/brewblox/blox/OneWireBusBlock.h
@@ -45,7 +45,7 @@ public:
 
     virtual cbox::CboxError streamPersistedTo(cbox::DataOut&) const override final
     {
-        return cbox::CboxError::OK;
+        return cbox::CboxError::PERSISTING_NOT_NEEDED;
     }
 
     virtual cbox::update_t update(const cbox::update_t& now) override final

--- a/app/brewblox/blox/SysInfoBlock.cpp
+++ b/app/brewblox/blox/SysInfoBlock.cpp
@@ -76,5 +76,5 @@ SysInfoBlock::streamFrom(cbox::DataIn& in)
 cbox::CboxError
 SysInfoBlock::streamPersistedTo(cbox::DataOut&) const
 {
-    return cbox::CboxError::OK;
+    return cbox::CboxError::PERSISTING_NOT_NEEDED;
 }

--- a/app/brewblox/blox/TicksBlock.h
+++ b/app/brewblox/blox/TicksBlock.h
@@ -62,7 +62,7 @@ public:
 
     virtual cbox::CboxError streamPersistedTo(cbox::DataOut&) const override final
     {
-        return cbox::CboxError::OK;
+        return cbox::CboxError::PERSISTING_NOT_NEEDED;
     }
 
     virtual cbox::update_t update(const cbox::update_t& now) override final

--- a/app/brewblox/test/SysinfoBlock_test.cpp
+++ b/app/brewblox/test/SysinfoBlock_test.cpp
@@ -84,6 +84,8 @@ SCENARIO("SysInfo Block")
             return decoded;
         };
 
+        testBox.update(0);
+
         WHEN("A READ_AND_SYS_CMD_TRACE_RESUME command is sent")
         {
             auto decoded = sendCmd(blox::SysInfo_SysInfoCommand_SYS_CMD_TRACE_READ_RESUME);
@@ -104,8 +106,8 @@ SCENARIO("SysInfo Block")
             {
                 CHECK(testBox.lastReplyHasStatusOk());
                 CHECK(decoded.ShortDebugString() == replyWithoutTrace +
-                                                        " trace { }"
-                                                        " trace { }"
+                                                        " trace { action: UPDATE_BLOCK id: 7 type: 314 }"
+                                                        " trace { action: UPDATE_BLOCK id: 19 type: 319 }"
                                                         " trace { action: UPDATE_BLOCK id: 1 type: 65534 }"
                                                         " trace { action: UPDATE_BLOCK id: 2 type: 256 }"
                                                         " trace { action: UPDATE_BLOCK id: 3 type: 257 }"

--- a/controlbox/src/cbox/CboxError.h
+++ b/controlbox/src/cbox/CboxError.h
@@ -44,6 +44,7 @@ enum class CboxError : uint8_t {
     PERSISTED_BLOCK_STREAM_ERROR = 20,
     PERSISTED_STORAGE_WRITE_ERROR = 21,
     CRC_ERROR_IN_STORED_OBJECT = 22,
+    PERSISTING_NOT_NEEDED = 23,
 
     // invalid actions
     OBJECT_NOT_WRITABLE = 32,

--- a/controlbox/src/cbox/EepromObjectStorage.h
+++ b/controlbox/src/cbox/EepromObjectStorage.h
@@ -72,6 +72,11 @@ public:
         CboxError res = handler(counter);
         uint16_t dataSize = counter.count() + 1;
 
+        if (res == CboxError::PERSISTING_NOT_NEEDED) {
+            // exit for objects that don't need to exist in EEPROM. Not even their id/groups/existence
+            return CboxError::OK;
+        }
+
         if (res != CboxError::OK) {
             return res;
         };

--- a/controlbox/test/EepromObjectStorage_test.cpp
+++ b/controlbox/test/EepromObjectStorage_test.cpp
@@ -599,4 +599,20 @@ SCENARIO("Storing and retreiving blocks with EEPROM storage")
             CHECK(int(res) == int(CboxError::INSUFFICIENT_PERSISTENT_STORAGE));
         }
     }
+
+    WHEN("An object indicates it does not need persistence")
+    {
+        MockStreamObject obj;
+        obj.streamPersistedToFunc = [](cbox::DataOut& out) {
+            return CboxError::PERSISTING_NOT_NEEDED;
+        };
+
+        THEN("The object does not end up in eeprom")
+        {
+            auto res = saveObjectToStorage(obj_id_t(1), obj);
+            CHECK(res == CboxError::OK);
+
+            CHECK(CboxError::PERSISTED_OBJECT_NOT_FOUND == retreiveObjectFromStorage(1, obj));
+        }
+    }
 }


### PR DESCRIPTION
System objects with no persisted data still existed in eeprom (their id and groups).

This adds an early exit to avoid them taking up space.
Note that user objects with no persisted data still need to return CboxError::OK, because they still want their existence to be stored.