### PR TITLE
Fix setting channel affecting other channels

### DIFF
--- a/app/brewblox-esp/main/ExpOwGpio.cpp
+++ b/app/brewblox-esp/main/ExpOwGpio.cpp
@@ -99,6 +99,11 @@ bool ExpOwGpio::senseChannelImpl(uint8_t channel, State& result) const
 
     auto pins = flexChannels[idx].pins();
 
+    if (pins == 0) {
+        result = State::Unknown;
+        return false;
+    }
+
     if (flexChannels[idx].pwm_duty) {
         // for a non-zero pwm value, return Active regardless of pin state
         result = State::Active;
@@ -257,13 +262,13 @@ void ExpOwGpio::update(bool forceRefresh)
 
         if (!(drv_status.bits.spi_error || drv_status.bits.power_on_reset)) {
             // status is valid
-            if (true || drv_status.bits.openload) {
+            if (drv_status.bits.openload) {
                 // open load is detected
                 old_status.bits.all = read2DrvRegisters(DRV8908::RegAddr::OLD_STAT_1);
             } else {
                 old_status.bits.all = 0;
             }
-            if (true || drv_status.bits.overcurrent) {
+            if (drv_status.bits.overcurrent) {
                 // status is valid and overcurrent is detected
                 ocp_status.bits.all = read2DrvRegisters(DRV8908::RegAddr::OCP_STAT_1);
             } else {

--- a/app/brewblox-esp/main/ExpOwGpio.hpp
+++ b/app/brewblox-esp/main/ExpOwGpio.hpp
@@ -113,7 +113,7 @@ public:
         void apply(const ChanBitsInternal& mask, const ChanBitsInternal& state)
         {
             bits.all &= ~mask.bits.all;
-            bits.all |= state.bits.all;
+            bits.all |= (mask.bits.all & state.bits.all);
         }
     };
 

--- a/app/brewblox-esp/test/ExpOwGpio_test.cpp
+++ b/app/brewblox-esp/test/ExpOwGpio_test.cpp
@@ -247,6 +247,42 @@ SCENARIO("OneWire + GPIO module using mock hw")
         }
     }
 
+    WHEN("A 2 + only channels are created")
+    {
+        gpio->setupChannel(1, ExpOwGpio::FlexChannel{blox_GpioDeviceType_GPIO_DEV_SSR_1P, 1, 0b00000001});
+        gpio->setupChannel(2, ExpOwGpio::FlexChannel{blox_GpioDeviceType_GPIO_DEV_SSR_1P, 1, 0b00000010});
+
+        THEN("The masks are correct")
+        {
+            CHECK(gpio->pullUpWhenActive() == 0b11);
+            CHECK(gpio->pullDownWhenActive() == 0b00);
+            CHECK(gpio->pullUpWhenInactive() == 0b00);
+            CHECK(gpio->pullDownWhenInactive() == 0b11);
+            CHECK(gpio->pullDownStatus() == 0b11);
+            CHECK(gpio->pullUpStatus() == 0b00);
+            CHECK(gpio->pullUpDesired() == 0b00);
+            CHECK(gpio->pullDownDesired() == 0b11);
+        }
+
+        THEN("When toggled, the status is correct")
+        {
+            gpio->writeChannelImpl(1, IoArray::ChannelConfig::DRIVING_ON);
+            CHECK(gpio->pullUpDesired() == 0b01);
+            CHECK(gpio->pullDownDesired() == 0b10);
+
+            gpio->writeChannelImpl(2, IoArray::ChannelConfig::DRIVING_ON);
+            CHECK(gpio->pullUpDesired() == 0b11);
+            CHECK(gpio->pullDownDesired() == 0b00);
+
+            gpio->writeChannelImpl(2, IoArray::ChannelConfig::DRIVING_OFF);
+            CHECK(gpio->pullUpDesired() == 0b01);
+            CHECK(gpio->pullDownDesired() == 0b10);
+
+            gpio->writeChannelImpl(1, IoArray::ChannelConfig::DRIVING_OFF);
+            CHECK(gpio->pullUpDesired() == 0b00);
+            CHECK(gpio->pullDownDesired() == 0b11);
+        }
+    }
     removeMockI2CDevice(0x70);
     removeMockSpiDevice(-1);
 }


### PR DESCRIPTION
Fixes critical bug in applying desired IO channel state. The desired state was not masked to the assigned pins and affected other channels. Caused flickering on IO pins.