### PR TITLE
1-Wire shorted bus recovery

### DIFF
--- a/app/brewblox-esp/main/ExpOwGpio.cpp
+++ b/app/brewblox-esp/main/ExpOwGpio.cpp
@@ -1,7 +1,6 @@
 #include "ExpOwGpio.hpp"
 using ChanBits = ExpOwGpio::ChanBits;
 using ChanBitsInternal = ExpOwGpio::ChanBitsInternal;
-using PinDrive = ExpOwGpio::PinDrive;
 using FlexChannel = ExpOwGpio::FlexChannel;
 
 ChanBits::ChanBits(const ChanBitsInternal& internal)
@@ -26,64 +25,6 @@ ChanBitsInternal::ChanBitsInternal(const ChanBits& external)
     bits.pin.c6 = external.bits.pin.c6;
     bits.pin.c7 = external.bits.pin.c7;
     bits.pin.c8 = external.bits.pin.c8;
-}
-
-PinDrive ChanBits::get(uint8_t chan)
-{
-    // numbering board pins doesn't match driver's bits
-    switch (chan) {
-    case 1:
-        return PinDrive(bits.pin.c1);
-    case 2:
-        return PinDrive(bits.pin.c2);
-    case 3:
-        return PinDrive(bits.pin.c3);
-    case 4:
-        return PinDrive(bits.pin.c4);
-    case 5:
-        return PinDrive(bits.pin.c5);
-    case 6:
-        return PinDrive(bits.pin.c6);
-    case 7:
-        return PinDrive(bits.pin.c7);
-    case 8:
-        return PinDrive(bits.pin.c8);
-    default:
-        return PinDrive(0x00);
-    }
-}
-
-void ChanBits::set(uint8_t chan, PinDrive drive)
-{
-    // numbering board pins doesn't match driver's bits
-    switch (chan) {
-    case 1:
-        bits.pin.c1 = drive;
-        return;
-    case 2:
-        bits.pin.c2 = drive;
-        return;
-    case 3:
-        bits.pin.c3 = drive;
-        return;
-    case 4:
-        bits.pin.c4 = drive;
-        return;
-    case 5:
-        bits.pin.c5 = drive;
-        return;
-    case 6:
-        bits.pin.c6 = drive;
-        return;
-    case 7:
-        bits.pin.c7 = drive;
-        return;
-    case 8:
-        bits.pin.c8 = drive;
-        return;
-    default:
-        return;
-    }
 }
 
 // get bits for pull-up transistors

--- a/app/brewblox-esp/main/ExpOwGpio.cpp
+++ b/app/brewblox-esp/main/ExpOwGpio.cpp
@@ -249,9 +249,7 @@ void ExpOwGpio::update()
 {
     auto drv_status = status();
 
-    bool onewireResetNeeded = owDriver.status().bits.device_reset || owDriver.status().bits.short_detected;
-
-    if (onewireResetNeeded) {
+    if (owDriver.shortDetected()) {
         expander.set_output(ExpanderPins::oneWirePowerEnable, false);
         hal_delay_ms(100);
         // ESP_LOGE("OWGPIO", "Power cycling OneWire on module %d, %x", modulePosition(), owDriver.status().all);

--- a/app/brewblox-esp/main/ExpOwGpio.hpp
+++ b/app/brewblox-esp/main/ExpOwGpio.hpp
@@ -46,13 +46,6 @@ public:
     }
 
 public:
-    enum PinDrive : uint8_t {
-        PULL_NONE = 0x0,
-        PULL_DOWN = 0x01,
-        PULL_UP = 0x02,
-        PULL_BOTH = 0x03, // this is a short circuit and should not actually be set
-    };
-
     struct ChanBitsInternal;
     struct ChanBits {
         ChanBits()
@@ -85,8 +78,7 @@ public:
         // get bits for pull-up transistors
         uint8_t up() const;
 
-        PinDrive get(uint8_t chan);
-        void set(uint8_t chan, PinDrive state);
+        // sets all up and down bits by interweaving them into a 16-bit value
         void setBits(uint8_t up, uint8_t down);
     };
 

--- a/app/brewblox-esp/main/ExpOwGpio.hpp
+++ b/app/brewblox-esp/main/ExpOwGpio.hpp
@@ -288,4 +288,12 @@ private:
     ChanBitsInternal ocp_status;
     ChanBitsInternal when_active_mask;   // state when active
     ChanBitsInternal when_inactive_mask; // state when inactive
+
+    enum ExpanderPins : uint8_t {
+        spiCsPin = 0,
+        exernalVoltageEnable = 1,
+        driverSleep = 2,
+        driverFault = 3,
+        oneWirePowerEnable = 4,
+    };
 };

--- a/app/brewblox-esp/main/brewblox_esp.cpp
+++ b/app/brewblox-esp/main/brewblox_esp.cpp
@@ -54,12 +54,13 @@ unsigned get_device_id(uint8_t* dest, unsigned max_len)
     return i;
 }
 
-
-int resetReason(){
+int resetReason()
+{
     return 0; // todo
 }
 
-int resetReasonData(){
+int resetReasonData()
+{
     return 0; // todo
 }
 
@@ -96,6 +97,8 @@ makeBrewBloxBox(asio::io_context& io)
         objectStore, connections, scanners);
 
     box.loadObjectsFromStorage(); // init box and load stored objects
+
+    box.discoverNewObjects(); // discover new/moved devices
 
     static auto updater = RecurringTask(
         io, asio::chrono::milliseconds(10),

--- a/app/brewblox-particle/brewblox_particle.cpp
+++ b/app/brewblox-particle/brewblox_particle.cpp
@@ -114,6 +114,16 @@ theConnectionPool()
     return connections;
 }
 
+void powerCyclePheripheral5V()
+{
+// The Onewire 5V on the Spark 3 can be toggled. The Spark 2 didn't have this functionality
+#if PLATFORM_ID == 8
+    enablePheripheral5V(false);
+    ticks.delayMillis(100);
+    enablePheripheral5V(true);
+#endif
+}
+
 cbox::Box&
 makeBrewBloxBox()
 {
@@ -124,7 +134,7 @@ makeBrewBloxBox()
                                              // groups will be at position 1
                                              cbox::ContainedObject(2, 0x80, std::shared_ptr<cbox::Object>(new SysInfoBlock(HAL_device_ID))),
                                              cbox::ContainedObject(3, 0x80, std::shared_ptr<cbox::Object>(new TicksBlock<TicksClass>(ticks))),
-                                             cbox::ContainedObject(4, 0x80, std::shared_ptr<cbox::Object>(new OneWireBusBlock(setupOneWire()))),
+                                             cbox::ContainedObject(4, 0x80, std::shared_ptr<cbox::Object>(new OneWireBusBlock(setupOneWire(), powerCyclePheripheral5V))),
 #if defined(SPARK)
                                              cbox::ContainedObject(5, 0x80, std::shared_ptr<cbox::Object>(new WiFiSettingsBlock())),
                                              cbox::ContainedObject(6, 0x80, std::shared_ptr<cbox::Object>(new TouchSettingsBlock())),
@@ -316,7 +326,8 @@ unsigned get_device_id(uint8_t* dest, unsigned max_len)
     return HAL_device_ID(dest, max_len);
 }
 
-int resetReason(){
+int resetReason()
+{
 #if PLATFORM_ID == 3
     return 0;
 #else
@@ -324,7 +335,8 @@ int resetReason(){
 #endif
 }
 
-int resetReasonData(){
+int resetReasonData()
+{
 #if PLATFORM_ID == 3
     return 0;
 #else

--- a/app/brewblox-particle/main.cpp
+++ b/app/brewblox-particle/main.cpp
@@ -155,7 +155,11 @@ void setup()
     brewbloxBox().loadObjectsFromStorage(); // init box and load stored objects
     HAL_Delay_Milliseconds(1);
 
-    StartupScreen::setProgress(80);
+    StartupScreen::setProgress(90);
+    StartupScreen::setStep("Scanning for new devices");
+    brewbloxBox().discoverNewObjects();
+
+    StartupScreen::setProgress(90);
     StartupScreen::setStep("Enabling WiFi and mDNS");
     wifiInit();
     HAL_Delay_Milliseconds(1);

--- a/brewblox/blox/OneWireBusBlock.cpp
+++ b/brewblox/blox/OneWireBusBlock.cpp
@@ -43,10 +43,11 @@ bool streamAdresses(pb_ostream_t* stream, const pb_field_t* field, void* const* 
     return true;
 }
 
-OneWireBusBlock::OneWireBusBlock(OneWire& ow)
+OneWireBusBlock::OneWireBusBlock(OneWire& ow, void (*onShortDetected_)())
     : bus(ow)
     , command({NO_OP, 0})
 {
+    onShortDetected = onShortDetected_;
     bus.init();
 }
 
@@ -122,3 +123,16 @@ void* OneWireBusBlock::implements(const cbox::obj_type_t& iface)
     }
     return nullptr;
 }
+
+cbox::update_t OneWireBusBlock::update(const cbox::update_t& now)
+{
+    if (onShortDetected) {
+        if (bus.shortDetected()) {
+            onShortDetected();
+            bus.init();
+        }
+    }
+    return update_1s(now);
+}
+
+void (*OneWireBusBlock::onShortDetected)();

--- a/brewblox/blox/OneWireBusBlock.h
+++ b/brewblox/blox/OneWireBusBlock.h
@@ -19,10 +19,9 @@
 
 #pragma once
 
+#include "OneWire.h"
 #include "blox/Block.h"
 #include "compiled_proto/src/OneWireBus.pb.h"
-
-class OneWire;
 
 class OneWireBusBlock : public Block<BrewBloxTypes_BlockType_OneWireBus> {
 private:
@@ -35,7 +34,7 @@ private:
     static const uint8_t SEARCH = 2; // pass family as data, 00 for all
 
 public:
-    OneWireBusBlock(OneWire& ow);
+    OneWireBusBlock(OneWire& ow, void (*onShortDetected)() = nullptr);
     virtual ~OneWireBusBlock() = default;
 
     OneWire& oneWire() { return bus; }
@@ -48,11 +47,8 @@ public:
         return cbox::CboxError::PERSISTING_NOT_NEEDED;
     }
 
-    virtual cbox::update_t update(const cbox::update_t& now) override final
-    {
-        // No updates for now. Alternatively, a periodic bus scan for new devices?
-        return update_never(now);
-    }
+    virtual cbox::update_t update(const cbox::update_t& now) override final;
 
+    static void (*onShortDetected)();
     virtual void* implements(const cbox::obj_type_t& iface) override final;
 };

--- a/lib/inc/DS248x.hpp
+++ b/lib/inc/DS248x.hpp
@@ -81,7 +81,6 @@ public:
     virtual bool read_bit(bool& bit) override final;
 
     // DS248X specific functions below
-
     bool resetMaster();
 
     //DS2482-800 only
@@ -96,6 +95,27 @@ public:
     //
     // Returns – The DS248X status byte result from the triplet command
     virtual uint8_t search_triplet(bool search_direction) override final;
+
+    typedef union {
+        struct {
+            uint8_t onewire_busy : 1;
+            uint8_t presense_pulse_detect : 1;
+            uint8_t short_detected : 1;
+            uint8_t logic_level : 1;
+            uint8_t device_reset : 1;
+            uint8_t single_bit_result : 1;
+            uint8_t triplet_second_bit : 1;
+            uint8_t direction_taken : 1;
+        } bits;
+        uint8_t all;
+    } Status;
+
+    Status status()
+    {
+        Status s;
+        s.all = mStatus;
+        return s;
+    }
 
 private:
     uint8_t mStatus = 0;

--- a/lib/inc/DS248x.hpp
+++ b/lib/inc/DS248x.hpp
@@ -117,6 +117,11 @@ public:
         return s;
     }
 
+    virtual bool shortDetected() override final
+    {
+        return status().bits.short_detected;
+    }
+
 private:
     uint8_t mStatus = 0;
 

--- a/lib/inc/OneWire.h
+++ b/lib/inc/OneWire.h
@@ -83,4 +83,10 @@ public:
     // When the last device has been return, reset_search or target_search has to be called
     // to reset the search.
     bool search(OneWireAddress& newAddr);
+
+    // Checks the driver for a short on the bus
+    bool shortDetected()
+    {
+        return driver.shortDetected();
+    }
 };

--- a/lib/inc/OneWireLowLevelInterface.h
+++ b/lib/inc/OneWireLowLevelInterface.h
@@ -51,4 +51,7 @@ public:
 
     // Perform a triple operation which will perform 2 read bits and 1 write bit, returns device status
     virtual uint8_t search_triplet(bool search_direction) = 0;
+
+    // Returens whether a short is detected on the bus
+    virtual bool shortDetected() = 0;
 };

--- a/lib/inc/OneWireMockDriver.h
+++ b/lib/inc/OneWireMockDriver.h
@@ -90,6 +90,11 @@ public:
         devices.push_back(std::move(device));
     }
 
+    bool shortDetected() override final
+    {
+        return false;
+    }
+
 private:
     std::vector<std::shared_ptr<OneWireMockDevice>> devices;
 };


### PR DESCRIPTION
When a 1-Wire temperature sensor gets an ESD spark of a few kilovolts, it can become stuck and keep pulling the bus low.
It will slowly get hot and will prevent all other OneWire devices from communicating.

A shorted bus state can be detected by the DS2482 1-Wire bus master.
The Spark 3 and the OneWire expansion modules for the Spark 4 also have a transistor to enable/disable 5V power to all peripherals.
By power cycling 5V power to pheripherals, the 1-Wire device that got stuck will reset and release the bus.

I tested this by zapping sensor probes with a spark generator out of a long lighter. Judging by the length of the spark, this is at least 15kV. A bus short is detected immediately and the sensors come back right away, without getting hot.
Without the fixes in this PR, the sensors would stay in this state.

resolves #245 