### PR TITLE
increase tcp buffer size and drop data if streambuf is full

### DIFF
--- a/app/brewblox-esp/main/main.cpp
+++ b/app/brewblox-esp/main/main.cpp
@@ -10,6 +10,8 @@
 #include "RecurringTask.hpp"
 #include "TempSensor.h"
 #include "brewblox_esp.hpp"
+// #include "esp_heap_caps.h"
+// #include "esp_heap_trace.h"
 #include "graphics/graphics.hpp"
 #include "graphics/widgets.hpp"
 #include "hal/hal_delay.h"
@@ -123,6 +125,7 @@ int main(int /*argc*/, char** /*argv*/)
                                             RecurringTask::IntervalType::FROM_EXPIRY,
                                             []() -> bool {
                                                 spark4::expander_check();
+                                                // heap_caps_print_heap_info(MALLOC_CAP_8BIT);
                                                 return true;
                                             });
 

--- a/app/brewblox-esp/main/network/CboxConnection.cpp
+++ b/app/brewblox-esp/main/network/CboxConnection.cpp
@@ -6,8 +6,8 @@
 CboxConnection::CboxConnection(
     CboxConnectionManager& connection_manager_,
     cbox::Box& box_)
-    : buffer_in(8192)
-    , buffer_out(8192)
+    : buffer_in(32768)
+    , buffer_out(32768)
     , connection_manager(connection_manager_)
     , box(box_)
 {

--- a/app/brewblox-esp/main/network/CboxConnection.hpp
+++ b/app/brewblox-esp/main/network/CboxConnection.hpp
@@ -5,10 +5,10 @@
 namespace cbox {
 
 class StreamBufDataIn : public DataIn {
-    std::streambuf& in;
+    asio::streambuf& in;
 
 public:
-    StreamBufDataIn(std::streambuf& in_)
+    StreamBufDataIn(asio::streambuf& in_)
         : in(in_)
     {
     }
@@ -33,21 +33,25 @@ public:
  * Provides a DataOut stream by wrapping a std::ostream.
  */
 class StreamBufDataOut final : public DataOut {
-    std::streambuf& out;
+    asio::streambuf& out;
 
 public:
-    StreamBufDataOut(std::streambuf& out_)
+    StreamBufDataOut(asio::streambuf& out_)
         : out(out_)
     {
     }
 
     virtual bool write(uint8_t data) override final
     {
-        out.sputc(data);
-        if (data == '\n') {
-            out.pubsync();
+        if (out.size() < out.max_size()) {
+            out.sputc(data);
+            // flush output if \n or , has been written
+            if (data == '\n' || data == ',') {
+                out.pubsync();
+            }
+            return true;
         }
-        return true;
+        return false;
     }
 };
 


### PR DESCRIPTION
We used 8192 as max size for in and outgoing TCP buffers.
Apparently this can be hit if you create more than 10 control chains on a single spark.

The asio streambuffers are variable size and allocate when needed. However when the max size was hit, it would throw an exception. With exceptions disabled, this is a hardfault reboot.

This PR implements 3 fixes:
- Increase max buffer size to 32768
- Drop data if the buffer is full. With 32768 as buffer size, this probably means the other side stopped listening anyway
- Flush data not only on '\n', but also on ',', so when sending out list responses of all blocks, the data is flushed between blocks too.

