### PR TITLE
Improve wifi provisioning feedback for Spark 4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ app/brewblox-esp-chemsense/*
 # Temp release dir
 release/
 app/brewblox-esp/secure_boot_signing_key.pem
+
+*.ii

--- a/app/brewblox-esp/main/HttpHandler.hpp
+++ b/app/brewblox-esp/main/HttpHandler.hpp
@@ -3,6 +3,7 @@
 #include "httpserver/connection.hpp"
 #include "httpserver/server.hpp"
 #include "network/CboxServer.hpp"
+#include "network/wifi.hpp"
 #include "ota.hpp"
 
 class HttpHandler {
@@ -19,18 +20,16 @@ public:
                 R"(<html lang=en>)"
                 R"(<head>)"
                 R"(<meta charset=utf-8>)"
-                R"(<title>Spark 4 status page</title>)"
+                R"(<title>This is the Spark 4 status page. For now it only contains a link for WiFi setup.</title>)"
                 R"(</head>)"
                 R"(<body>)"
                 R"(<p>)"
-                R"(Spark 4 test page)"
-                R"(<br />)");
-            for (auto& h : req.headers) {
-                rep.content.append(h.name);
-                rep.content.append(": ");
-                rep.content.append(h.value);
-                rep.content.append("<br />");
-            }
+                R"(Spark 4 status page)"
+                R"(</p><p>)"
+                R"(<a href=')");
+
+            wifi::append_qr_url(rep.content);
+            rep.content.append(R"('>Click here to generate a QR code for WiFi setup</a>)");
             // ending tags are implicit
         });
 

--- a/app/brewblox-esp/main/network/wifi.cpp
+++ b/app/brewblox-esp/main/network/wifi.cpp
@@ -20,6 +20,7 @@
 
 #include <wifi_provisioning/manager.h>
 
+#include "Spark4.hpp"
 #include "qrcode.h"
 #include <string>
 #include <wifi_provisioning/scheme_ble.h>
@@ -116,9 +117,13 @@ static void event_handler(void* arg, esp_event_base_t event_base,
     if (event_base == WIFI_PROV_EVENT) {
         switch (event_id) {
         case WIFI_PROV_START:
+            // Configure blue blinking
+            spark4::set_led(0, 0, 128, spark4::LED_MODE::BLINK, 2);
             ESP_LOGI(TAG, "Provisioning started");
             break;
         case WIFI_PROV_CRED_RECV: {
+            // Configure blue/green blinking
+            spark4::set_led(0, 128, 128, spark4::LED_MODE::BLINK, 2);
             wifi_sta_config_t* wifi_sta_cfg = (wifi_sta_config_t*)event_data;
             ESP_LOGI(TAG,
                      "Received Wi-Fi credentials for SSID: %s\n",
@@ -126,6 +131,8 @@ static void event_handler(void* arg, esp_event_base_t event_base,
             break;
         }
         case WIFI_PROV_CRED_FAIL: {
+            // Configure fast red blinking
+            spark4::set_led(128, 0, 0, spark4::LED_MODE::BLINK, 1);
             wifi_prov_sta_fail_reason_t* reason = (wifi_prov_sta_fail_reason_t*)event_data;
             ESP_LOGE(TAG,
                      "Provisioning failed!\n\tReason : %s"
@@ -137,6 +144,8 @@ static void event_handler(void* arg, esp_event_base_t event_base,
             ESP_LOGI(TAG, "Provisioning successful");
             break;
         case WIFI_PROV_END:
+            // Configure blue slow breathing
+            spark4::set_led(0, 0, 128, spark4::LED_MODE::BREATHE, 5);
             /* De-initialize manager once provisioning is finished */
             wifi_prov_mgr_deinit();
             break;
@@ -144,8 +153,13 @@ static void event_handler(void* arg, esp_event_base_t event_base,
             break;
         }
     } else if (event_base == WIFI_EVENT && event_id == WIFI_EVENT_STA_START) {
+        // Configure Green for blinking fast
+        spark4::set_led(0, 128, 0, spark4::LED_MODE::BLINK, 1);
         esp_wifi_connect();
     } else if (event_base == IP_EVENT && event_id == IP_EVENT_STA_GOT_IP) {
+        // Configure Blue and Green for breathing
+        spark4::set_led(0, 128, 128, spark4::LED_MODE::BREATHE, 4);
+
         connected = true;
         ip_event_got_ip_t* event = (ip_event_got_ip_t*)event_data;
         ip.addr = reinterpret_cast<ip_event_got_ip_t*>(event_data)->ip_info.ip.addr;
@@ -158,6 +172,8 @@ static void event_handler(void* arg, esp_event_base_t event_base,
     } else if (event_base == WIFI_EVENT && event_id == WIFI_EVENT_STA_DISCONNECTED) {
         connected = false;
         ESP_LOGI(TAG, "Disconnected. Connecting to the AP again...");
+        // Configure Green for blinking fast
+        spark4::set_led(0, 128, 0, spark4::LED_MODE::BLINK, 1);
         esp_wifi_connect();
 
         /* enable wifi power saving */

--- a/app/brewblox-esp/main/network/wifi.cpp
+++ b/app/brewblox-esp/main/network/wifi.cpp
@@ -54,7 +54,7 @@ void init_sta(void)
 void get_device_service_name(char* service_name, size_t max)
 {
     uint8_t eth_mac[6];
-    const char* ssid_prefix = "BREWBLOX_";
+    const char* ssid_prefix = "PROV_BREWBLOX_";
     esp_wifi_get_mac(WIFI_IF_STA, eth_mac);
     snprintf(service_name, max, "%s%02X%02X%02X",
              ssid_prefix, eth_mac[3], eth_mac[4], eth_mac[5]);
@@ -62,7 +62,7 @@ void get_device_service_name(char* service_name, size_t max)
 
 std::string qr_payload()
 {
-    char service_name[16];
+    char service_name[22];
     get_device_service_name(service_name, sizeof(service_name));
 
     std::string payload;
@@ -213,7 +213,7 @@ void init(PROVISION_METHOD method, bool forceProvision)
          *     - Wi-Fi SSID when scheme is wifi_prov_scheme_softap
          *     - device name when scheme is wifi_prov_scheme_ble
          */
-        char service_name[16];
+        char service_name[22];
         get_device_service_name(service_name, sizeof(service_name));
 
         /* What is the security level that we want (0 or 1):

--- a/app/brewblox-esp/main/network/wifi.cpp
+++ b/app/brewblox-esp/main/network/wifi.cpp
@@ -21,6 +21,7 @@
 #include <wifi_provisioning/manager.h>
 
 #include "qrcode.h"
+#include <string>
 #include <wifi_provisioning/scheme_ble.h>
 #include <wifi_provisioning/scheme_softap.h>
 
@@ -57,6 +58,29 @@ void get_device_service_name(char* service_name, size_t max)
     esp_wifi_get_mac(WIFI_IF_STA, eth_mac);
     snprintf(service_name, max, "%s%02X%02X%02X",
              ssid_prefix, eth_mac[3], eth_mac[4], eth_mac[5]);
+}
+
+std::string qr_payload()
+{
+    char service_name[16];
+    get_device_service_name(service_name, sizeof(service_name));
+
+    std::string payload;
+    payload.append("{\"ver\":\"");
+    payload.append(PROV_QR_VERSION);
+    payload.append("\",\"name\":\"");
+    payload.append(service_name);
+    payload.append("\",\"transport\":\"");
+    payload.append(PROV_TRANSPORT_BLE);
+    payload.append("\"}");
+    return payload;
+}
+
+void append_qr_url(std::string& s)
+{
+    s.append(QRCODE_BASE_URL);
+    s.append("?data=");
+    s.append(qr_payload());
 }
 
 void prov_print_qr(const char* name, const char* pop, const char* transport)

--- a/app/brewblox-esp/main/network/wifi.cpp
+++ b/app/brewblox-esp/main/network/wifi.cpp
@@ -118,12 +118,12 @@ static void event_handler(void* arg, esp_event_base_t event_base,
         switch (event_id) {
         case WIFI_PROV_START:
             // Configure blue blinking
-            spark4::set_led(0, 0, 128, spark4::LED_MODE::BLINK, 2);
+            spark4::set_led(0, 0, 128, spark4::LED_MODE::BLINK, 8);
             ESP_LOGI(TAG, "Provisioning started");
             break;
         case WIFI_PROV_CRED_RECV: {
             // Configure blue/green blinking
-            spark4::set_led(0, 128, 128, spark4::LED_MODE::BLINK, 2);
+            spark4::set_led(0, 128, 128, spark4::LED_MODE::BLINK, 8);
             wifi_sta_config_t* wifi_sta_cfg = (wifi_sta_config_t*)event_data;
             ESP_LOGI(TAG,
                      "Received Wi-Fi credentials for SSID: %s\n",
@@ -132,7 +132,7 @@ static void event_handler(void* arg, esp_event_base_t event_base,
         }
         case WIFI_PROV_CRED_FAIL: {
             // Configure fast red blinking
-            spark4::set_led(128, 0, 0, spark4::LED_MODE::BLINK, 1);
+            spark4::set_led(128, 0, 0, spark4::LED_MODE::BLINK, 4);
             wifi_prov_sta_fail_reason_t* reason = (wifi_prov_sta_fail_reason_t*)event_data;
             ESP_LOGE(TAG,
                      "Provisioning failed!\n\tReason : %s"
@@ -144,8 +144,6 @@ static void event_handler(void* arg, esp_event_base_t event_base,
             ESP_LOGI(TAG, "Provisioning successful");
             break;
         case WIFI_PROV_END:
-            // Configure blue slow breathing
-            spark4::set_led(0, 0, 128, spark4::LED_MODE::BREATHE, 5);
             /* De-initialize manager once provisioning is finished */
             wifi_prov_mgr_deinit();
             break;
@@ -154,11 +152,11 @@ static void event_handler(void* arg, esp_event_base_t event_base,
         }
     } else if (event_base == WIFI_EVENT && event_id == WIFI_EVENT_STA_START) {
         // Configure Green for blinking fast
-        spark4::set_led(0, 128, 0, spark4::LED_MODE::BLINK, 1);
+        spark4::set_led(0, 128, 0, spark4::LED_MODE::BLINK, 2);
         esp_wifi_connect();
     } else if (event_base == IP_EVENT && event_id == IP_EVENT_STA_GOT_IP) {
         // Configure Blue and Green for breathing
-        spark4::set_led(0, 128, 128, spark4::LED_MODE::BREATHE, 4);
+        spark4::set_led(0, 128, 128, spark4::LED_MODE::BREATHE, 15);
 
         connected = true;
         ip_event_got_ip_t* event = (ip_event_got_ip_t*)event_data;
@@ -173,7 +171,7 @@ static void event_handler(void* arg, esp_event_base_t event_base,
         connected = false;
         ESP_LOGI(TAG, "Disconnected. Connecting to the AP again...");
         // Configure Green for blinking fast
-        spark4::set_led(0, 128, 0, spark4::LED_MODE::BLINK, 1);
+        spark4::set_led(0, 128, 0, spark4::LED_MODE::BLINK, 2);
         esp_wifi_connect();
 
         /* enable wifi power saving */

--- a/app/brewblox-esp/main/network/wifi.hpp
+++ b/app/brewblox-esp/main/network/wifi.hpp
@@ -2,6 +2,7 @@
 
 #include <esp_err.h>
 #include <esp_netif_ip_addr.h>
+#include <string>
 
 namespace wifi {
 
@@ -20,4 +21,6 @@ bool isConnected();
  * @return The rssi in dBm
  */
 int8_t getRssi();
+
+void append_qr_url(std::string& s);
 };

--- a/app/brewblox-esp/main/ota.cpp
+++ b/app/brewblox-esp/main/ota.cpp
@@ -20,6 +20,7 @@
 #include "nvs_flash.h"
 #include <string.h>
 // #include "protocol_examples_common.h"
+#include "Spark4.hpp"
 #include "errno.h"
 #include "esp_wifi.h"
 #include "ota.hpp"
@@ -47,6 +48,9 @@ static void __attribute__((noreturn)) task_fatal_error(void)
 {
     ESP_LOGE(TAG, "Exiting task due to fatal error...");
 
+    // red fast blink
+    spark4::set_led(128, 0, 0, spark4::LED_MODE::BLINK, 1);
+
     vTaskDelay(3000);
     esp_restart();
 }
@@ -69,6 +73,9 @@ static void ota_task(void* pvParameter)
     const esp_partition_t* update_partition = NULL;
 
     ESP_LOGI(TAG, "Starting OTA");
+
+    // slow purple blink
+    spark4::set_led(64, 0, 128, spark4::LED_MODE::BLINK, 4);
 
     const esp_partition_t* configured = esp_ota_get_boot_partition();
     const esp_partition_t* running = esp_ota_get_running_partition();
@@ -111,6 +118,7 @@ static void ota_task(void* pvParameter)
     int binary_file_length = 0;
     /*deal with all receive packet*/
     bool image_header_was_checked = false;
+
     while (1) {
         int data_read = esp_http_client_read(client, ota_write_data, BUFFSIZE);
         if (data_read < 0) {
@@ -193,6 +201,10 @@ static void ota_task(void* pvParameter)
             }
         }
     }
+
+    // fast purple when receive is complete
+    spark4::set_led(64, 0, 128, spark4::LED_MODE::BLINK, 1);
+
     ESP_LOGI(TAG, "Total Write binary data length: %d", binary_file_length);
     if (esp_http_client_is_complete_data_received(client) != true) {
         ESP_LOGE(TAG, "Error in receiving complete file");

--- a/app/brewblox-esp/main/ota.cpp
+++ b/app/brewblox-esp/main/ota.cpp
@@ -48,8 +48,8 @@ static void __attribute__((noreturn)) task_fatal_error(void)
 {
     ESP_LOGE(TAG, "Exiting task due to fatal error...");
 
-    // red fast blink
-    spark4::set_led(128, 0, 0, spark4::LED_MODE::BLINK, 1);
+    // red blink
+    spark4::set_led(128, 0, 0, spark4::LED_MODE::BLINK, 4);
 
     vTaskDelay(3000);
     esp_restart();
@@ -75,7 +75,7 @@ static void ota_task(void* pvParameter)
     ESP_LOGI(TAG, "Starting OTA");
 
     // slow purple blink
-    spark4::set_led(64, 0, 128, spark4::LED_MODE::BLINK, 4);
+    spark4::set_led(64, 0, 128, spark4::LED_MODE::BLINK, 15);
 
     const esp_partition_t* configured = esp_ota_get_boot_partition();
     const esp_partition_t* running = esp_ota_get_running_partition();
@@ -202,8 +202,8 @@ static void ota_task(void* pvParameter)
         }
     }
 
-    // fast purple when receive is complete
-    spark4::set_led(64, 0, 128, spark4::LED_MODE::BLINK, 1);
+    // faster purple when receive is complete
+    spark4::set_led(64, 0, 128, spark4::LED_MODE::BLINK, 4);
 
     ESP_LOGI(TAG, "Total Write binary data length: %d", binary_file_length);
     if (esp_http_client_is_complete_data_received(client) != true) {

--- a/app/brewblox-esp/ota-flash.sh
+++ b/app/brewblox-esp/ota-flash.sh
@@ -26,6 +26,8 @@ echo "Sending POST to $POST_URL with firmware URL $SERVE_URL"
 
 python3 -m http.server $PORT --directory build & 
 
+sleep 2
+
 curl -X POST "$POST_URL" -d "$SERVE_URL"
 wait
 exit $?

--- a/lib/inc/SX1508.hpp
+++ b/lib/inc/SX1508.hpp
@@ -21,6 +21,7 @@
 
 #include "I2CDevice.hpp"
 #include <stdint.h>
+#include <vector>
 
 class SX1508 : public I2CDeviceBase<0x20> {
 public:
@@ -92,6 +93,7 @@ public:
 
     void reset();
     bool write_reg(RegAddr addr, uint8_t data);
+    bool write_regs(std::vector<uint8_t>&& data); // first byte is start address
     // void write_regs(RegAddr addr, const uint8_t* data, size_t len);
     bool read_reg(RegAddr addr, uint8_t& result);
 };

--- a/lib/src/SX1508.cpp
+++ b/lib/src/SX1508.cpp
@@ -24,6 +24,11 @@ bool SX1508::write_reg(RegAddr addr, uint8_t data)
     return i2c_write({static_cast<uint8_t>(addr), data});
 }
 
+bool SX1508::write_regs(std::vector<uint8_t>&& data) // first byte is start address
+{
+    return i2c_write(data);
+}
+
 bool SX1508::read_reg(RegAddr addr, uint8_t& result)
 {
     if (i2c_write(static_cast<uint8_t>(addr), true)) {

--- a/platform/esp/Spark4.cpp
+++ b/platform/esp/Spark4.cpp
@@ -31,6 +31,7 @@ constexpr auto PIN_NUM_I2C_SDA = GPIO_NUM_32;
 constexpr auto PIN_NUM_I2C_SCL = GPIO_NUM_33;
 
 SX1508 expander(0);
+uint8_t backLightPwm = 128;
 
 void hw_init()
 {
@@ -94,36 +95,47 @@ void expander_check()
 
 void set_led(uint8_t R, uint8_t G, uint8_t B, LED_MODE mode, uint8_t duration)
 {
-    expander.write_reg(SX1508::RegAddr::iOn6, R);
-    expander.write_reg(SX1508::RegAddr::iOn7, G);
-    expander.write_reg(SX1508::RegAddr::iOn3, B);
+    uint8_t tOn3 = duration;
+    uint8_t tOn7 = duration;
+    uint8_t tOn6 = duration;
+    uint8_t off3 = duration << 3;
+    uint8_t off7 = duration << 3;
+    uint8_t off6 = duration << 3;
+    uint8_t tRise3 = 0;
+    uint8_t tFall3 = 0;
+    uint8_t tRise7 = 0;
+    uint8_t tFall7 = 0;
 
     if (mode == BREATHE) {
         //green
-        expander.write_reg(SX1508::RegAddr::tRise7, duration - 1);
-        expander.write_reg(SX1508::RegAddr::tOn7, 1); // 1 period on
-        expander.write_reg(SX1508::RegAddr::tFall7, duration - 1);
-        expander.write_reg(SX1508::RegAddr::off7, 0b00001010); // 1 period off, intensity 2
-        //blue
-        expander.write_reg(SX1508::RegAddr::tRise3, duration - 1);
-        expander.write_reg(SX1508::RegAddr::tOn3, 1); // 1 period on
-        expander.write_reg(SX1508::RegAddr::tFall3, duration - 1);
-        expander.write_reg(SX1508::RegAddr::off3, 0b00001010); // 1 period off, intensity 2
-    } else {
-        //green
-        expander.write_reg(SX1508::RegAddr::tRise7, 0);
-        expander.write_reg(SX1508::RegAddr::tOn7, duration);
-        expander.write_reg(SX1508::RegAddr::tFall7, 0);
-        expander.write_reg(SX1508::RegAddr::off7, duration << 3);
-        //blue
-        expander.write_reg(SX1508::RegAddr::tRise3, 0);
-        expander.write_reg(SX1508::RegAddr::tOn3, duration);
-        expander.write_reg(SX1508::RegAddr::tFall3, 0);
-        expander.write_reg(SX1508::RegAddr::off3, duration << 3);
+        tOn3 = 1;
+        tRise3 = duration - 1;
+        tFall3 = duration - 1;
+        off3 = 0b00001010; // period off, intensity 2
+        tOn7 = 1;
+        tRise7 = duration - 1;
+        tFall7 = duration - 1;
+        off7 = 0b00001010; // period off, intensity 2
     }
 
-    expander.write_reg(SX1508::RegAddr::tOn6, duration);
-    expander.write_reg(SX1508::RegAddr::off6, duration << 3);
+    expander.write_regs({
+        uint8_t(SX1508::RegAddr::tOn3), // start address
+        tOn3,                           // tOn3
+        B,                              // iOn3
+        off3,                           // off3
+        tRise3,                         // tRise3
+        tFall3,                         // tFall3
+        0,                              // iOn4, led driver is disdabled on this pin but by including it we can use a single transaction
+        backLightPwm,                   // iOn5
+        tOn6,                           // tOn6
+        R,                              // iOn6
+        off6,                           // off6
+        tOn7,                           // tOn7
+        G,                              // iOn7
+        off7,                           // off7
+        tRise7,                         // tRise7
+        tFall7,                         // tFall7
+    });
 }
 
 void expander_init()
@@ -134,7 +146,7 @@ void expander_init()
     expander.write_reg(SX1508::RegAddr::inputDisable, 0b11101000);
     // Disable pullup for RGB LED and TFT backlight
     expander.write_reg(SX1508::RegAddr::pullUp, 0b00010111);
-    // Set direction
+    // Setuint8_t backLightPwm = 128; direction
     expander.write_reg(SX1508::RegAddr::dir, 0b00010111);
     // Enable open drain for RGB LED, TFT backlight is push/pull
     expander.write_reg(SX1508::RegAddr::openDrain, 0b11001000);
@@ -166,10 +178,12 @@ void hw_deinit()
 void display_brightness(uint8_t b)
 {
     if (b < 20) {
-        b = 128; // if a too low value is set, revert back to default
+        backLightPwm = 128; // if a too low value is set, revert back to default
+    } else {
+        backLightPwm = 255 - b;
     }
     // enable signal should be inverted
-    expander.write_reg(SX1508::RegAddr::iOn5, uint8_t{255} - b);
+    expander.write_reg(SX1508::RegAddr::iOn5, backLightPwm);
 }
 
 void startup_beep()
@@ -215,5 +229,4 @@ uint32_t adcReadExternal()
 // 0,1,2,4 -> EX0, EX1, EX2, EX3 (interrupt inputs)
 // 3, 6, 7 -> LED B, R, G. (B and G support breathing)
 // 5 -> LCD backlight
-
 }

--- a/platform/esp/Spark4.cpp
+++ b/platform/esp/Spark4.cpp
@@ -140,7 +140,8 @@ void expander_init()
     expander.write_reg(SX1508::RegAddr::openDrain, 0b11001000);
     // logarithmic fading for RGB, PWM frequendy 250 Hz, reset is POR, auto increment register, auto clean nint on read
     expander.write_reg(SX1508::RegAddr::misc, 0b11101000);
-    // enable led driver on RGB and backlight
+
+    // enable led drivers
     expander.write_reg(SX1508::RegAddr::ledDriverEnable, 0b11101000);
 
     // Blink fast white during boot

--- a/platform/esp/Spark4.hpp
+++ b/platform/esp/Spark4.hpp
@@ -2,6 +2,13 @@
 #include <cstdint>
 
 namespace spark4 {
+enum LED_MODE : uint8_t {
+    BREATHE,
+    BLINK,
+};
+
+void set_led(uint8_t R, uint8_t G, uint8_t B, LED_MODE mode, uint8_t duration);
+
 void hw_init();
 void expander_init();
 void expander_check();


### PR DESCRIPTION
This adds a link to the wifi provisioning QR code on the pot 80 status page of the Spark 4.
This can be used to get the QR code when the spark is plugged into wired ethernet.

Changed prefix to 'PROV_BREWBLOX_' instead of 'BREWBLOX_' for compatibility the default prefix of the ESP provisioning app. Now it is easy to choose 'I don't have a QR code' and scan Bluetooth.

Also changed LED colors based on wifi status.

Also fixed a OneWire bug that was present on develop after the onewire refactor, causing the DS2413 to not work on photon/p1. This is because i2c ack was used to get the busy status of the master, which does work on the ESP. Reverted back to just using busyWait as before.