### PR TITLE
Use GCC 8 for simulator builds

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -3,9 +3,9 @@ resources:
     - repository: self
   containers:
     - container: firmware-compiler
-      image: brewblox/firmware-compiler:10.3
+      image: brewblox/firmware-compiler:8
     - container: simulator-compiler
-      image: brewblox/simulator-compiler:10.3
+      image: brewblox/simulator-compiler:8
     - container: idf
       image: espressif/idf:release-v4.4
 
@@ -261,7 +261,6 @@ jobs:
           SRC: docker/firmware-bin/source
 
       - bash: |
-          export TAG=$(TAG)
-          bash docker/firmware-bin/build.sh --push
+          bash docker/firmware-bin/build.sh $(TAG) --push
         displayName: Build firmware-bin image
         condition: and(succeeded(), variables['BRANCH'])

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -3,7 +3,7 @@ resources:
     - repository: self
   containers:
     - container: firmware-compiler
-      image: brewblox/firmware-compiler:8
+      image: brewblox/firmware-compiler:10.3
     - container: simulator-compiler
       image: brewblox/simulator-compiler:8
     - container: idf

--- a/build/build-sim-arm32.sh
+++ b/build/build-sim-arm32.sh
@@ -26,7 +26,7 @@ sed -i 's/-O$(GCC_OPTIMIZE)/-Os/g' platform/spark/device-os/build/gcc-tools.mk
 # Pull compiler image for target arch
 docker pull \
     --platform=linux/arm/v7 \
-    brewblox/simulator-compiler:10.3
+    brewblox/simulator-compiler:8
 
 # Build
 docker run \
@@ -34,7 +34,7 @@ docker run \
     --rm \
     --platform=linux/arm/v7 \
     -v "$(pwd)/":/firmware/ \
-    brewblox/simulator-compiler:10.3 \
+    brewblox/simulator-compiler:8 \
     make APP=brewblox PLATFORM=gcc
 
 # reset modified file

--- a/build/build-sim-arm64.sh
+++ b/build/build-sim-arm64.sh
@@ -26,7 +26,7 @@ sed -i 's/-O$(GCC_OPTIMIZE)/-Os/g' platform/spark/device-os/build/gcc-tools.mk
 # Make sure compiler is up-to-date
 docker pull \
     --platform=linux/arm64/v8 \
-    brewblox/simulator-compiler:10.3
+    brewblox/simulator-compiler:8
 
 # build
 docker run \
@@ -34,7 +34,7 @@ docker run \
     --rm \
     --platform=linux/arm64/v8 \
     -v "$(pwd)/":/firmware/ \
-    brewblox/simulator-compiler:10.3 \
+    brewblox/simulator-compiler:8 \
     make APP=brewblox PLATFORM=gcc
 
 # reset modified file

--- a/build/build-sim-native.sh
+++ b/build/build-sim-native.sh
@@ -10,6 +10,8 @@ fi
 # remove debug info and optimize for size
 sed -i 's/-g3//g' ../platform/spark/device-os/build/gcc-tools.mk
 sed -i 's/-gdwarf-2//g' ../platform/spark/device-os/build/gcc-tools.mk
+# We want to match the shell expression, not expand it before matching
+# shellcheck disable=SC2016
 sed -i 's/-O$(GCC_OPTIMIZE)/-Os/g' ../platform/spark/device-os/build/gcc-tools.mk
 
 make APP=brewblox PLATFORM=gcc

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3.7"
 services:
     compiler:
-        image: brewblox/firmware-compiler:10.3
+        image: brewblox/firmware-compiler:8
         container_name: firmware-compiler
         init: true
         privileged: true

--- a/docker/firmware-bin/before_build.sh
+++ b/docker/firmware-bin/before_build.sh
@@ -1,5 +1,5 @@
 #! /usr/bin/env bash
-set -e
+set -euo pipefail
 pushd "$(dirname "$0")/../.." > /dev/null # Run from repo root
 
 SRC=docker/firmware-bin/source

--- a/docker/firmware-bin/build.sh
+++ b/docker/firmware-bin/build.sh
@@ -1,12 +1,13 @@
 #! /usr/bin/env bash
-set -e
+set -euo pipefail
 pushd "$(dirname "$0")" > /dev/null
 
 # Prerequisite steps:
 # - Build all desired binary/executable firmware files
 # - Run before_build.sh to add dependency files
 
-TAG=${TAG:-local}
+TAG="${1:?}"
+shift
 
 # don't forget to call with --push
 docker buildx build \

--- a/docker/firmware-compiler/Dockerfile
+++ b/docker/firmware-compiler/Dockerfile
@@ -1,4 +1,4 @@
-FROM gcc:10.3
+FROM gcc:8
 
 ENV TZ=Europe/Amsterdam \
   DEBIAN_FRONTEND=noninteractive \
@@ -16,8 +16,8 @@ RUN apt-get update -q \
   && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 # install arm compiler
-ENV GCC_ARM_URL="https://developer.arm.com/-/media/Files/downloads/gnu-rm/10.3-2021.07/gcc-arm-none-eabi-10.3-2021.07-x86_64-linux.tar.bz2" \
-  GCC_ARM_VERSION="10.3-2021.07"
+ENV GCC_ARM_URL="https://developer.arm.com/-/media/Files/downloads/gnu-rm/8-2019q3/RC1.1/gcc-arm-none-eabi-8-2019-q3-update-linux.tar.bz2" \
+  GCC_ARM_VERSION="8-2019-q3-update"
 
 RUN dpkg --add-architecture i386 \
   && apt-get update -q \
@@ -48,8 +48,8 @@ RUN mkdir -p /boost && curl -sSL https://s3.amazonaws.com/spark-assets/boost_$BO
   && export DYLD_LIBRARY_PATH="$BOOST_ROOT/stage/lib:$DYLD_LIBRARY_PATH" \
   && export LD_LIBRARY_PATH="$BOOST_ROOT/stage/lib:$LD_LIBRARY_PATH" \
   && cd $BOOST_ROOT \
-  && ./bootstrap.sh \  
-  && ./b2  --with-thread --with-system --with-program_options --with-random --with-regex --threading=multi link=static runtime-link=static
+  && ./bootstrap.sh \
+  && ./b2 --with-thread --with-system --with-program_options --with-random --with-regex --threading=multi link=static runtime-link=static
 
 WORKDIR /firmware/build
 CMD bash

--- a/docker/firmware-compiler/Dockerfile
+++ b/docker/firmware-compiler/Dockerfile
@@ -1,4 +1,4 @@
-FROM gcc:8
+FROM gcc:10.3
 
 ENV TZ=Europe/Amsterdam \
   DEBIAN_FRONTEND=noninteractive \
@@ -16,8 +16,8 @@ RUN apt-get update -q \
   && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 # install arm compiler
-ENV GCC_ARM_URL="https://developer.arm.com/-/media/Files/downloads/gnu-rm/8-2019q3/RC1.1/gcc-arm-none-eabi-8-2019-q3-update-linux.tar.bz2" \
-  GCC_ARM_VERSION="8-2019-q3-update"
+ENV GCC_ARM_URL="https://developer.arm.com/-/media/Files/downloads/gnu-rm/10.3-2021.07/gcc-arm-none-eabi-10.3-2021.07-x86_64-linux.tar.bz2" \
+  GCC_ARM_VERSION="10.3-2021.07"
 
 RUN dpkg --add-architecture i386 \
   && apt-get update -q \
@@ -48,8 +48,8 @@ RUN mkdir -p /boost && curl -sSL https://s3.amazonaws.com/spark-assets/boost_$BO
   && export DYLD_LIBRARY_PATH="$BOOST_ROOT/stage/lib:$DYLD_LIBRARY_PATH" \
   && export LD_LIBRARY_PATH="$BOOST_ROOT/stage/lib:$LD_LIBRARY_PATH" \
   && cd $BOOST_ROOT \
-  && ./bootstrap.sh \
-  && ./b2 --with-thread --with-system --with-program_options --with-random --with-regex --threading=multi link=static runtime-link=static
+  && ./bootstrap.sh \  
+  && ./b2  --with-thread --with-system --with-program_options --with-random --with-regex --threading=multi link=static runtime-link=static
 
 WORKDIR /firmware/build
 CMD bash

--- a/docker/firmware-compiler/build.sh
+++ b/docker/firmware-compiler/build.sh
@@ -1,5 +1,5 @@
 #! /usr/bin/env bash
-set -e
+set -euo pipefail
 pushd "$(dirname "$0")" > /dev/null
 
 # The compiler image is expected to remain relatively stable
@@ -8,7 +8,10 @@ pushd "$(dirname "$0")" > /dev/null
 # Multi-platform support is handled by simulator-compiler
 # We only need the default amd64
 
-if [ -z "$TAG" ]; then echo "Error: TAG is not set"; exit 1; else echo "building brewblox/firmware-compiler:$TAG"; fi
+TAG="${1:?}"
+shift
+
+echo "building brewblox/firmware-compiler:$TAG"
 
 # don't forget to call with --push
 docker buildx build \

--- a/docker/firmware-particle/Dockerfile
+++ b/docker/firmware-particle/Dockerfile
@@ -1,30 +1,29 @@
-FROM node:14-buster-slim
+FROM node:14-bullseye-slim
 
 WORKDIR /app
+
+ENV PIP_EXTRA_INDEX_URL=https://www.piwheels.org/simple
 
 RUN set -ex \
   && apt-get update \
   && apt-get install -y \
-    make \
-    gcc \
-    g++ \
+    build-essential \
     udev \
     libudev-dev \
-    python \
-    python-pip \
+    libffi-dev \
+    python3-dev \
+    python3-pip \
     usbutils \
     curl \
     dfu-util \
-  && python -m pip install \
+  && python3 -m pip install \
     esptool \
   && npm install --production --build-from-source --unsafe-perm \
     serialport \
     particle-cli \
     particle-usb \
   && apt-get remove -y \
-    make \
-    gcc \
-    g++ \
+    build-essential \
   && apt-get autoremove -y \
   && rm -rf /var/lib/apt/lists/*
 

--- a/docker/firmware-particle/build.sh
+++ b/docker/firmware-particle/build.sh
@@ -1,11 +1,12 @@
 #! /usr/bin/env bash
-set -e
+set -euo pipefail
 pushd "$(dirname "$0")" > /dev/null
 
 # The particle image is expected to remain relatively stable
 # It wraps the Particle CLI in a docker image, so it can easily be used to flash the firmware
 
-TAG=${TAG:-latest}
+TAG="${1:?}"
+shift
 
 bash ../prepare-buildx.sh
 

--- a/docker/firmware-particle/particle
+++ b/docker/firmware-particle/particle
@@ -1,3 +1,3 @@
 #! /usr/bin/env bash
 
-/app/node_modules/.bin/particle --no-update-check "$@"
+exec /app/node_modules/.bin/particle --no-update-check "$@"

--- a/docker/simulator-compiler/Dockerfile
+++ b/docker/simulator-compiler/Dockerfile
@@ -1,4 +1,4 @@
-FROM gcc:10.3
+FROM gcc:8
 
 ENV DEBIAN_FRONTEND=noninteractive \
   DEBCONF_NONINTERACTIVE_SEEN=true


### PR DESCRIPTION
- rollback gcc 10.3 to 8
- use 10.3 for P1/Photon build
