### PR TITLE
Fix hex decoding and spooling of hex messages when they are back-to-back

### DIFF
--- a/app/brewblox-particle/test/makefile
+++ b/app/brewblox-particle/test/makefile
@@ -137,7 +137,7 @@ CFLAGS += -g -fprofile-arcs -ftest-coverage
 LDFLAGS += -lgcov
 
 # compile with coverage and sanitizer (uncommented because cnl doesn't work well with it)
-include $(SOURCE_PATH)/build/checkers.mk # sanitizer and gcov
+# include $(SOURCE_PATH)/build/checkers.mk # sanitizer and gcov
 
 # the following warnings can help find opportunities for impromevent in virtual functions
 # Warn when virtual functions are overriden without override/override final specifier (requires gcc 5.1)

--- a/controlbox/src/cbox/Box.cpp
+++ b/controlbox/src/cbox/Box.cpp
@@ -623,8 +623,8 @@ void Box::handleCommand(DataIn& dataIn, DataOut& dataOut)
         tracing::add(tracing::Action(cmd_id)); // non-custom commands trace that they are invoked
         switch (cmd_id) {
         case NONE:
-            connectionStarted(dataOut); // insert welcome message annotation
             noop(in, out);
+            connectionStarted(dataOut); // insert welcome message annotation
             break;
         case READ_OBJECT:
             readObject(in, out);
@@ -673,7 +673,7 @@ void Box::handleCommand(DataIn& dataIn, DataOut& dataOut)
         }
     }
 
-    hexIn.consumeLineEnd(); // consumes any leftover \r or \n
+    hexIn.consumeNonHex(); // consumes any leftover \r or \n or non-hex characters blocking the stream
 
     out.endMessage();
 }

--- a/controlbox/src/cbox/DataStreamConverters.h
+++ b/controlbox/src/cbox/DataStreamConverters.h
@@ -105,6 +105,9 @@ public:
     void fetch()
     {
         if (upper < 0) { // 2 bytes to fetch
+            if (!isxdigit(textIn.peek())) {
+                return; // leave non-hex characters in the stream
+            }
             upper = textIn.read();
             if (upper < 0) {
                 // no data
@@ -113,6 +116,9 @@ public:
         }
 
         if (lower < 0) {
+            if (!isxdigit(textIn.peek())) {
+                return; // leave non-hex characters in the stream
+            }
             lower = textIn.read();
         }
     }
@@ -137,12 +143,17 @@ public:
         return v;
     }
 
-    void consumeLineEnd()
+    void consumeNonHex()
     {
         while (true) {
-            auto v = peek();
-            if (v == '\r' || v == '\n') {
-                read();
+            auto v = textIn.peek();
+            if (v < 0) {
+                break;
+            }
+            if (!isxdigit(v)) {
+                textIn.read();
+                upper = -1;
+                lower = -1;
             } else {
                 return;
             }


### PR DESCRIPTION
This fixes a bug in controlbox when decoding a hex input stream.

The hex decoder consumed 1 byte too many from the stream when spooling the input, nibbling off the first byte of the next message.

This went unnoticed in most cases because messages are usually not received back-to-back, so the input stream would go empty in between.
