### PR TITLE
Ensure io modules are initialized when scanning for devices

### DIFF
--- a/app/brewblox-esp/main/ExpOwGpio.cpp
+++ b/app/brewblox-esp/main/ExpOwGpio.cpp
@@ -245,15 +245,20 @@ uint16_t ExpOwGpio::read2DrvRegisters(DRV8908::RegAddr addr)
     return (uint16_t(upper) << 8) + lower;
 }
 
+void ExpOwGpio::init()
+{
+    // try to reconnect
+    connected = hal_i2c_detect(expander.address()) == 0;
+    if (connected) {
+        init_driver(); // init io driver
+        ow.init();     // init OneWire bus
+    }
+}
+
 void ExpOwGpio::update(bool forceRefresh)
 {
     if (!connected) {
-        // try to reconnect
-        connected = hal_i2c_detect(expander.address()) == 0;
-        if (connected) {
-            init_driver(); // init io driver
-            ow.init();     // init OneWire bus
-        }
+        init();
     }
     if (!connected) {
         return;

--- a/app/brewblox-esp/main/ExpOwGpio.hpp
+++ b/app/brewblox-esp/main/ExpOwGpio.hpp
@@ -37,6 +37,7 @@ public:
                && hal_i2c_detect(DS248x::base_address() + lower_address) == 0;
     }
 
+    void init();
     void init_expander();
     void init_driver();
 

--- a/app/brewblox-esp/main/I2cScanningFactory.cpp
+++ b/app/brewblox-esp/main/I2cScanningFactory.cpp
@@ -65,7 +65,7 @@ std::shared_ptr<cbox::Object> I2cScanningFactory::scan(cbox::ObjectContainer& ob
             uint8_t expander_address = TCA9538::base_address() + lower_bits;
             if (hal_i2c_detect(expander_address) == 0) {
                 // new OneWire GPIO module detected (OneWire bus master and port expander)
-                return std::shared_ptr<cbox::Object>(new ExpOwGpioBlock(lower_bits));
+                return std::shared_ptr<cbox::Object>(new ExpOwGpioBlock(lower_bits, true));
             }
         }
     };

--- a/app/brewblox-esp/main/blox/ExpOwGpioBlock.hpp
+++ b/app/brewblox-esp/main/blox/ExpOwGpioBlock.hpp
@@ -30,9 +30,12 @@ private:
     ExpOwGpio drivers;
 
 public:
-    ExpOwGpioBlock(uint8_t lower_address = 0xFF)
+    ExpOwGpioBlock(uint8_t lower_address = 0xFF, bool init = false)
         : drivers(lower_address)
     {
+        if (init) {
+            drivers.init();
+        }
     }
 
     virtual cbox::CboxError streamFrom(cbox::DataIn& in) override final;


### PR DESCRIPTION
In previous PR, io module and onewire init was postponed to only once per second in the update loop.
As a result, in a single discovery only io modules were found and onewire devices in the next discovery.

The fix is to initialize IO modules immediately if they are found in discovery.