### PR TITLE
Potential fixes for Spark 3 hangups

### DIFF
--- a/app/brewblox-esp/main/I2cScanningFactory.cpp
+++ b/app/brewblox-esp/main/I2cScanningFactory.cpp
@@ -68,6 +68,7 @@ std::shared_ptr<cbox::Object> I2cScanningFactory::scan(cbox::ObjectContainer& ob
                 return std::shared_ptr<cbox::Object>(new ExpOwGpioBlock(lower_bits));
             }
         }
+        hal_yield();
     };
     return nullptr;
 }

--- a/app/brewblox-particle/connectivity.cpp
+++ b/app/brewblox-particle/connectivity.cpp
@@ -149,7 +149,9 @@ void manageConnections(uint32_t now)
 
     if (wifiConnected()) {
         cbox::tracing::add(AppTrace::MDNS_PROCESS);
-        theMdns().processQueries();
+        theMdns().process();
+    } else {
+        theMdns().stop();
     }
 
     while (auto client = httpserver.available()) {
@@ -181,16 +183,12 @@ void handleNetworkEvent(system_event_t event, int param)
         localIp = spark::WiFi.localIP().raw().ipv4;
         // store ssid
         strncpy(currentSsid, spark::WiFi.SSID(), sizeof(currentSsid));
-        // announce MDNS services
-        cbox::tracing::add(AppTrace::MDNS_START);
-        theMdns().begin(true);
         break;
     case network_status_disconnected:
     case network_status_off:
         localIp = 0;
         wifiSignalRssi = 2;
         currentSsid[0] = 0;
-        theMdns().flush();
         // explicit reconnect. WiFi channel switch would otherwise not reconnect
         spark::WiFi.connect(WIFI_CONNECT_SKIP_LISTEN);
         break;

--- a/app/brewblox-particle/connectivity.cpp
+++ b/app/brewblox-particle/connectivity.cpp
@@ -24,6 +24,7 @@
 #include "brewblox_particle.hpp"
 #include "cbox/Tracing.h"
 #include "deviceid_hal.h"
+#include "hal/hal_delay.h"
 #include "reset.h"
 #include "spark_wiring_tcpclient.h"
 #include "spark_wiring_tcpserver.h"
@@ -193,6 +194,7 @@ void manageConnections(uint32_t now)
                 } else {
                     break;
                 }
+                hal_yield();
             }
         }
     } else {

--- a/app/brewblox-particle/connectivity.cpp
+++ b/app/brewblox-particle/connectivity.cpp
@@ -147,8 +147,10 @@ void manageConnections(uint32_t now)
         lastChecked = now;
     }
 
-    cbox::tracing::add(AppTrace::MDNS_PROCESS);
-    theMdns().processQueries();
+    if (wifiConnected()) {
+        cbox::tracing::add(AppTrace::MDNS_PROCESS);
+        theMdns().processQueries();
+    }
 
     while (auto client = httpserver.available()) {
         cbox::tracing::add(AppTrace::HTTP_RESPONSE);
@@ -188,6 +190,7 @@ void handleNetworkEvent(system_event_t event, int param)
         localIp = 0;
         wifiSignalRssi = 2;
         currentSsid[0] = 0;
+        theMdns().flush();
         // explicit reconnect. WiFi channel switch would otherwise not reconnect
         spark::WiFi.connect(WIFI_CONNECT_SKIP_LISTEN);
         break;

--- a/app/brewblox-particle/main.cpp
+++ b/app/brewblox-particle/main.cpp
@@ -104,7 +104,7 @@ void onSetupModeEnd()
 
 void onOutOfMemory(system_event_t event, int param)
 {
-    // reboot when out of memory, beter than undefined behavior
+    // reboot when out of memory, better than undefined behavior
     System.reset(RESET_USER_REASON::OUT_OF_MEMORY, RESET_NO_WAIT);
 }
 

--- a/brewblox/OneWireScanningFactory.hpp
+++ b/brewblox/OneWireScanningFactory.hpp
@@ -29,6 +29,7 @@
 #include "cbox/Object.h"
 #include "cbox/ObjectContainer.h"
 #include "cbox/ScanningFactory.hpp"
+#include "hal/hal_delay.h"
 #include <memory>
 
 class OneWireScanningFactory : public cbox::ScanningFactory {
@@ -86,6 +87,7 @@ public:
                             break;
                         }
                     }
+                    hal_yield();
                 } else {
                     return {};
                 }

--- a/controlbox/src/cbox/ConnectionPool.cpp
+++ b/controlbox/src/cbox/ConnectionPool.cpp
@@ -41,20 +41,21 @@ void ConnectionPool::updateConnections()
     for (auto& source : connectionSources) {
         while (true) {
             auto con = source.get().newConnection();
-            if (con) {
-                if (connections.size() >= 4) {
-                    auto oldest = connections.begin();
-                    auto& out = (*oldest)->getDataOut();
-                    const char message[] = "<!Max connections exceeded, closing oldest>";
-                    out.writeBuffer(message, sizeof(message) / sizeof(message[0]));
-                    connections.erase(oldest);
-                }
-                auto& out = con->getDataOut();
-                connectionStarted(out);
-                connections.push_back(std::move(con));
-            } else {
+            if (!con) {
                 break;
             }
+
+            if (connections.size() >= 4) {
+                auto oldest = connections.begin();
+                auto& out = (*oldest)->getDataOut();
+                const char message[] = "<!Max connections exceeded, closing oldest>";
+                out.writeBuffer(message, sizeof(message) / sizeof(message[0]));
+                connections.erase(oldest);
+            }
+
+            auto& out = con->getDataOut();
+            connectionStarted(out);
+            connections.push_back(std::move(con));
         }
     }
 }

--- a/controlbox/src/cbox/DataStreamConverters.h
+++ b/controlbox/src/cbox/DataStreamConverters.h
@@ -126,7 +126,7 @@ public:
     virtual int16_t peek() override
     {
         fetch();
-        if (upper < '0' || lower < '0' || lower > 'F' || upper > 'F') {
+        if (!isxdigit(upper) || !isxdigit(lower)) {
             return -1;
         }
         return h2d(upper) * 16 + h2d(lower);
@@ -145,18 +145,20 @@ public:
 
     void consumeNonHex()
     {
+        // reset nibbles, because we want a fresh hex char after this function
+        upper = -1;
+        lower = -1;
         while (true) {
             auto v = textIn.peek();
-            if (v < 0) {
-                break;
+            if (isxdigit(v)) {
+                return; // next char is in hex range
             }
-            if (!isxdigit(v)) {
-                textIn.read();
-                upper = -1;
-                lower = -1;
-            } else {
+            if (v < 0) {
+                // stream is empty
                 return;
             }
+            // consume
+            textIn.read();
         }
     }
 

--- a/controlbox/src/cbox/hex_utility.h
+++ b/controlbox/src/cbox/hex_utility.h
@@ -13,7 +13,7 @@ isdigit(char c)
 inline bool
 isxdigit(char c)
 {
-    return isdigit(c) || (c >= 'A' && c <= 'F') || (c >= 'a' && c <= 'f');
+    return isdigit(c) || (c >= 'A' && c <= 'F');
 }
 
 /**

--- a/lib/inc/I2CDevice.hpp
+++ b/lib/inc/I2CDevice.hpp
@@ -21,7 +21,6 @@
 #include "hal/hal_i2c.h"
 #include <array>
 #include <initializer_list>
-#include <vector>
 
 class I2CDevice {
 public:

--- a/lib/inc/hal/hal_delay.h
+++ b/lib/inc/hal/hal_delay.h
@@ -23,3 +23,4 @@
 
 void hal_delay_us(uint32_t v);
 void hal_delay_ms(uint32_t v);
+void hal_yield();

--- a/platform/esp/hal_delay_esp.cpp
+++ b/platform/esp/hal_delay_esp.cpp
@@ -13,3 +13,8 @@ void hal_delay_ms(uint32_t duration)
 {
     vTaskDelay(duration / portTICK_PERIOD_MS);
 }
+
+void hal_yield()
+{
+    taskYIELD();
+}

--- a/platform/spark/modules/mdns/src/MDNS.cpp
+++ b/platform/spark/modules/mdns/src/MDNS.cpp
@@ -1,4 +1,5 @@
 #include "MDNS.h"
+#include "hal/hal_delay.h"
 #include "spark_wiring_wifi.h"
 #include <algorithm>
 #include <cctype> // for std::tolower
@@ -201,6 +202,7 @@ MDNS::getQuery()
                 } else {
                     break;
                 }
+                hal_yield();
             }
             if (udp->available() >= 4) {
                 udpGet(question.qtype);

--- a/platform/spark/modules/mdns/src/MDNS.h
+++ b/platform/spark/modules/mdns/src/MDNS.h
@@ -16,22 +16,17 @@ public:
     };
 
     MDNS(const std::string& hostname);
-    ~MDNS()
-    {
-        delete udp;
-    };
+    ~MDNS();
 
-    void addService(Protocol protocol, std::string serviceType, const std::string serviceName, uint16_t port,
-                    std::vector<std::string>&& txtEntries,
-                    std::vector<std::string>&& subServices);
+    static void addService(Protocol protocol, std::string serviceType, const std::string serviceName, uint16_t port,
+                           std::vector<std::string>&& txtEntries,
+                           std::vector<std::string>&& subServices);
 
-    bool begin(bool announce = false);
-
-    bool processQueries();
-    void flush()
-    {
-        udp->flush_buffer();
-    }
+    static bool begin();
+    static void announce();
+    static void process();
+    static bool processQueries();
+    static void stop();
 
 private:
     struct QueryHeader {
@@ -81,27 +76,27 @@ private:
     static const IPAddress ip;
     static const auto port = uint16_t{5353};
 
-    Query getQuery();
+    static Query getQuery();
 
-    void processQuery(const Query& q);
-    void processQuestion(const Query::Question& question);
-    void writeResponses();
+    static void processQuery(const Query& q);
+    static void processQuestion(const Query::Question& question);
+    static void writeResponses();
 
-    void udpGet(uint8_t& v)
+    static void udpGet(uint8_t& v)
     {
         if (udp->available() >= 1) {
             v = udp->read();
         }
     }
 
-    void udpGet(uint16_t& v)
+    static void udpGet(uint16_t& v)
     {
         if (udp->available() >= 2) {
             v = (uint16_t(udp->read()) << 8) + uint16_t(udp->read());
         }
     }
 
-    void udpGet(uint32_t& v)
+    static void udpGet(uint32_t& v)
     {
         if (udp->available() >= 4) {
             v = (uint32_t(udp->read()) << 24) + (uint32_t(udp->read()) << 16) + (uint32_t(udp->read()) << 8) + uint32_t(udp->read());

--- a/platform/spark/modules/mdns/src/MDNS.h
+++ b/platform/spark/modules/mdns/src/MDNS.h
@@ -28,6 +28,10 @@ public:
     bool begin(bool announce = false);
 
     bool processQueries();
+    void flush()
+    {
+        udp->flush_buffer();
+    }
 
 private:
     struct QueryHeader {

--- a/platform/spark/modules/mdns/src/MDNS.h
+++ b/platform/spark/modules/mdns/src/MDNS.h
@@ -16,7 +16,10 @@ public:
     };
 
     MDNS(const std::string& hostname);
-    ~MDNS() = default;
+    ~MDNS()
+    {
+        delete udp;
+    };
 
     void addService(Protocol protocol, std::string serviceType, const std::string serviceName, uint16_t port,
                     std::vector<std::string>&& txtEntries,
@@ -54,7 +57,7 @@ private:
         std::vector<Question> questions;
     };
 
-    static UDP udp;
+    static UDP* udp;
 
     // static meta records to re-use labels
     static MetaRecord metaLOCAL;
@@ -82,22 +85,22 @@ private:
 
     void udpGet(uint8_t& v)
     {
-        if (udp.available() >= 1) {
-            v = udp.read();
+        if (udp->available() >= 1) {
+            v = udp->read();
         }
     }
 
     void udpGet(uint16_t& v)
     {
-        if (udp.available() >= 2) {
-            v = (uint16_t(udp.read()) << 8) + uint16_t(udp.read());
+        if (udp->available() >= 2) {
+            v = (uint16_t(udp->read()) << 8) + uint16_t(udp->read());
         }
     }
 
     void udpGet(uint32_t& v)
     {
-        if (udp.available() >= 4) {
-            v = (uint32_t(udp.read()) << 24) + (uint32_t(udp.read()) << 16) + (uint32_t(udp.read()) << 8) + uint32_t(udp.read());
+        if (udp->available() >= 4) {
+            v = (uint32_t(udp->read()) << 24) + (uint32_t(udp->read()) << 16) + (uint32_t(udp->read()) << 8) + uint32_t(udp->read());
         }
     }
 };

--- a/platform/spark/modules/mdns/src/UDPMessage.h
+++ b/platform/spark/modules/mdns/src/UDPMessage.h
@@ -41,13 +41,13 @@ public:
         }
     }
 
-    int send(UDP& udp, IPAddress ip, uint16_t port)
+    int send(UDP* udp, IPAddress ip, uint16_t port)
     {
         if (buf.empty()) {
             return 0;
         }
         const uint8_t* data = reinterpret_cast<const uint8_t*>(buf.data());
         size_t size = buf.size();
-        return udp.sendPacket(data, size, ip, port);
+        return udp->sendPacket(data, size, ip, port);
     }
 };

--- a/platform/stub/hal_delay_stub.cpp
+++ b/platform/stub/hal_delay_stub.cpp
@@ -7,3 +7,5 @@ void hal_delay_us(uint32_t /*duration*/)
 void hal_delay_ms(uint32_t /*duration*/)
 {
 }
+
+void hal_yield() {}

--- a/platform/wiring/hal_delay_wiring.cpp
+++ b/platform/wiring/hal_delay_wiring.cpp
@@ -1,5 +1,12 @@
-#include "concurrent_hal.h"
 #include "delay_hal.h"
+#include "platforms.h"
+
+#if PLATFORM_ID == PLATFORM_GCC
+#include "boost_posix_time_wrap.h"
+#include "boost_thread_wrap.h"
+#else
+#include "concurrent_hal.h"
+#endif
 
 void hal_delay_us(uint32_t duration)
 {
@@ -13,5 +20,10 @@ void hal_delay_ms(uint32_t duration)
 
 void hal_yield()
 {
+
+#if PLATFORM_ID == PLATFORM_GCC
+    boost::this_thread::yield();
+#else
     os_thread_yield();
+#endif
 }

--- a/platform/wiring/hal_delay_wiring.cpp
+++ b/platform/wiring/hal_delay_wiring.cpp
@@ -1,3 +1,4 @@
+#include "concurrent_hal.h"
 #include "delay_hal.h"
 
 void hal_delay_us(uint32_t duration)
@@ -8,4 +9,9 @@ void hal_delay_us(uint32_t duration)
 void hal_delay_ms(uint32_t duration)
 {
     HAL_Delay_Milliseconds(duration);
+}
+
+void hal_yield()
+{
+    os_thread_yield();
 }


### PR DESCRIPTION
Spark 2 and 3 have suffered from hangups since recent updates.
The source of these hangups is yet unclear, but seems to be triggered by switching between multiple access points.
We have been unable to reproduce it easily. These fixes might help, but we could not confirm this.

Update:
Some of the functions in the WiFi class from particle are not thread-safe.
This might be a reason for the hangup/deadlock.

I removed the periodic reconnect to wifi and moved it to a particle event hook on disconnect/network_off.
This ensures the reconnect happens on the system thread and possible avoids 2 reconnect functions deadlocking each other.

WiFi reconnects should be automatic according to Particle, but after a WiFi channel switch, the device stays in a breathing blue LED state. With the extra WiFi::connect call in the event handler, the device does reconnect and can even hop between access points.

I also only take the IP/SSID now on first connect, to avoid unnecessary calls into the WiFi stack.

