### PR TITLE
Reduce compiled code size

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -84,5 +84,8 @@
     "regex": "cpp",
     "shared_mutex": "cpp",
     "wifi_config.h": "c"
+  },
+  "disasexpl.associations": {
+    "**/*.cpp": "${workspaceFolder}/build/target/user/platform-8-m/firmware/brewblox/${relativeFileDir}/${fileBasenameNoExtension}.s"
   }
 }

--- a/app/brewblox-esp/main/CMakeLists.txt
+++ b/app/brewblox-esp/main/CMakeLists.txt
@@ -110,5 +110,5 @@ idf_component_register(
     ${lib_inc}
     ${cnl_inc}
     ${esp_inc}
-    ../../../platform/all
+    ${REPO_ROOT}/platform/all
 )

--- a/app/brewblox-particle/build.mk
+++ b/app/brewblox-particle/build.mk
@@ -132,6 +132,9 @@ include $(SOURCE_PATH)/build/checkers.mk # sanitizer and gcov
 endif
 endif
 
+# keep temporary files for disassembly viewer in vscode
+CPPFLAGS += -save-temps=obj
+
 CSRC := $(filter-out $(CEXCLUDES),$(CSRC))
 CPPSRC := $(filter-out $(CPPEXCLUDES),$(CPPSRC)) 
 

--- a/brewblox/blox/DigitalActuatorBlock.cpp
+++ b/brewblox/blox/DigitalActuatorBlock.cpp
@@ -1,7 +1,6 @@
 #include "DigitalActuatorBlock.h"
 #include "ActuatorDigitalConstraintsProto.h"
 #include "FieldTags.h"
-#include "IoArray.h"
 
 DigitalActuatorBlock::DigitalActuatorBlock(cbox::ObjectContainer& objects)
     : objectsRef(objects)
@@ -31,8 +30,7 @@ DigitalActuatorBlock::streamFrom(cbox::DataIn& dataIn)
     return result;
 }
 
-void
-DigitalActuatorBlock::writePersistedStateToMessage(blox_DigitalActuator& message) const
+void DigitalActuatorBlock::writePersistedStateToMessage(blox_DigitalActuator& message) const
 {
     message.hwDevice = hwDevice.getId();
     message.channel = actuator.channel();
@@ -75,8 +73,7 @@ DigitalActuatorBlock::update(const cbox::update_t& now)
     return constrained.update(now);
 }
 
-void*
-DigitalActuatorBlock::implements(const cbox::obj_type_t& iface)
+void* DigitalActuatorBlock::implements(const cbox::obj_type_t& iface)
 {
     if (iface == BrewBloxTypes_BlockType_DigitalActuator) {
         return this; // me!

--- a/brewblox/blox/DigitalActuatorBlock.h
+++ b/brewblox/blox/DigitalActuatorBlock.h
@@ -6,8 +6,6 @@
 #include "cbox/CboxPtr.h"
 #include "compiled_proto/src/DigitalActuator.pb.h"
 
-class IoArray;
-
 class DigitalActuatorBlock : public Block<BrewBloxTypes_BlockType_DigitalActuator> {
 private:
     cbox::ObjectContainer& objectsRef; // remember object container reference to create constraints

--- a/brewblox/blox/TempSensorCombiBlock.cpp
+++ b/brewblox/blox/TempSensorCombiBlock.cpp
@@ -20,8 +20,7 @@
 #include "TempSensorCombiBlock.h"
 #include "FieldTags.h"
 
-cbox::CboxError
-TempSensorCombiBlock::streamFrom(cbox::DataIn& in)
+cbox::CboxError TempSensorCombiBlock::streamFrom(cbox::DataIn& in)
 {
     blox_TempSensorCombi newData = blox_TempSensorCombi_init_zero;
     cbox::CboxError result = streamProtoFrom(in, &newData, blox_TempSensorCombi_fields, blox_TempSensorCombi_size);
@@ -32,7 +31,7 @@ TempSensorCombiBlock::streamFrom(cbox::DataIn& in)
         inputs.reserve(newData.sensors_count);
         sensor.inputs.reserve(newData.sensors_count);
         for (uint8_t i = 0; i < newData.sensors_count && i < 8; i++) {
-            inputs.push_back(cbox::CboxPtr<TempSensor>(objectsRef, newData.sensors[i]));
+            inputs.emplace_back(objectsRef, newData.sensors[i]);
         }
         for (auto& i : inputs) {
             sensor.inputs.push_back(i.lockFunctor());
@@ -41,8 +40,7 @@ TempSensorCombiBlock::streamFrom(cbox::DataIn& in)
     return result;
 }
 
-void
-TempSensorCombiBlock::writeMessage(blox_TempSensorCombi& message, bool includeReadOnly) const
+void TempSensorCombiBlock::writeMessage(blox_TempSensorCombi& message, bool includeReadOnly) const
 {
     FieldTags stripped;
 
@@ -62,8 +60,7 @@ TempSensorCombiBlock::writeMessage(blox_TempSensorCombi& message, bool includeRe
     stripped.copyToMessage(message.strippedFields, message.strippedFields_count, 1);
 }
 
-cbox::CboxError
-TempSensorCombiBlock::streamTo(cbox::DataOut& out) const
+cbox::CboxError TempSensorCombiBlock::streamTo(cbox::DataOut& out) const
 {
     blox_TempSensorCombi message = blox_TempSensorCombi_init_zero;
     writeMessage(message, true);
@@ -71,23 +68,20 @@ TempSensorCombiBlock::streamTo(cbox::DataOut& out) const
     return streamProtoTo(out, &message, blox_TempSensorCombi_fields, blox_TempSensorCombi_size);
 }
 
-cbox::CboxError
-TempSensorCombiBlock::streamPersistedTo(cbox::DataOut& out) const
+cbox::CboxError TempSensorCombiBlock::streamPersistedTo(cbox::DataOut& out) const
 {
     blox_TempSensorCombi message = blox_TempSensorCombi_init_zero;
     writeMessage(message, false);
     return streamProtoTo(out, &message, blox_TempSensorCombi_fields, blox_TempSensorCombi_size);
 }
 
-cbox::update_t
-TempSensorCombiBlock::update(const cbox::update_t& now)
+cbox::update_t TempSensorCombiBlock::update(const cbox::update_t& now)
 {
     sensor.update();
     return update_1s(now);
 }
 
-void*
-TempSensorCombiBlock::implements(const cbox::obj_type_t& iface)
+void* TempSensorCombiBlock::implements(const cbox::obj_type_t& iface)
 {
     if (iface == BrewBloxTypes_BlockType_TempSensorCombi) {
         return this; // me!

--- a/brewblox/blox/TempSensorOneWireBlock.cpp
+++ b/brewblox/blox/TempSensorOneWireBlock.cpp
@@ -1,0 +1,93 @@
+#include "TempSensorOneWireBlock.h"
+#include "blox/FieldTags.h"
+#include "compiled_proto/src/TempSensorOneWire.pb.h"
+
+TempSensorOneWireBlock::TempSensorOneWireBlock(cbox::ObjectContainer& objects)
+    : OneWireDeviceBlock(objects)
+    , sensor(owBus.lockFunctor())
+{
+}
+
+TempSensorOneWireBlock::TempSensorOneWireBlock(cbox::ObjectContainer& objects, cbox::obj_id_t busId)
+    : OneWireDeviceBlock(objects, busId)
+    , sensor(owBus.lockFunctor())
+{
+}
+
+TempSensorOneWireBlock::TempSensorOneWireBlock(cbox::ObjectContainer& objects, cbox::obj_id_t busId, const OneWireAddress& addr)
+    : OneWireDeviceBlock(objects, busId)
+    , sensor(owBus.lockFunctor(), addr)
+{
+}
+
+cbox::CboxError TempSensorOneWireBlock::streamFrom(cbox::DataIn& in)
+{
+    blox_TempSensorOneWire newData = blox_TempSensorOneWire_init_zero;
+    cbox::CboxError res = streamProtoFrom(in, &newData, blox_TempSensorOneWire_fields, blox_TempSensorOneWire_size);
+    /* if no errors occur, write new settings to wrapped object */
+    if (res == cbox::CboxError::OK) {
+        owBus.setId(newData.oneWireBusId);
+        sensor.address(OneWireAddress(newData.address));
+        sensor.setCalibration(cnl::wrap<temp_t>(newData.offset));
+    }
+    return res;
+}
+
+cbox::CboxError TempSensorOneWireBlock::streamTo(cbox::DataOut& out) const
+{
+    blox_TempSensorOneWire message = blox_TempSensorOneWire_init_zero;
+    FieldTags stripped;
+
+    if (sensor.valid()) {
+        message.value = cnl::unwrap((sensor.value()));
+    } else {
+        stripped.add(blox_TempSensorOneWire_value_tag);
+    }
+
+    message.oneWireBusId = owBus.getId();
+    message.address = sensor.address();
+    message.offset = cnl::unwrap(sensor.getCalibration());
+
+    stripped.copyToMessage(message.strippedFields, message.strippedFields_count, 1);
+    return streamProtoTo(out, &message, blox_TempSensorOneWire_fields, blox_TempSensorOneWire_size);
+}
+
+cbox::CboxError TempSensorOneWireBlock::streamPersistedTo(cbox::DataOut& out) const
+{
+    blox_TempSensorOneWire message = blox_TempSensorOneWire_init_zero;
+    message.oneWireBusId = owBus.getId();
+    message.address = sensor.address();
+    message.offset = cnl::unwrap(sensor.getCalibration());
+    return streamProtoTo(out, &message, blox_TempSensorOneWire_fields, blox_TempSensorOneWire_size);
+}
+
+cbox::update_t TempSensorOneWireBlock::update(const cbox::update_t& now)
+{
+    sensor.update();
+    return update_1s(now);
+}
+
+void* TempSensorOneWireBlock::implements(const cbox::obj_type_t& iface)
+{
+    if (iface == BrewBloxTypes_BlockType_TempSensorOneWire) {
+        return this; // me!
+    }
+    if (iface == cbox::interfaceId<TempSensor>()) {
+        // return the member that implements the interface in this case
+        DS18B20* dallasPtr = &sensor;
+        TempSensor* sensorPtr = dallasPtr;
+        return sensorPtr;
+    }
+    if (iface == cbox::interfaceId<OneWireDevice>()) {
+        // return the member that implements the interface in this case
+        DS18B20* dallasPtr = &sensor;
+        OneWireDevice* devicePtr = dallasPtr;
+        return devicePtr;
+    }
+    if (iface == cbox::interfaceId<OneWireDeviceBlock>()) {
+        // return the base that implements the interface
+        OneWireDeviceBlock* ptr = this;
+        return ptr;
+    }
+    return nullptr;
+}

--- a/brewblox/blox/TempSensorOneWireBlock.h
+++ b/brewblox/blox/TempSensorOneWireBlock.h
@@ -2,12 +2,7 @@
 
 #include "DS18B20.h"
 #include "OneWireDeviceBlock.h"
-#include "Temperature.h"
 #include "blox/Block.h"
-#include "blox/FieldTags.h"
-#include "compiled_proto/src/TempSensorOneWire.pb.h"
-
-class OneWire;
 
 class TempSensorOneWireBlock : public Block<BrewBloxTypes_BlockType_TempSensorOneWire>, public OneWireDeviceBlock {
 
@@ -15,95 +10,16 @@ private:
     DS18B20 sensor;
 
 public:
-    TempSensorOneWireBlock(cbox::ObjectContainer& objects)
-        : OneWireDeviceBlock(objects)
-        , sensor(owBus.lockFunctor())
-    {
-    }
+    TempSensorOneWireBlock(cbox::ObjectContainer& objects);
+    TempSensorOneWireBlock(cbox::ObjectContainer& objects, cbox::obj_id_t busId);
+    TempSensorOneWireBlock(cbox::ObjectContainer& objects, cbox::obj_id_t busId, const OneWireAddress& addr);
 
-    TempSensorOneWireBlock(cbox::ObjectContainer& objects, cbox::obj_id_t busId)
-        : OneWireDeviceBlock(objects, busId)
-        , sensor(owBus.lockFunctor())
-    {
-    }
+    virtual cbox::CboxError streamFrom(cbox::DataIn& in) override final;
+    virtual cbox::CboxError streamTo(cbox::DataOut& out) const override final;
+    virtual cbox::CboxError streamPersistedTo(cbox::DataOut& out) const override final;
+    virtual cbox::update_t update(const cbox::update_t& now) override final;
 
-    TempSensorOneWireBlock(cbox::ObjectContainer& objects, cbox::obj_id_t busId, const OneWireAddress& addr)
-        : OneWireDeviceBlock(objects, busId)
-        , sensor(owBus.lockFunctor(), addr)
-    {
-    }
-
-    virtual cbox::CboxError streamFrom(cbox::DataIn& in) override final
-    {
-        blox_TempSensorOneWire newData = blox_TempSensorOneWire_init_zero;
-        cbox::CboxError res = streamProtoFrom(in, &newData, blox_TempSensorOneWire_fields, blox_TempSensorOneWire_size);
-        /* if no errors occur, write new settings to wrapped object */
-        if (res == cbox::CboxError::OK) {
-            owBus.setId(newData.oneWireBusId);
-            sensor.address(OneWireAddress(newData.address));
-            sensor.setCalibration(cnl::wrap<temp_t>(newData.offset));
-        }
-        return res;
-    }
-
-    virtual cbox::CboxError streamTo(cbox::DataOut& out) const override final
-    {
-        blox_TempSensorOneWire message = blox_TempSensorOneWire_init_zero;
-        FieldTags stripped;
-
-        if (sensor.valid()) {
-            message.value = cnl::unwrap((sensor.value()));
-        } else {
-            stripped.add(blox_TempSensorOneWire_value_tag);
-        }
-
-        message.oneWireBusId = owBus.getId();
-        message.address = sensor.address();
-        message.offset = cnl::unwrap(sensor.getCalibration());
-
-        stripped.copyToMessage(message.strippedFields, message.strippedFields_count, 1);
-        return streamProtoTo(out, &message, blox_TempSensorOneWire_fields, blox_TempSensorOneWire_size);
-    }
-
-    virtual cbox::CboxError streamPersistedTo(cbox::DataOut& out) const override final
-    {
-        blox_TempSensorOneWire message = blox_TempSensorOneWire_init_zero;
-        message.oneWireBusId = owBus.getId();
-        message.address = sensor.address();
-        message.offset = cnl::unwrap(sensor.getCalibration());
-        return streamProtoTo(out, &message, blox_TempSensorOneWire_fields, blox_TempSensorOneWire_size);
-    }
-
-    virtual cbox::update_t update(const cbox::update_t& now) override final
-    {
-        sensor.update();
-        return update_1s(now);
-    }
-
-    virtual void* implements(const cbox::obj_type_t& iface) override final
-    {
-        if (iface == BrewBloxTypes_BlockType_TempSensorOneWire) {
-            return this; // me!
-        }
-        if (iface == cbox::interfaceId<TempSensor>()) {
-            // return the member that implements the interface in this case
-            DS18B20* dallasPtr = &sensor;
-            TempSensor* sensorPtr = dallasPtr;
-            return sensorPtr;
-        }
-        if (iface == cbox::interfaceId<OneWireDevice>()) {
-            // return the member that implements the interface in this case
-            DS18B20* dallasPtr = &sensor;
-            OneWireDevice* devicePtr = dallasPtr;
-            return devicePtr;
-        }
-        if (iface == cbox::interfaceId<OneWireDeviceBlock>()) {
-            // return the base that implements the interface
-            OneWireDeviceBlock* ptr = this;
-            return ptr;
-        }
-        return nullptr;
-    }
+    virtual void* implements(const cbox::obj_type_t& iface) override final;
 
     DS18B20& get()
     {

--- a/controlbox/src/cbox/CboxPtr.cpp
+++ b/controlbox/src/cbox/CboxPtr.cpp
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2018 Elco Jacobs / BrewBlox
+ *
+ * This file is part of ControlBox.
+ *
+ * Controlbox is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Controlbox.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "CboxPtr.h"
+
+namespace cbox {
+
+void CboxPtrBase::setId(obj_id_t newId)
+{
+    if (newId != id) {
+        id = std::move(newId);
+        ptr.reset();
+    }
+}
+
+std::shared_ptr<Object> CboxPtrBase::lockObject()
+{
+    // try to lock the weak pointer we already had. If it cannot be locked, we need to do a lookup again
+    auto sptr = ptr.lock();
+    if (!sptr) {
+        // Try to find the object in the container
+        ptr = objects.fetch(id);
+        sptr = ptr.lock();
+    }
+    return sptr;
+}
+
+} // end namespace cbox

--- a/controlbox/src/cbox/CboxPtr.h
+++ b/controlbox/src/cbox/CboxPtr.h
@@ -32,13 +32,7 @@ private:
     std::weak_ptr<Object> ptr;
 
 public:
-    void setId(obj_id_t newId)
-    {
-        if (newId != id) {
-            id = std::move(newId);
-            ptr.reset();
-        }
-    }
+    void setId(obj_id_t newId);
 
     obj_id_t getId() const
     {
@@ -63,17 +57,7 @@ protected:
     }
     ~CboxPtrBase() = default;
 
-    std::shared_ptr<Object> lockObject()
-    {
-        // try to lock the weak pointer we already had. If it cannot be locked, we need to do a lookup again
-        auto sptr = ptr.lock();
-        if (!sptr) {
-            // Try to find the object in the container
-            ptr = objects.fetch(id);
-            sptr = ptr.lock();
-        }
-        return sptr;
-    }
+    std::shared_ptr<Object> lockObject();
 };
 
 template <typename T>

--- a/controlbox/src/cbox/CboxPtr.h
+++ b/controlbox/src/cbox/CboxPtr.h
@@ -69,15 +69,13 @@ public:
             sptr = ptr.lock();
         }
         if (sptr) {
-            // if the lookup succeeded, check if the Object implements the requested interface using the object types
-            if (auto interfacePointer = sptr->implements(interfaceId<U>())) {
-                // If the object returned a non-zero pointer, it supports the interface
-                // If multiple-inheritance is involved, it is possible that the shared pointer and interface pointer
-                // do not point to the same address. That is why the this pointer is returned by the base that implements
-                // the interface.
-                // create a shared_ptr by re-using the ref counting block, but for the offset pointer.
-                return std::shared_ptr<U>(std::move(sptr), reinterpret_cast<U*>(interfacePointer));
-            }
+            // if the lookup succeeded, check if the Object implements the requested interface using the interface id
+            // If the object returned a non-zero pointer, it supports the interface
+            // If multiple-inheritance is involved, it is possible that the shared pointer and interface pointer
+            // do not point to the same address. The pointer that is returned is of the address that implements
+            // the interface.
+            // create a shared_ptr by re-using the ref counting block, but for the offset pointer.
+            return std::shared_ptr<U>(std::move(sptr), reinterpret_cast<U*>(sptr->implements(interfaceId<U>())));
         }
         // return empty share pointer
         return std::shared_ptr<U>();

--- a/lib/inc/ActuatorDigital.h
+++ b/lib/inc/ActuatorDigital.h
@@ -21,11 +21,10 @@
 #pragma once
 
 #include "ActuatorDigitalBase.h"
+#include "IoArray.h"
 #include <cstdint>
 #include <functional>
 #include <memory>
-
-class IoArray;
 
 /*
  * A digital actuator that toggles a channel of an ArrayIo object.

--- a/lib/inc/ActuatorDigitalBase.h
+++ b/lib/inc/ActuatorDigitalBase.h
@@ -21,8 +21,6 @@
 #pragma once
 
 #include <cstdint>
-#include <functional>
-#include <memory>
 
 /*
  * A digital actuator that toggles a channel of an ArrayIo object.

--- a/lib/inc/hal/hal_spi.hpp
+++ b/lib/inc/hal/hal_spi.hpp
@@ -134,8 +134,8 @@ struct SpiDevice {
     * @param callbacks The callbacks to be called before and after the transaction. 
     * @return If any error has occurred a non zero result will indicate an error has happened.
     */
-    template <typename Pre, typename Post>
-    hal_spi::error_t dmaWrite(const uint8_t* data, size_t size, const hal_spi::StaticCallbacks<Pre, Post>& callbacks)
+
+    hal_spi::error_t dmaWrite(const uint8_t* data, size_t size, const hal_spi::StaticCallbacks& callbacks)
     {
         return platform_spi::dmaWrite(settings, data, size, static_cast<const hal_spi::CallbacksBase*>(&callbacks));
     }

--- a/lib/inc/hal/hal_spi_types.h
+++ b/lib/inc/hal/hal_spi_types.h
@@ -55,44 +55,40 @@ struct Callbacks : public CallbacksBase {
         , post(std::move(post))
     {
     }
+
     Pre pre;
     Post post;
 
     void callPre(TransactionData& t) override final
     {
-        if constexpr (!std::is_same<Pre, nullptr_t>::value) {
-            pre(t);
-        }
+        pre(t);
     }
     void callPost(TransactionData& t) override final
     {
-        if constexpr (!std::is_same<Post, nullptr_t>::value) {
-            post(t);
-        }
+        post(t);
     }
 };
 
-template <typename Pre, typename Post>
 struct StaticCallbacks : public CallbacksBase {
 
-    StaticCallbacks(Pre pre, Post post)
+    StaticCallbacks(void (*pre)(TransactionData& t), void (*post)(TransactionData& t))
         : pre(pre)
         , post(post)
     {
     }
 
-    Pre& pre;
-    Post& post;
+    void (*pre)(TransactionData& t);
+    void (*post)(TransactionData& t);
 
     void callPre(TransactionData& t) override final
     {
-        if constexpr (!std::is_same<Pre, nullptr_t>::value) {
+        if (pre) {
             pre(t);
         }
     }
     void callPost(TransactionData& t) override final
     {
-        if constexpr (!std::is_same<Post, nullptr_t>::value) {
+        if (post) {
             post(t);
         }
     }

--- a/platform/esp/TFT035.cpp
+++ b/platform/esp/TFT035.cpp
@@ -38,7 +38,7 @@ auto callbackDcPinOff = StaticCallbacks{
     },
     nullptr};
 
-TFT035::TFT035(std::function<void()> finishCallback)
+TFT035::TFT035(void (*finishCallback)(void))
     : spiDevice(Settings{.spi_idx = 0, .speed = 20'000'000UL, .queueSize = 10, .ssPin = 4, .mode = Settings::Mode::SPI_MODE0, .bitOrder = Settings::BitOrder::MSBFIRST})
     , finishCallback(finishCallback)
     , dc(2)

--- a/platform/esp/TFT035.hpp
+++ b/platform/esp/TFT035.hpp
@@ -22,7 +22,6 @@
 #include "hal/hal_gpio.h"
 #include "hal/hal_spi.hpp"
 #include "hal/hal_spi_types.h"
-#include <functional>
 
 /**
  * A driver for the TFT035 display controller. 
@@ -34,7 +33,7 @@ public:
     * 
     * @param finishCallback The callback to be called when the pixels are transfered to the screen.
     */
-    TFT035(std::function<void()> finishCallback);
+    TFT035(void (*finishCallback)(void));
     ~TFT035() = default;
 
     /// Initialises the display driver.
@@ -82,7 +81,7 @@ public:
 
 private:
     SpiDevice spiDevice;
-    std::function<void()> finishCallback;
+    void (*finishCallback)(void);
     const hal_pin_t dc;
 
     hal_spi::error_t setPos(unsigned int xs, unsigned int xe, unsigned int ys, unsigned int ye);

--- a/platform/simulator/TFT035.cpp
+++ b/platform/simulator/TFT035.cpp
@@ -4,7 +4,7 @@
 #include <vector>
 std::vector<uint64_t> graphicsBuffer;
 
-TFT035::TFT035(std::function<void()> finishCallback)
+TFT035::TFT035(void (*finishCallback)(void))
     : finishCallback(finishCallback)
 {
 }

--- a/platform/simulator/TFT035.hpp
+++ b/platform/simulator/TFT035.hpp
@@ -19,7 +19,6 @@
 
 #pragma once
 #include <cstdint>
-#include <functional>
 
 /**
  * A simulated driver for the TFT035 display controller. 
@@ -31,7 +30,7 @@ public:
     * 
     * @param finishCallback The callback to be called when the pixels are transfered to the screen.
     */
-    TFT035(std::function<void()> finishCallback);
+    TFT035(void (*finishCallback)(void));
     ~TFT035() = default;
 
     /// Initialises the display driver.
@@ -78,5 +77,5 @@ public:
     };
 
 private:
-    std::function<void()> finishCallback;
+    void (*finishCallback)(void);
 };


### PR DESCRIPTION
- Use lambda's instead of std::bind
- Optimized pointer conversions in CboxPtr
- Use shared non-template base for CboxPtr
- Remove use of std::function in graphics driver and use lambdas directly or c function ptr for static callbacks