### PR TITLE
Update device-os to 3.2.0

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3.7"
 services:
     compiler:
-        image: brewblox/firmware-compiler:8
+        image: brewblox/firmware-compiler:10.3
         container_name: firmware-compiler
         init: true
         privileged: true


### PR DESCRIPTION
Updates Particle device-os to 3.2.0 which includes our bugfix for the hardfault bug that caused complete system freeze.