### PR TITLE
More detailed network status

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,8 @@
 {
   "files.associations": {
+    "*.h": "cpp",
+    "*.sass": "sass",
+    "*.svg": "html",
     "**/include/**": "cpp",
     "array": "cpp",
     "*.tcc": "cpp",
@@ -31,7 +34,8 @@
     "cstddef": "cpp",
     "cstring": "cpp",
     "ctime": "cpp",
-    "*.ipp": "cpp"
+    "*.ipp": "cpp",
+    "*.inc": "c"
   },
   "C_Cpp.formatting": "clangFormat",
   "C_Cpp.configurationWarnings": "Disabled",

--- a/lib/blox_hal/inc/blox_hal/hal_network.hpp
+++ b/lib/blox_hal/inc/blox_hal/hal_network.hpp
@@ -4,10 +4,16 @@
 namespace network {
 
 enum class Mode : uint8_t {
-    OFF,
     ETHERNET,
     WIFI,
     WIFI_PROVISIONING,
+};
+
+enum class State : uint8_t {
+    OFF,
+    CONNECTED,
+    NOT_FOUND,
+    NETWORK_ERROR,
 };
 
 Mode mode();
@@ -19,4 +25,5 @@ bool isConnected();
 int8_t wifiStrength();
 void provision();
 void clearProvision();
+State state();
 }

--- a/platform/all/graphics/bar.hpp
+++ b/platform/all/graphics/bar.hpp
@@ -69,16 +69,16 @@ public:
             networkState.push_back(' ');
             switch (network::state()) {
             case network::State::OFF:
-                networkState.append("Network off");
+                networkState.append("wifi disconnected");
                 break;
             case network::State::CONNECTED:
                 networkState.append(formatIp(network::ip4()));
                 break;
             case network::State::NOT_FOUND:
-                networkState.append("WiFi not found");
+                networkState.append("wifi unavailable");
                 break;
             case network::State::NETWORK_ERROR:
-                networkState.append("WiFi error");
+                networkState.append("wifi error");
                 break;
             }
         }

--- a/platform/all/graphics/bar.hpp
+++ b/platform/all/graphics/bar.hpp
@@ -43,37 +43,44 @@ public:
     void updateNetworks()
     {
         std::string networkState = " ";
-        switch (network::mode()) {
-        case network::Mode::ETHERNET:
-            networkState.append(symbols::ethernet);
-            networkState.push_back(' ');
-            networkState.append(formatIp(network::ip4()));
-            break;
-        case network::Mode::WIFI: {
-            auto signal = network::wifiStrength();
-            if (signal < -80) {
-                networkState.append(symbols::wifi_strength1);
-            } else if (signal < -70) {
-                networkState.append(symbols::wifi_strength2);
-            } else if (signal < -67) {
-                networkState.append(symbols::wifi_strength3);
-            } else if (signal < 0) {
-                networkState.append(symbols::wifi_strength4);
-            } else {
-                networkState.append(symbols::wifi_off);
-            }
-            networkState.push_back(' ');
-            networkState.append(formatIp(network::ip4()));
-        } break;
-        case network::Mode::WIFI_PROVISIONING:
+        if (network::mode() == network::Mode::WIFI_PROVISIONING) {
             networkState.append(symbols::wifi_cog);
             networkState.append(symbols::bluetooth);
             networkState.append(" provisioning");
-            break;
-        case network::Mode::OFF:
-            networkState.append(symbols::wifi_off);
-            networkState.append(" no network");
-            break;
+
+        } else {
+            if (network::mode() == network::Mode::ETHERNET) {
+                networkState.append(symbols::ethernet);
+                networkState.push_back(' ');
+            } else {
+                auto signal = network::wifiStrength();
+                if (signal < -80) {
+                    networkState.append(symbols::wifi_strength1);
+                } else if (signal < -70) {
+                    networkState.append(symbols::wifi_strength2);
+                } else if (signal < -67) {
+                    networkState.append(symbols::wifi_strength3);
+                } else if (signal < 0) {
+                    networkState.append(symbols::wifi_strength4);
+                } else {
+                    networkState.append(symbols::wifi_off);
+                }
+            }
+            networkState.push_back(' ');
+            switch (network::state()) {
+            case network::State::OFF:
+                networkState.append("Network off");
+                break;
+            case network::State::CONNECTED:
+                networkState.append(formatIp(network::ip4()));
+                break;
+            case network::State::NOT_FOUND:
+                networkState.append("WiFi not found");
+                break;
+            case network::State::NETWORK_ERROR:
+                networkState.append("WiFi error");
+                break;
+            }
         }
 
         lv_label_set_text(this->networksLabel, networkState.c_str());
@@ -87,9 +94,6 @@ public:
 
     static std::string formatIp(uint32_t ip)
     {
-        if (!ip) {
-            return std::string("not connected");
-        }
         return std::to_string((ip >> (8 * 0)) & 0xff) + "." + std::to_string((ip >> (8 * 1)) & 0xff) + "." + std::to_string((ip >> (8 * 2)) & 0xff) + "." + std::to_string((ip >> (8 * 3)) & 0xff);
     }
 

--- a/platform/esp/blox_hal_esp/inc_private/ethernet.hpp
+++ b/platform/esp/blox_hal_esp/inc_private/ethernet.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include "blox_hal/hal_network.hpp"
 #include <esp_netif.h>
 #include <esp_netif_ip_addr.h>
 
@@ -7,5 +8,5 @@ void start();
 void stop();
 esp_ip4_addr_t ip4();
 esp_netif_t* interface();
-bool isConnected();
+network::State state();
 }

--- a/platform/esp/blox_hal_esp/inc_private/network_events.hpp
+++ b/platform/esp/blox_hal_esp/inc_private/network_events.hpp
@@ -8,5 +8,6 @@ void onWifiConnected();
 void onWifiDisconnected();
 void onWifiGotIp();
 void onWifiLostIp();
+void beforeProvision();
 void onProvisionStarted();
 void onProvisionStopped();

--- a/platform/esp/blox_hal_esp/inc_private/wifi.hpp
+++ b/platform/esp/blox_hal_esp/inc_private/wifi.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "blox_hal/hal_network.hpp"
 #include <esp_netif.h>
 #include <esp_netif_ip_addr.h>
 
@@ -12,7 +13,7 @@ void start_provision();
 void stop();
 esp_ip4_addr_t ip4();
 esp_netif_t* interface();
-bool isConnected();
+network::State state();
 bool hasCredentials();
 
 /**

--- a/platform/esp/blox_hal_esp/src/ethernet.cpp
+++ b/platform/esp/blox_hal_esp/src/ethernet.cpp
@@ -26,6 +26,12 @@ esp_eth_phy_t* phy{nullptr};
 esp_eth_handle_t eth_handle{nullptr};
 esp_eth_netif_glue_handle_t eth_glue{nullptr};
 esp_ip4_addr_t ip_addr{0};
+network::State eth_state = network::State::NOT_FOUND;
+
+network::State state()
+{
+    return eth_state;
+}
 
 void on_got_ip(void* arg, esp_event_base_t event_base, int32_t event_id, void* event_data)
 {
@@ -47,18 +53,21 @@ void on_lost_ip(void* arg, esp_event_base_t base, int32_t event_id, void* event_
 
 void on_disconnected(void* arg, esp_event_base_t base, int32_t event_id, void* event_data)
 {
+    eth_state = network::State::NOT_FOUND;
     onEthernetDisconnected();
     ESP_LOGI(TAG, "Ethernet disconnected");
 }
 
 void on_connected(void* arg, esp_event_base_t base, int32_t event_id, void* event_data)
 {
+    eth_state = network::State::CONNECTED;
     onEthernetConnected();
     ESP_LOGI(TAG, "Ethernet connected");
 }
 
 void start()
 {
+    eth_state = network::State::NOT_FOUND;
     esp_netif_config_t cfg = ESP_NETIF_DEFAULT_ETH();
     eth_netif = esp_netif_new(&cfg);
 
@@ -82,7 +91,7 @@ void start()
     ESP_ERROR_CHECK(esp_event_handler_register(ETH_EVENT, ETHERNET_EVENT_CONNECTED, &on_connected, nullptr));
 
     if (err == ESP_OK) {
-        /* start Ethernet driver state machine */
+        /* start Ethernet driver eth_state machine */
         err = esp_eth_start(eth_handle);
     }
 }
@@ -104,6 +113,7 @@ void stop()
         esp_netif_destroy(eth_netif);
         eth_netif = nullptr;
     }
+    eth_state = network::State::OFF;
 }
 
 esp_netif_t* interface()

--- a/platform/esp/blox_hal_esp/src/ethernet.cpp
+++ b/platform/esp/blox_hal_esp/src/ethernet.cpp
@@ -91,7 +91,7 @@ void start()
     ESP_ERROR_CHECK(esp_event_handler_register(ETH_EVENT, ETHERNET_EVENT_CONNECTED, &on_connected, nullptr));
 
     if (err == ESP_OK) {
-        /* start Ethernet driver eth_state machine */
+        /* start Ethernet driver state machine */
         err = esp_eth_start(eth_handle);
     }
 }

--- a/platform/esp/blox_hal_esp/src/network_esp.cpp
+++ b/platform/esp/blox_hal_esp/src/network_esp.cpp
@@ -49,22 +49,27 @@ Mode mode()
     if (wifi_provision::isActive()) {
         return Mode::WIFI_PROVISIONING;
     }
-    if (ethernet::isConnected()) {
+    if (ethernet::state() == State::CONNECTED) {
         return Mode::ETHERNET;
     }
-    if (wifi::hasCredentials()) {
-        return Mode::WIFI;
-    }
 
-    return (Mode::OFF);
+    return Mode::WIFI;
+}
+
+State state()
+{
+    if (ethernet::state() == State::CONNECTED) {
+        return State::CONNECTED;
+    }
+    return wifi::state();
 }
 
 uint32_t ip4()
 {
-    if (ethernet::isConnected()) {
+    if (ethernet::state() == network::State::CONNECTED) {
         return ethernet::ip4().addr;
     }
-    if (wifi::isConnected()) {
+    if (wifi::state() == network::State::CONNECTED) {
         return wifi::ip4().addr;
     }
     return 0;

--- a/platform/esp/blox_hal_esp/src/network_events.cpp
+++ b/platform/esp/blox_hal_esp/src/network_events.cpp
@@ -6,10 +6,14 @@
 
 void updateLed()
 {
-    if (network::ip4()) {
+    if (network::mode() == network::Mode::WIFI_PROVISIONING) {
+        spark4::set_led(0, 0, 128, spark4::LED_MODE::BLINK, 5);
+    } else if (network::ip4()) {
         spark4::set_led(0, 128, 128, spark4::LED_MODE::BREATHE, 15);
+    } else if (network::mode() == network::Mode::WIFI) {
+        spark4::set_led(0, 128, 0, spark4::LED_MODE::BLINK, 5);
     } else {
-        spark4::set_led(0, 128, 0, spark4::LED_MODE::BLINK, 2);
+        spark4::set_led(0, 128, 0, spark4::LED_MODE::BLINK, 10);
     }
 }
 
@@ -52,11 +56,15 @@ void onWifiLostIp()
     updateLed();
 }
 
-void onProvisionStarted()
+void beforeProvision()
 {
-    spark4::set_led(0, 0, 128, spark4::LED_MODE::BLINK, 5);
     wifi::stop(); // stop wifi as normal access point and disable custom event handlers and enable power saving
     wifi::init(); // ensure wifi is initialized, could be disabled if ethernet is connected
+}
+
+void onProvisionStarted()
+{
+    updateLed();
 }
 
 void onProvisionStopped()
@@ -64,4 +72,5 @@ void onProvisionStopped()
     // restart wifi to re-enable our event handlers and get the ip
     wifi::stop();
     wifi::start();
+    updateLed();
 }

--- a/platform/esp/blox_hal_esp/src/wifi.cpp
+++ b/platform/esp/blox_hal_esp/src/wifi.cpp
@@ -61,7 +61,6 @@ void on_wifi_disconnected(void* arg, esp_event_base_t event_base,
 
 void on_got_ip(void* arg, esp_event_base_t event_base, int32_t event_id, void* event_data)
 {
-    onWifiConnected();
     ip_event_got_ip_t* data = reinterpret_cast<ip_event_got_ip_t*>(event_data);
     memcpy(&ip_addr, &data->ip_info.ip, sizeof(ip_addr));
     ESP_LOGI(TAG, "Got IPv4 event: Interface \"%s\" address: " IPSTR, esp_netif_get_desc(data->esp_netif), IP2STR(&data->ip_info.ip));

--- a/platform/esp/blox_hal_esp/src/wifi.cpp
+++ b/platform/esp/blox_hal_esp/src/wifi.cpp
@@ -21,12 +21,18 @@ namespace wifi {
 constexpr auto TAG = "WIFI";
 esp_netif_t* wifi_netif{nullptr};
 esp_ip4_addr_t ip_addr{0};
-static bool connected = false;
+
+static network::State wifi_state = network::State::OFF;
+
+network::State state()
+{
+    return wifi_state;
+}
 
 void on_wifi_connected(void* arg, esp_event_base_t event_base,
                        int32_t event_id, void* event_data)
 {
-    connected = true;
+    wifi_state = network::State::CONNECTED;
     onWifiConnected();
     ESP_LOGI(TAG, "Wi-Fi connected");
 }
@@ -34,26 +40,39 @@ void on_wifi_connected(void* arg, esp_event_base_t event_base,
 void on_wifi_disconnected(void* arg, esp_event_base_t event_base,
                           int32_t event_id, void* event_data)
 {
-    connected = false;
+    wifi_event_sta_disconnected_t* data = reinterpret_cast<wifi_event_sta_disconnected_t*>(event_data);
+    auto reason = data->reason;
+    switch (reason) {
+    case WIFI_REASON_NO_AP_FOUND:
+        wifi_state = network::State::NOT_FOUND;
+        break;
+    case WIFI_REASON_ASSOC_LEAVE:
+        wifi_state = network::State::OFF;
+        break;
+    default:
+        wifi_state = network::State::NETWORK_ERROR;
+    }
+
     onWifiDisconnected();
-    ESP_LOGI(TAG, "Wi-Fi disconnected");
+
+    ESP_LOGI(TAG, "Wi-Fi disconnected: %d", reason);
     esp_wifi_connect();
 }
 
 void on_got_ip(void* arg, esp_event_base_t event_base, int32_t event_id, void* event_data)
 {
     onWifiConnected();
-    ip_event_got_ip_t* event = reinterpret_cast<ip_event_got_ip_t*>(event_data);
-    memcpy(&ip_addr, &event->ip_info.ip, sizeof(ip_addr));
-    ESP_LOGI(TAG, "Got IPv4 event: Interface \"%s\" address: " IPSTR, esp_netif_get_desc(event->esp_netif), IP2STR(&event->ip_info.ip));
+    ip_event_got_ip_t* data = reinterpret_cast<ip_event_got_ip_t*>(event_data);
+    memcpy(&ip_addr, &data->ip_info.ip, sizeof(ip_addr));
+    ESP_LOGI(TAG, "Got IPv4 event: Interface \"%s\" address: " IPSTR, esp_netif_get_desc(data->esp_netif), IP2STR(&data->ip_info.ip));
     onWifiGotIp();
 }
 
 void on_lost_ip(void* arg, esp_event_base_t base, int32_t event_id, void* event_data)
 {
-    ip_event_got_ip_t* event = reinterpret_cast<ip_event_got_ip_t*>(event_data);
+    ip_event_got_ip_t* data = reinterpret_cast<ip_event_got_ip_t*>(event_data);
     esp_netif_set_ip4_addr(&ip_addr, 0, 0, 0, 0);
-    ESP_LOGI(TAG, "Got IPv4 event: Interface \"%s\" lost ip", esp_netif_get_desc(event->esp_netif));
+    ESP_LOGI(TAG, "Got IPv4 event: Interface \"%s\" lost ip", esp_netif_get_desc(data->esp_netif));
     onWifiLostIp();
 }
 
@@ -81,6 +100,7 @@ void deinit()
 
 void start()
 {
+    wifi_state = network::State::NOT_FOUND;
     init();
     ESP_ERROR_CHECK(esp_event_handler_register(WIFI_EVENT, WIFI_EVENT_STA_CONNECTED, &on_wifi_connected, NULL));
     ESP_ERROR_CHECK(esp_event_handler_register(WIFI_EVENT, WIFI_EVENT_STA_DISCONNECTED, &on_wifi_disconnected, NULL));
@@ -99,12 +119,13 @@ void stop()
     ESP_ERROR_CHECK(esp_event_handler_unregister(IP_EVENT, IP_EVENT_STA_LOST_IP, &on_lost_ip));
     esp_wifi_stop();
     esp_wifi_set_ps(WIFI_PS_MIN_MODEM);
+    wifi_state = network::State::OFF;
 }
 
 int8_t rssi()
 {
     wifi_ap_record_t wifidata;
-    if (connected && esp_wifi_sta_get_ap_info(&wifidata) == 0) {
+    if (wifi_state == network::State::CONNECTED && esp_wifi_sta_get_ap_info(&wifidata) == 0) {
         return wifidata.rssi;
     }
     return 0;

--- a/platform/esp/blox_hal_esp/src/wifi_provision.cpp
+++ b/platform/esp/blox_hal_esp/src/wifi_provision.cpp
@@ -94,7 +94,7 @@ void start()
         .app_event_handler = WIFI_PROV_EVENT_HANDLER_NONE};
 
     isRunning = true;
-    onProvisionStarted();
+    beforeProvision();
 
     if (!instance_wifi_prov_event) {
         /* Register our event handler for provisioning related events */
@@ -202,6 +202,7 @@ void clear()
 {
     // wipe credentials
     wifi_prov_mgr_reset_provisioning();
+    stop();
 }
 
 bool isActive()


### PR DESCRIPTION
Changes to give better status on network:
LED blinks green when there is no network
LED breathes teal when network is connected
LED blinks blue during provisioning

Display shows IP address on successful network connection.
Display shows "Network off" when there are no wifi credentials and no ethernet.
Display shows "Wifi not found" when the SSID is not seen.
Display shows "Wifi error" on other WiFi errors, including authentication failure.