### PR TITLE
Rework PWM calculations to handle changing setting better and limit the effect of long history

### DIFF
--- a/lib/src/ActuatorDigitalChangeLogged.cpp
+++ b/lib/src/ActuatorDigitalChangeLogged.cpp
@@ -92,7 +92,6 @@ ActuatorDigitalChangeLogged::activeDurations(const ticks_millis_t& now)
     result.lastState = history.front().newState;
     auto end = now;
     auto start = ticks_millis_t(0);
-    //auto minStartTime = now - maxHistory;
     uint8_t activePeriods = 0;
 
     auto h = history.cbegin();

--- a/lib/src/ActuatorPwm.cpp
+++ b/lib/src/ActuatorPwm.cpp
@@ -149,10 +149,7 @@ ActuatorPwm::slowPwmUpdate(const update_t& now)
 
         auto wait = duration_millis_t(0);
 
-        // limit history length taken into account to 2.5 periods duration.
-        // 2.5 periods gives room to correct jitter, 2 periods is too tight at the end of the period
-        // Note that future of this period is also counted later, so this implements 'max 2 periods in the past', not 2 periods total.
-
+        // limit history length taken into account
         // special case for 0% and 100%, use fixed window of 2*m_period
         auto twoPeriods = 2 * m_period;
         if (m_dutySetting == 0) {
@@ -179,69 +176,59 @@ ActuatorPwm::slowPwmUpdate(const update_t& now)
             previousPeriod = 0;
             previousHighTime = 0;
         } else {
+            // The shortest part of the period is fixed (high over 50%, low under 50%)
+            // For the previous period, cap the fixed part at m_period if the period was over 2 * m_periods long
+            // discard excess
+            if (previousPeriod > (twoPeriods)) {
+                auto limit = m_period;
+                if ((2 * m_dutyTime <= m_period)) {
+                    // high period is fixed, low period adapts
+                    if (previousHighTime > limit) {
+                        auto excess = previousHighTime - limit;
 
-            // Scenario 1: current period is longer than 2* m_period. Limit history for the fixed part to 50% of the period
-            // If the current period exeeds that limit, rewrite the previous period to absorb the discarded part
-            // Shift the previous period in time by excess
-            // This means that if the excess was larger than the previous period, the excess fully encapsulates the period
-            // If it doesn't fully encapsulate it there are 2 options:
-            // - The excess is smaller than the high/low time ending the previous period -> high/low is previous period - excess
-            // - The excess is larger than the high/low time ending the previous period -> high/low time doesn't change
-
-            if (currentPeriod > (twoPeriods)) {
-                auto limit = m_period >> 1;
-                if ((m_dutySetting <= (maxDuty() >> 1))) {
+                        previousHighTime = limit;
+                        previousPeriod -= excess;
+                    }
+                } else {
+                    // low period is fixed, high period adapts
+                    auto previousLowTime = previousPeriod - previousHighTime;
+                    if (previousLowTime > limit) {
+                        auto excess = previousLowTime - limit;
+                        previousPeriod -= excess;
+                    }
+                }
+            }
+            // for the current period, do the same, but shift the discarded bit to the previous period
+            if (currentPeriod > twoPeriods) {
+                auto limit = m_period;
+                if ((2 * m_dutyTime <= m_period)) {
                     // high period is fixed, low period adapts
                     if (currentHighTime > limit) {
                         auto excess = currentHighTime - limit;
-                        if (excess > previousPeriod) {
-                            previousHighTime = previousPeriod;
-                        } else if (!(excess < previousHighTime)) {
-                            previousHighTime = excess;
-                        }
-                        auto currentLowTime = currentPeriod - currentHighTime;
+
+                        previousHighTime += excess;
+                        previousPeriod += excess;
                         currentHighTime = limit;
-                        currentPeriod = currentLowTime + limit;
+                        currentPeriod -= excess;
                     }
                 } else {
                     // low period is fixed, high period adapts
                     auto currentLowTime = currentPeriod - currentHighTime;
                     if (currentLowTime > limit) {
                         auto excess = currentLowTime - limit;
-                        if (excess > previousPeriod) {
-                            previousHighTime = 0;
-                        } else if (excess < previousHighTime) {
-                            previousHighTime = previousPeriod - excess;
-                        }
-                        currentPeriod = currentHighTime + limit;
-                    }
-                }
-            }
-            // scenario 2: both periods combined are euqal to or longer than 2.5 * m_period
-            if (previousPeriod + currentPeriod > twoPeriods + (m_period >> 1)) {
-                // compress the previous period, limit length to current period length.
-                auto maxPeriod = std::max(currentPeriod, m_period);
-                if (previousPeriod > maxPeriod) {
-                    if (lastHistoricState == State::Active) {
-                        // limit low time of previous period (oldest history) to 3x current low time
-                        auto maxLowTime = 3 * (maxPeriod - currentHighTime);
-                        auto previousLowTime = previousPeriod - previousHighTime;
-                        if (previousLowTime > maxLowTime) {
-                            previousPeriod = previousHighTime + maxLowTime;
-                        }
-                    } else if (lastHistoricState == State::Inactive) {
-                        // limit high time of previous period (oldest history) to 3x current high time
-                        auto maxHighTime = 3 * (std::max(currentHighTime, m_dutyTime));
-                        if (previousHighTime > maxHighTime) {
-                            auto previousLowTime = previousPeriod - previousHighTime;
-                            previousHighTime = maxHighTime;
-                            previousPeriod = previousHighTime + previousLowTime;
-                        }
+
+                        previousPeriod += excess;
+                        currentPeriod -= excess;
                     }
                 }
             }
 
-            if (previousPeriod < m_period) {
+            // compress the previous period, limit length to 3*m_period, keep duty % equal
+            auto maxPeriod = 3 * m_period;
+            if (previousPeriod > maxPeriod) {
+                previousHighTime = uint64_t(previousHighTime) * uint64_t(maxPeriod) / previousPeriod;
+                previousPeriod = maxPeriod;
+            } else if (previousPeriod < m_period) {
                 // if previous period was shortened, lengthen it again with the state that would result it bringing duty closer to desired duty
                 auto shortenedBy = m_period - previousPeriod;
                 previousPeriod = m_period;
@@ -255,15 +242,16 @@ ActuatorPwm::slowPwmUpdate(const update_t& now)
         auto twoPeriodHighTime = previousHighTime + currentHighTime;
 
         if (lastHistoricState == State::Active) {
-            if (m_dutySetting == maxDuty()) {
-                auto actWait = actPtr->desiredState(State::Active, now); // ensure desired state is correct
+            if (m_dutyTime == m_period) { // 100%
+                // ensure desired state is correct and get time from possibly blocked actuator
+                auto actWait = actPtr->desiredState(State::Active, now);
                 if (currentPeriod + 1000 <= m_period) {
-                    wait = m_period - currentPeriod; // runs from high to 1000
+                    wait = m_period - currentPeriod;
                 } else {
                     wait = 1000;
                 }
                 wait = std::max(actWait, wait);
-            } else if (m_dutySetting <= (maxDuty() >> 1)) {
+            } else if (2 * m_dutyTime <= m_period) {
                 // high period is fixed, low period adapts
                 if (currentHighTime < m_dutyTime) {
                     wait = m_dutyTime - currentHighTime;
@@ -306,15 +294,16 @@ ActuatorPwm::slowPwmUpdate(const update_t& now)
             }
         } else if (lastHistoricState == State::Inactive) {
             auto currentLowTime = currentPeriod - currentHighTime;
-            if (m_dutySetting == value_t{0}) {
-                auto actWait = actPtr->desiredState(State::Inactive, now); // ensure desired state is correct
+            if (m_dutyTime == 0) {
+                // ensure desired state is correct and get time from possibly blocked actuator
+                auto actWait = actPtr->desiredState(State::Inactive, now);
                 if (currentPeriod + 1000 <= m_period) {
-                    wait = m_period - currentPeriod; // runs from high to 1000
+                    wait = m_period - currentPeriod;
                 } else {
                     wait = 1000;
                 }
                 wait = std::max(actWait, wait);
-            } else if (m_dutySetting > (maxDuty() >> 1)) {
+            } else if (2 * m_dutyTime > m_period) {
                 // low period is fixed, high period adapts
                 if (currentLowTime < invDutyTime) {
                     wait = invDutyTime - currentLowTime;

--- a/lib/src/ActuatorPwm.cpp
+++ b/lib/src/ActuatorPwm.cpp
@@ -152,7 +152,7 @@ ActuatorPwm::slowPwmUpdate(const update_t& now)
         // limit history length taken into account
         // special case for 0% and 100%, use fixed window of 2*m_period
         auto twoPeriods = 2 * m_period;
-        if (m_dutySetting == 0) {
+        if (m_dutyTime == 0) {
             auto previousLowTime = previousPeriod - previousHighTime;
             auto currentLowTime = currentPeriod - currentHighTime;
             if (currentPeriod < twoPeriods && currentPeriod + previousLowTime > twoPeriods) {
@@ -164,7 +164,7 @@ ActuatorPwm::slowPwmUpdate(const update_t& now)
             currentHighTime = twoPeriods - std::min(currentLowTime, twoPeriods);
             previousPeriod = 0;
             previousHighTime = 0;
-        } else if (m_dutySetting == maxDuty()) {
+        } else if (m_dutyTime == m_period) {
             if (currentPeriod < twoPeriods && currentPeriod + previousHighTime > twoPeriods) {
                 auto currentLowTime = currentPeriod - currentHighTime;
                 currentHighTime = std::min(currentHighTime + previousHighTime, twoPeriods - currentLowTime);

--- a/lib/test/ActuatorPwm_test.cpp
+++ b/lib/test/ActuatorPwm_test.cpp
@@ -581,7 +581,7 @@ SCENARIO("ActuatorPWM driving mock actuator", "[pwm]")
         pwm.update(now + 1);
         CHECK(mock.state() == State::Inactive);
     }
-    WHEN("the PWM actuator is set to 40% at startup, the duty cycle it reports doesn't overshoot more than 5%")
+    WHEN("the PWM actuator is set to 40% at startup")
     {
         pwm.setting(40);
         auto previous = pwm.value();
@@ -598,7 +598,7 @@ SCENARIO("ActuatorPWM driving mock actuator", "[pwm]")
         REQUIRE(previous == Approx(40.0).margin(0.1));
     }
 
-    WHEN("the PWM actuator is set to 40% after being 10%, the achieved value increases to 40%")
+    WHEN("the PWM actuator is set to 40% after being 10%")
     {
         pwm.setting(10.0);
         auto changeSettingAt = 5 * pwm.period();
@@ -619,7 +619,7 @@ SCENARIO("ActuatorPWM driving mock actuator", "[pwm]")
         REQUIRE(previous == Approx(40.0).margin(0.1));
     }
 
-    WHEN("the PWM actuator is set to 100% after being 10%, the achieved value increases to 100% in steps")
+    WHEN("the PWM actuator is set to 100% after being 10%")
     {
         pwm.setting(10.0);
         auto changeSettingAt = 5 * pwm.period();
@@ -640,7 +640,7 @@ SCENARIO("ActuatorPWM driving mock actuator", "[pwm]")
         REQUIRE(previous == 100);
     }
 
-    WHEN("the PWM actuator is set to 90% after being 10%, the achieved value slowly transitions")
+    WHEN("the PWM actuator is set to 90% after being 10%")
     {
         pwm.setting(10.0);
         auto changeSettingAt = 5 * pwm.period();
@@ -661,7 +661,7 @@ SCENARIO("ActuatorPWM driving mock actuator", "[pwm]")
         REQUIRE(previous == Approx(90).margin(0.1));
     }
 
-    WHEN("the PWM actuator is set to 0% after being 100%, the achieved value transitions from 33% to 0%")
+    WHEN("the PWM actuator is set to 0% after being 100%")
     {
         // run at 50% for a while first to have some cycle history, end on a high output
         pwm.setting(50.0);


### PR DESCRIPTION
The PWM block can stretch its period and high/low time to adjust for:
- Constraints on the target digital actuator
  - period is 10m, but minimum ON time is 1m. To achieve a duty cycle of 5%, it will stretch to 1m, 19m off.
- Changes to its setting in the middle of a period
  - period is 10m, duty cycle is 90%. Runs for while, then the duty cycle is set to 10%. The next OFF duration will be a bit longer than 9m, to compensate for the past when it was at 90% to reach the correct average quicker.

This PR implements some alternative handling of how the achieved duty cycle is calculated from the history and most importantly places stricter limits on how much history is taken into account.

This fixes the following bug:
- PWM is at 100% for an hour.
- PWM is at 0% for an hour.
- PWM is set to 60%.
Before this PR, the PWM would see a long time at 50% in the past and would overcompensate and hold the output pin high for too long.