### PR TITLE
More WiFi stability fixes

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -116,7 +116,7 @@
       "rtos": "FreeRTOS",
       "device": "STM32F205RG",
       "configFiles": [
-        "/usr/local/share/openocd/scripts/interface/stlink-v2.cfg",
+        "/usr/local/share/openocd/scripts/interface/stlink.cfg",
         "/usr/local/share/openocd/scripts/target/stm32f2x.cfg"
       ],
       "armToolchainPath": "/home/elco/opt/gcc-arm-none-eabi-9-2020-q2-update/bin",
@@ -140,8 +140,8 @@
         "/home/elco/opt/openocd/tcl/interface/stlink.cfg",
         "/home/elco/opt/openocd/tcl/target/stm32f2x.cfg"
       ],
-      "armToolchainPath": "/home/elco/source/gcc-arm-none-eabi-_3-2016q1/bin",
-      "gdbpath": "/home/elco/source/gcc-arm-none-eabi-_3-2016q1/bin/arm-none-eabi-gdb-py", // hidden setting
+      "armToolchainPath": "/home/elco/opt/gcc-arm-none-eabi-9-2020-q2-update/bin/",
+      "gdbpath": "/home/elco/opt/gcc-arm-none-eabi-9-2020-q2-update/bin/arm-none-eabi-gdb-py", // hidden setting
       // "showDevDebugOutput": true,
       "svdFile": "./tools/STM32F215.svd",
       "rtos": "FreeRTOS",
@@ -156,7 +156,7 @@
       "executable": "./platform/spark/device-os/build/target/user-part/platform-8-m/user-part.elf",
       "device": "STM32F205RG",
       "configFiles": [
-        "/usr/local/share/openocd/scripts/interface/stlink-v2.cfg",
+        "/usr/local/share/openocd/scripts/interface/stlink.cfg",
         "/usr/local/share/openocd/scripts/target/stm32f2x.cfg"
       ],
       "armToolchainPath": "/home/elco/opt/gcc-arm-none-eabi-9-2020-q2-update/bin",

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -472,7 +472,8 @@
         "../wrapped_make.sh",
         "APP=brewblox",
         "PLATFORM=p1",
-        "USE_SWD=y"
+        "USE_SWD=y",
+        "program-dfu"
       ],
       "group": "build",
       "options": {

--- a/app/brewblox/BrewBlox.cpp
+++ b/app/brewblox/BrewBlox.cpp
@@ -320,7 +320,7 @@ updateFirmwareStreamHandler(Stream* stream)
                 HAL_Core_System_Reset_Ex(RESET_REASON_UPDATE, 0, nullptr);
 #else
                 bool success = system_firmwareUpdate(stream);
-                System.reset(success ? RESET_USER_REASON::FIRMWARE_UPDATE_SUCCESS : RESET_USER_REASON::FIRMWARE_UPDATE_FAILED);
+                System.reset(success ? RESET_USER_REASON::FIRMWARE_UPDATE_SUCCESS : RESET_USER_REASON::FIRMWARE_UPDATE_FAILED, RESET_NO_WAIT);
 #endif
                 break;
             } else {
@@ -419,7 +419,7 @@ applicationCommand(uint8_t cmdId, cbox::DataIn& in, cbox::EncodedDataOut& out)
 #if PLATFORM_ID != PLATFORM_GCC
             updateFirmwareFromStream(in.streamType());
             // reset in case the firmware update failed
-            System.reset(RESET_USER_REASON::FIRMWARE_UPDATE_FAILED);
+            System.reset(RESET_USER_REASON::FIRMWARE_UPDATE_FAILED, RESET_NO_WAIT);
 #endif
         }
         return true;

--- a/app/brewblox/connectivity.cpp
+++ b/app/brewblox/connectivity.cpp
@@ -51,6 +51,11 @@ void
 updateWifiSignal()
 {
     if (spark::WiFi.ready()) {
+        // From a particle issue #1967:
+        // avtolstoy: As a workaround for now I might suggest trying to make sure that WiFi.ready() is true
+        // before any WiFi.xxx() calls that rely on wifi_config(), so localIP, macAddress, subnetMask, gatewayIP,
+        // dnsServerIP, dhcpServerIP, BSSID, SSID.
+
         auto rssi = wlan_connected_rssi();
         if (rssi == 0) {
             // means caller should retry, wait until next update for retry
@@ -74,9 +79,9 @@ wifiSignal()
 bool
 wifiConnected()
 {
-    // WiFi.ready() ensures underlying wifi driver has been initialized
+    // WiFi.ready() ensures underlying wifi driver has been initialized correctly
     // wifiSignalRssi is set above an ensures an IP address is assigned and we have signal
-    // checking ready() too ensures that a disconnected is detected immediately
+    // checking ready() too ensures that a disconnect is detected immediately
     return wifiSignalRssi < 0 && spark::WiFi.ready();
 }
 

--- a/app/brewblox/display/screens/WidgetsScreen.cpp
+++ b/app/brewblox/display/screens/WidgetsScreen.cpp
@@ -156,8 +156,6 @@ void
 WidgetsScreen::updateWiFi()
 {
     auto signal = wifiSignal();
-    printWiFiIp(wifi_ip);
-
     bool connected = true;
     if (signal >= 0) {
         wifi_icon[0] = 0x22;
@@ -170,6 +168,7 @@ WidgetsScreen::updateWiFi()
         wifi_icon[0] = 0x23;
     }
     if (connected != D4D_IsEnabled(const_cast<D4D_OBJECT*>(&scrWidgets_wifi_ip))) {
+        printWiFiIp(wifi_ip);
         D4D_InvalidateObject(&scrWidgets_wifi_ip, D4D_FALSE); // force rewriting IP to display
         D4D_EnableObject(&scrWidgets_wifi_icon, connected);
         D4D_EnableObject(&scrWidgets_wifi_ip, connected);

--- a/app/brewblox/main.cpp
+++ b/app/brewblox/main.cpp
@@ -57,7 +57,7 @@ signal_handler(int signal)
 void
 watchdogReset()
 {
-    System.reset(RESET_USER_REASON::WATCHDOG);
+    System.reset(RESET_USER_REASON::WATCHDOG, RESET_NO_WAIT);
 }
 
 #if PLATFORM_THREADING
@@ -103,14 +103,14 @@ onSetupModeBegin()
 void
 onSetupModeEnd()
 {
-    System.reset(RESET_USER_REASON::LISTENING_MODE_EXIT);
+    System.reset(RESET_USER_REASON::LISTENING_MODE_EXIT, RESET_NO_WAIT);
 }
 
 void
 onOutOfMemory(system_event_t event, int param)
 {
     // reboot when out of memory, beter than undefined behavior
-    System.reset(RESET_USER_REASON::OUT_OF_MEMORY);
+    System.reset(RESET_USER_REASON::OUT_OF_MEMORY, RESET_NO_WAIT);
 }
 
 void
@@ -216,7 +216,7 @@ handleReset(bool exitFlag, uint8_t reason)
 #if PLATFORM_ID == PLATFORM_GCC
         exit(0);
 #else
-        System.reset(reason);
+        System.reset(reason, RESET_NO_WAIT);
 #endif
     }
 }

--- a/tools/arm-pretty.gdbinit
+++ b/tools/arm-pretty.gdbinit
@@ -4,8 +4,8 @@ import gdb
 
 # sys.path.append('/home/elco/repos/firmware/tools')
 # from prettyprinters import printers
-
-sys.path.append('/home/elco/source/gcc-arm-none-eabi-5_3-2016q1/share/gcc-arm-none-eabi')
+      
+sys.path.append('/home/elco/opt/gcc-arm-none-eabi-9-2020-q2-update/share/gcc-arm-none-eabi')
 
 # Load the pretty-printers.
 from libstdcxx.v6.printers import register_libstdcxx_printers

--- a/tools/system.gdbinit
+++ b/tools/system.gdbinit
@@ -1,6 +1,6 @@
 define add-symbol-file-auto
-  # Parse .text address to temp file
-  shell echo set \$text_address=$(readelf -WS $arg0 | grep .text | awk '{ print "0x"$5 }') >/tmp/temp_gdb_text_address.txt
+  # Parse .text address to temp file  
+  shell echo set \$text_address=(readelf -WS $arg0 | grep .text | awk '{ print "0x"$5 }') >/tmp/temp_gdb_text_address.txt
 
   # Source .text address
   source /tmp/temp_gdb_text_address.txt


### PR DESCRIPTION
Fixes some additional issues around wifi management.
Wifi stack can cause hardfault for some functions (localIp() being one of them).
Workaround is to check WiFi.ready() before calling it.

Added RESET_NO_WAIT flag to immediately reset and not notify the cloud if applicable.
Also fixes multithreaded debugging with particle sources.