### PR TITLE
Remove vector interface from i2c device class and add mutex

### DIFF
--- a/lib/inc/I2CDevice.hpp
+++ b/lib/inc/I2CDevice.hpp
@@ -38,7 +38,16 @@ public:
         addr = (lower_bits < 4) ? lower_bits + family_address() : 0xFF;
     }
 
-    bool i2c_write(const std::vector<uint8_t>& values, bool stop = true)
+    bool i2c_write(uint8_t value, bool stop = true)
+    {
+        lastError = hal_i2c_write(addr, &value, 1, stop);
+        return lastError == 0;
+    }
+
+    bool i2c_write(uint8_t value, uint8_t value2) = delete;
+
+    template <size_t N>
+    bool i2c_write(const std::array<uint8_t, N>& values, bool stop = true)
     {
         if (addr == 0xFF) {
             return false;
@@ -47,39 +56,24 @@ public:
         return lastError == 0;
     }
 
-    bool i2c_write(std::initializer_list<uint8_t> values, bool stop = true)
-    {
-        return i2c_write(std::vector<uint8_t>{values}, stop);
-    }
-
-    bool i2c_write(uint8_t value, bool stop = true)
-    {
-        return i2c_write(std::vector<uint8_t>{value}, stop);
-    }
-
-    bool i2c_write(uint8_t value, uint8_t value2) = delete;
-
-    std::vector<uint8_t> i2c_read(size_t n, bool stop = true)
-    {
-        if (addr == 0xFF) {
-            return {};
-        }
-        std::vector<uint8_t> values(n);
-        lastError = hal_i2c_read(addr, values.data(), values.size(), stop);
-        if (lastError == 0) {
-            return values;
-        }
-        return {};
-    }
-
     template <size_t N>
-    bool i2c_read(std::array<uint8_t, N>& data, bool stop = true)
+    bool i2c_read(std::array<uint8_t, N>& values, bool stop = true)
     {
         if (addr == 0xFF) {
-            return {};
+            return false;
         }
 
-        lastError = hal_i2c_read(addr, data.data(), data.size(), stop);
+        lastError = hal_i2c_read(addr, values.data(), values.size(), stop);
+        return lastError == 0;
+    }
+
+    bool i2c_read(uint8_t& value, bool stop = true)
+    {
+        if (addr == 0xFF) {
+            return false;
+        }
+
+        lastError = hal_i2c_read(addr, &value, 1, stop);
         return lastError == 0;
     }
 

--- a/lib/inc/SX1508.hpp
+++ b/lib/inc/SX1508.hpp
@@ -93,7 +93,5 @@ public:
 
     void reset();
     bool write_reg(RegAddr addr, uint8_t data);
-    bool write_regs(std::vector<uint8_t>&& data); // first byte is start address
-    // void write_regs(RegAddr addr, const uint8_t* data, size_t len);
     bool read_reg(RegAddr addr, uint8_t& result);
 };

--- a/lib/src/SX1508.cpp
+++ b/lib/src/SX1508.cpp
@@ -21,22 +21,13 @@
 
 bool SX1508::write_reg(RegAddr addr, uint8_t data)
 {
-    return i2c_write({static_cast<uint8_t>(addr), data});
-}
-
-bool SX1508::write_regs(std::vector<uint8_t>&& data) // first byte is start address
-{
-    return i2c_write(data);
+    return i2c_write(std::array<uint8_t, 2>({static_cast<uint8_t>(addr), data}));
 }
 
 bool SX1508::read_reg(RegAddr addr, uint8_t& result)
 {
     if (i2c_write(static_cast<uint8_t>(addr), true)) {
-        auto answer = i2c_read(1);
-        if (answer.size()) {
-            result = answer[0];
-            return true;
-        }
+        return i2c_read(result);
     }
     return false;
 }

--- a/platform/esp/FT6236.cpp
+++ b/platform/esp/FT6236.cpp
@@ -28,7 +28,7 @@ void FT6236::init()
 
 bool FT6236::writeRegister(Register reg, uint8_t value)
 {
-    return i2c_write({static_cast<uint8_t>(reg), value});
+    return i2c_write(std::array<uint8_t, 2>({static_cast<uint8_t>(reg), value}));
 }
 
 FT6236::Touch FT6236::getLastTouch()
@@ -38,14 +38,13 @@ FT6236::Touch FT6236::getLastTouch()
 
 std::optional<uint8_t> FT6236::readRegister(Register reg)
 {
-    auto value = std::array<uint8_t, 1>{};
-    i2c_write(static_cast<uint8_t>(reg));
-    auto read = i2c_read(value);
-    if (read) {
-        return value[0];
-    } else {
-        return std::nullopt;
+    if (i2c_write(static_cast<uint8_t>(reg))) {
+        uint8_t v;
+        if (i2c_read(v)) {
+            return v;
+        }
     }
+    return std::nullopt;
 }
 
 std::optional<FT6236::Touch> FT6236::getTouch()

--- a/platform/esp/Spark4.cpp
+++ b/platform/esp/Spark4.cpp
@@ -122,7 +122,7 @@ void set_led(uint8_t R, uint8_t G, uint8_t B, LED_MODE mode, uint8_t duration)
         off7 = 0b00001010; // period off, intensity 2
     }
 
-    expander.write_regs({
+    expander.i2c_write(std::array<uint8_t, 16>({
         uint8_t(SX1508::RegAddr::tOn3), // start address
         tOn3,                           // tOn3
         B,                              // iOn3
@@ -139,7 +139,7 @@ void set_led(uint8_t R, uint8_t G, uint8_t B, LED_MODE mode, uint8_t duration)
         off7,                           // off7
         tRise7,                         // tRise7
         tFall7,                         // tFall7
-    });
+    }));
 }
 
 void expander_init()

--- a/platform/esp/TCA9538.hpp
+++ b/platform/esp/TCA9538.hpp
@@ -12,7 +12,7 @@ public:
     void set_outputs(uint8_t bits)
     {
         outputs = bits;
-        i2c_write({0x01, outputs});
+        i2c_write(std::array<uint8_t, 2>({0x01, outputs}));
     }
 
     void set_output(uint8_t pin, bool state)
@@ -28,16 +28,15 @@ public:
     // 1 for input, 0 for output
     void set_config(uint8_t inputs_mask)
     {
-        i2c_write({0x03, inputs_mask});
+        i2c_write(std::array<uint8_t, 2>({0x03, inputs_mask}));
     }
 
     bool get_outputs(uint8_t& result)
     {
-        i2c_write({0x1});
-        auto v = i2c_read(1);
-        if (v.size()) {
-            result = v[0];
-            return true;
+        if (i2c_write(uint8_t(0x1))) {
+            if (i2c_read(result)) {
+                return true;
+            }
         }
         return false;
     }

--- a/platform/esp/hal_i2c_esp.cpp
+++ b/platform/esp/hal_i2c_esp.cpp
@@ -1,9 +1,26 @@
 #include "driver/i2c.h"
+#include "esp_log.h"
 #include "hal/hal_i2c.h"
+#include <mutex>
+
+namespace detail {
+std::mutex i2c_mutex;
 
 hal_i2c_err_t to_hal_err(esp_err_t err)
 {
+    if (err) {
+        ESP_LOGE("I2C", "Error %d", err);
+    }
     return err; // TODO: convert errors to platform independent enum
+}
+
+hal_i2c_err_t cmd_link_send(i2c_cmd_handle_t cmd)
+{
+    std::lock_guard<std::mutex> guard(detail::i2c_mutex);
+    auto err = i2c_master_cmd_begin(I2C_NUM_0, cmd, 1000 / portTICK_RATE_MS);
+    i2c_cmd_link_delete(cmd);
+    return to_hal_err(err);
+}
 }
 
 hal_i2c_err_t hal_i2c_master_init()
@@ -22,7 +39,7 @@ hal_i2c_err_t hal_i2c_master_init()
     i2c_set_data_mode(I2C_NUM_0, I2C_DATA_MODE_MSB_FIRST, I2C_DATA_MODE_MSB_FIRST);
     i2c_filter_enable(I2C_NUM_0, 7);
 
-    return to_hal_err(err);
+    return detail::to_hal_err(err);
 }
 
 hal_i2c_err_t hal_i2c_write(uint8_t address, const uint8_t* data, size_t len, bool stop)
@@ -34,9 +51,7 @@ hal_i2c_err_t hal_i2c_write(uint8_t address, const uint8_t* data, size_t len, bo
     if (stop) {
         i2c_master_stop(cmd);
     }
-    auto err = i2c_master_cmd_begin(I2C_NUM_0, cmd, 1000 / portTICK_RATE_MS);
-    i2c_cmd_link_delete(cmd);
-    return to_hal_err(err);
+    return detail::cmd_link_send(cmd);
 }
 
 hal_i2c_err_t hal_i2c_read(uint8_t address, uint8_t* data, size_t len, bool stop)
@@ -48,9 +63,7 @@ hal_i2c_err_t hal_i2c_read(uint8_t address, uint8_t* data, size_t len, bool stop
     if (stop) {
         i2c_master_stop(cmd);
     }
-    auto err = i2c_master_cmd_begin(I2C_NUM_0, cmd, 1000 / portTICK_RATE_MS);
-    i2c_cmd_link_delete(cmd);
-    return to_hal_err(err);
+    return detail::cmd_link_send(cmd);
 }
 
 hal_i2c_err_t hal_i2c_detect(uint8_t address)
@@ -59,7 +72,5 @@ hal_i2c_err_t hal_i2c_detect(uint8_t address)
     i2c_master_start(cmd);
     i2c_master_write_byte(cmd, address << 1U, true);
     i2c_master_stop(cmd);
-    auto err = i2c_master_cmd_begin(I2C_NUM_0, cmd, 1000 / portTICK_RATE_MS);
-    i2c_cmd_link_delete(cmd);
-    return to_hal_err(err);
+    return detail::cmd_link_send(cmd);
 }

--- a/platform/esp/hal_spi_esp.cpp
+++ b/platform/esp/hal_spi_esp.cpp
@@ -113,7 +113,7 @@ void deInit(Settings& settings)
 error_t write(Settings& settings, const uint8_t* data, size_t size)
 {
     auto trans = spi_transaction_t{};
-    if (size < 4) {
+    if (size <= 4) {
         trans = spi_transaction_t{
             .flags = uint32_t{SPI_TRANS_USE_TXDATA},
             .cmd = 0,


### PR DESCRIPTION
- Remove vector functions from i2c device interface to avoid heap allocations
- Add mutex on ESP because i2c functions are not thread-safe
- Fix non-DMA spi transfer to use tx_data for 4 bytes