### PR TITLE
Fix output pin not always set to LOW in fast PWM mode

### DIFF
--- a/lib/src/ActuatorPwm.cpp
+++ b/lib/src/ActuatorPwm.cpp
@@ -108,15 +108,15 @@ ActuatorPwm::timerTask()
             m_dutyAchieved = value_t{0};
         }
         m_fastPwmElapsed = 0;
-    } else {
-        if (m_fastPwmElapsed == m_dutyTime) {
-            if (auto actPtr = m_target()) {
-                actPtr->setStateUnlogged(State::Inactive);
-                m_dutyAchieved = m_dutySetting;
-            }
+    }
+    if (m_fastPwmElapsed == m_dutyTime) {
+        if (auto actPtr = m_target()) {
+            actPtr->setStateUnlogged(State::Inactive);
+            m_dutyAchieved = m_dutySetting;
         }
     }
-    m_fastPwmElapsed = m_fastPwmElapsed == 99 ? 0 : m_fastPwmElapsed + 1;
+
+    m_fastPwmElapsed = m_fastPwmElapsed >= 99 ? 0 : m_fastPwmElapsed + 1;
 }
 
 ActuatorPwm::update_t


### PR DESCRIPTION
As reported on the forum, the output pin was not always set to LOW, when switching from 100% to 0% in fast interrupt based 100Hz PWM mode.

Fixed by removing `else`