### PR TITLE
Replace CboxPtr lock functors with virtual base class

### DIFF
--- a/lib/blocks/inc/blocks/ActuatorOffsetBlock.hpp
+++ b/lib/blocks/inc/blocks/ActuatorOffsetBlock.hpp
@@ -14,7 +14,7 @@ private:
 
 public:
     ActuatorOffsetBlock()
-        : offset(target.lockFunctor(), reference.lockFunctor())
+        : offset(target, reference)
         , constrained(offset)
     {
     }

--- a/lib/blocks/inc/blocks/ActuatorPwmBlock.hpp
+++ b/lib/blocks/inc/blocks/ActuatorPwmBlock.hpp
@@ -17,7 +17,7 @@ private:
 
 public:
     ActuatorPwmBlock()
-        : pwm(actuator.lockFunctor())
+        : pwm(actuator)
         , constrained(pwm)
     {
     }

--- a/lib/blocks/inc/blocks/ActuatorPwmBlock.hpp
+++ b/lib/blocks/inc/blocks/ActuatorPwmBlock.hpp
@@ -29,7 +29,7 @@ public:
     cbox::update_t updateHandler(const cbox::update_t& now) override;
     void* implements(cbox::obj_type_t iface) override;
 
-    const cbox::CboxPtr<ActuatorDigitalConstrained>& targetLookup() const
+    const auto& targetLookup() const
     {
         return actuator;
     }

--- a/lib/blocks/inc/blocks/DS2408Block.hpp
+++ b/lib/blocks/inc/blocks/DS2408Block.hpp
@@ -34,19 +34,19 @@ private:
 public:
     DS2408Block()
         : OneWireDeviceBlock()
-        , device(owBus.lockFunctor())
+        , device(owBus)
     {
     }
 
     DS2408Block(cbox::obj_id_t busId)
         : OneWireDeviceBlock(busId)
-        , device(owBus.lockFunctor())
+        , device(owBus)
     {
     }
 
     DS2408Block(cbox::obj_id_t busId, const OneWireAddress& addr)
         : OneWireDeviceBlock(busId)
-        , device(owBus.lockFunctor(), addr)
+        , device(owBus, addr)
     {
     }
 

--- a/lib/blocks/inc/blocks/DS2413Block.hpp
+++ b/lib/blocks/inc/blocks/DS2413Block.hpp
@@ -32,19 +32,19 @@ private:
 public:
     DS2413Block()
         : OneWireDeviceBlock()
-        , device(owBus.lockFunctor())
+        , device(owBus)
     {
     }
 
     DS2413Block(cbox::obj_id_t busId)
         : OneWireDeviceBlock(busId)
-        , device(owBus.lockFunctor())
+        , device(owBus)
     {
     }
 
     DS2413Block(cbox::obj_id_t busId, const OneWireAddress& addr)
         : OneWireDeviceBlock(busId)
-        , device(owBus.lockFunctor(), addr)
+        , device(owBus, addr)
     {
     }
 

--- a/lib/blocks/inc/blocks/DigitalActuatorBlock.hpp
+++ b/lib/blocks/inc/blocks/DigitalActuatorBlock.hpp
@@ -15,7 +15,7 @@ private:
 public:
     DigitalActuatorBlock()
         : hwDevice()
-        , actuator(hwDevice.lockFunctor(), 0)
+        , actuator(hwDevice, 0)
         , constrained(actuator)
     {
     }

--- a/lib/blocks/inc/blocks/MotorValveBlock.hpp
+++ b/lib/blocks/inc/blocks/MotorValveBlock.hpp
@@ -34,7 +34,7 @@ private:
 
 public:
     MotorValveBlock()
-        : valve(hwDevice.lockFunctor(), 0)
+        : valve(hwDevice, 0)
         , constrained(valve)
     {
     }

--- a/lib/blocks/inc/blocks/PidBlock.hpp
+++ b/lib/blocks/inc/blocks/PidBlock.hpp
@@ -21,15 +21,14 @@
 
 #include "blocks/Block.hpp"
 #include "cbox/CboxPtr.hpp"
-#include "control/ActuatorAnalogConstrained.hpp"
+#include "control/ActuatorAnalog.hpp"
 #include "control/IntervalHelper.hpp"
 #include "control/Pid.hpp"
 
 class PidBlock final : public Block<brewblox_BlockType_Pid> {
 private:
     cbox::CboxPtr<SetpointSensorPair> input;
-    cbox::CboxPtr<ActuatorAnalogConstrained> output;
-    ControlPtrAdapter<ActuatorAnalogConstrained, ProcessValue<Pid::out_t>> pvOutput; // mirrors output
+    cbox::CboxPtr<ActuatorAnalog> output;
 
     Pid pid;
     IntervalHelper<1000> m_intervalHelper;

--- a/lib/blocks/inc/blocks/PidBlock.hpp
+++ b/lib/blocks/inc/blocks/PidBlock.hpp
@@ -28,7 +28,7 @@
 class PidBlock final : public Block<brewblox_BlockType_Pid> {
 private:
     cbox::CboxPtr<SetpointSensorPair> input;
-    cbox::CboxPtr<ActuatorAnalog> output;
+    cbox::CboxPtr<ProcessValue<Pid::out_t>> output;
 
     Pid pid;
     IntervalHelper<1000> m_intervalHelper;

--- a/lib/blocks/inc/blocks/PidBlock.hpp
+++ b/lib/blocks/inc/blocks/PidBlock.hpp
@@ -29,6 +29,7 @@ class PidBlock final : public Block<brewblox_BlockType_Pid> {
 private:
     cbox::CboxPtr<SetpointSensorPair> input;
     cbox::CboxPtr<ActuatorAnalogConstrained> output;
+    ControlPtrAdapter<ActuatorAnalogConstrained, ProcessValue<Pid::out_t>> pvOutput; // mirrors output
 
     Pid pid;
     IntervalHelper<1000> m_intervalHelper;

--- a/lib/blocks/inc/blocks/SetpointProfileBlock.hpp
+++ b/lib/blocks/inc/blocks/SetpointProfileBlock.hpp
@@ -35,7 +35,7 @@ private:
 public:
     SetpointProfileBlock()
         : ticksPtr(3)
-        , profile(target.lockFunctor())
+        , profile(target)
     {
     }
     ~SetpointProfileBlock() = default;

--- a/lib/blocks/inc/blocks/SetpointProfileBlock.hpp
+++ b/lib/blocks/inc/blocks/SetpointProfileBlock.hpp
@@ -19,7 +19,6 @@
 
 #pragma once
 
-#include "AppTicks.hpp"
 #include "blocks/Block.hpp"
 #include "blocks/TicksBlock.hpp"
 #include "cbox/CboxPtr.hpp"
@@ -28,14 +27,12 @@
 
 class SetpointProfileBlock final : public Block<brewblox_BlockType_SetpointProfile> {
 private:
-    cbox::CboxPtr<TicksBlock<TicksClass>> ticksPtr;
     cbox::CboxPtr<SetpointSensorPair> target;
     SetpointProfile profile;
 
 public:
     SetpointProfileBlock()
-        : ticksPtr(3)
-        , profile(target)
+        : profile(target)
     {
     }
     ~SetpointProfileBlock() = default;

--- a/lib/blocks/inc/blocks/SetpointSensorPairBlock.hpp
+++ b/lib/blocks/inc/blocks/SetpointSensorPairBlock.hpp
@@ -30,7 +30,7 @@ private:
 
 public:
     SetpointSensorPairBlock()
-        : pair(sensor.lockFunctor())
+        : pair(sensor)
     {
     }
     ~SetpointSensorPairBlock() = default;

--- a/lib/blocks/src/ActuatorLogicBlock.cpp
+++ b/lib/blocks/src/ActuatorLogicBlock.cpp
@@ -3,7 +3,7 @@
 blox_ActuatorLogic_Result
 DigitalCompare::eval() const
 {
-    if (auto actPtr = m_lookup.const_lock()) {
+    if (auto actPtr = m_lookup.lock()) {
         switch (m_op) {
         case blox_ActuatorLogic_DigitalOperator_OP_VALUE_IS:
             return blox_ActuatorLogic_Result(actPtr->state() == m_rhs);
@@ -32,7 +32,7 @@ void DigitalCompare::write(blox_ActuatorLogic_DigitalCompare& dest, bool include
 blox_ActuatorLogic_Result
 AnalogCompare::eval() const
 {
-    if (auto pvPtr = m_lookup.const_lock()) {
+    if (auto pvPtr = m_lookup.lock()) {
         switch (m_op) {
         case blox_ActuatorLogic_AnalogOperator_OP_VALUE_LE:
             if (!pvPtr->valueValid()) {

--- a/lib/blocks/src/ConstraintsProto.cpp
+++ b/lib/blocks/src/ConstraintsProto.cpp
@@ -21,7 +21,7 @@ private:
 
 public:
     CboxBalanced(const cbox::obj_id_t& objId)
-        : lookup(cbox::CboxPtr<Balancer_t>(objId))
+        : lookup(objId)
         , m_balanced(lookup)
     {
     }
@@ -128,7 +128,7 @@ private:
 
 public:
     CboxMutex(const cbox::obj_id_t& objId, duration_millis_t extraHoldTime, bool customHoldTime)
-        : lookup(cbox::CboxPtr<MutexTarget>(objId))
+        : lookup(objId)
         , m_mutexConstraint(lookup, extraHoldTime, customHoldTime)
     {
     }

--- a/lib/blocks/src/ConstraintsProto.cpp
+++ b/lib/blocks/src/ConstraintsProto.cpp
@@ -22,7 +22,7 @@ private:
 public:
     CboxBalanced(const cbox::obj_id_t& objId)
         : lookup(cbox::CboxPtr<Balancer_t>(objId))
-        , m_balanced(lookup.lockFunctor())
+        , m_balanced(lookup)
     {
     }
 
@@ -129,7 +129,7 @@ private:
 public:
     CboxMutex(const cbox::obj_id_t& objId, duration_millis_t extraHoldTime, bool customHoldTime)
         : lookup(cbox::CboxPtr<MutexTarget>(objId))
-        , m_mutexConstraint(lookup.lockFunctor(), extraHoldTime, customHoldTime)
+        , m_mutexConstraint(lookup, extraHoldTime, customHoldTime)
     {
     }
 

--- a/lib/blocks/src/PidBlock.cpp
+++ b/lib/blocks/src/PidBlock.cpp
@@ -31,10 +31,8 @@ struct __attribute__((packed)) PidCacheLayout {
 static constexpr uint16_t cacheInterval{5000};
 
 PidBlock::PidBlock()
-    : pid(input.lockFunctor(), [this]() {
-        // convert ActuatorConstrained to base ProcessValue
-        return std::shared_ptr<ProcessValue<Pid::out_t>>(this->output.lock());
-    })
+    : pvOutput(output)
+    , pid(input, pvOutput)
 {
 }
 
@@ -46,7 +44,7 @@ cbox::CboxError PidBlock::read(const cbox::PayloadCallback& callback) const
     message.inputId = input.getId();
     message.outputId = output.getId();
 
-    if (auto ptr = input.const_lock()) {
+    if (auto ptr = input.lock()) {
         if (ptr->valueValid()) {
             message.inputValue = cnl::unwrap(ptr->value());
         } else {
@@ -62,7 +60,7 @@ cbox::CboxError PidBlock::read(const cbox::PayloadCallback& callback) const
         stripped.add(blox_Pid_Block_inputValue_tag);
     }
 
-    if (auto ptr = output.const_lock()) {
+    if (auto ptr = output.lock()) {
         if (ptr->valueValid()) {
             message.outputValue = cnl::unwrap(ptr->value());
         } else {

--- a/lib/blocks/src/PidBlock.cpp
+++ b/lib/blocks/src/PidBlock.cpp
@@ -31,8 +31,7 @@ struct __attribute__((packed)) PidCacheLayout {
 static constexpr uint16_t cacheInterval{5000};
 
 PidBlock::PidBlock()
-    : pvOutput(output)
-    , pid(input, pvOutput)
+    : pid(input, output)
 {
 }
 

--- a/lib/blocks/src/SetpointProfileBlock.cpp
+++ b/lib/blocks/src/SetpointProfileBlock.cpp
@@ -115,7 +115,7 @@ SetpointProfileBlock::write(const cbox::Payload& payload)
 cbox::update_t
 SetpointProfileBlock::updateHandler(const cbox::update_t& now)
 {
-    if (auto pTicks = ticksPtr.const_lock()) {
+    if (auto pTicks = ticksPtr.lock()) {
         auto time = pTicks->const_get().utc();
         profile.update(time);
     }

--- a/lib/blocks/src/SetpointProfileBlock.cpp
+++ b/lib/blocks/src/SetpointProfileBlock.cpp
@@ -18,6 +18,7 @@
  */
 
 #include "blocks/SetpointProfileBlock.hpp"
+#include "AppTicks.hpp"
 #include "blocks/FieldTags.hpp"
 #include "pb_decode.h"
 #include "pb_encode.h"
@@ -115,10 +116,8 @@ SetpointProfileBlock::write(const cbox::Payload& payload)
 cbox::update_t
 SetpointProfileBlock::updateHandler(const cbox::update_t& now)
 {
-    if (auto pTicks = ticksPtr.lock()) {
-        auto time = pTicks->const_get().utc();
-        profile.update(time);
-    }
+    auto time = ticks.utc();
+    profile.update(time);
     return next_update_1s(now);
 }
 

--- a/lib/blocks/src/TempSensorCombiBlock.cpp
+++ b/lib/blocks/src/TempSensorCombiBlock.cpp
@@ -84,7 +84,7 @@ TempSensorCombiBlock::write(const cbox::Payload& payload)
         inputs.reserve(message.sensors_count);
         for (uint8_t i = 0; i < message.sensors_count && i < 8; i++) {
             auto& input = inputs.emplace_back(message.sensors[i]);
-            sensor.inputs.push_back(std::ref(input));
+            sensor.inputs.emplace_back(input);
         }
     }
 

--- a/lib/blocks/src/TempSensorCombiBlock.cpp
+++ b/lib/blocks/src/TempSensorCombiBlock.cpp
@@ -24,7 +24,7 @@ void TempSensorCombiBlock::writeMessage(blox_TempSensorCombi_Block& message, boo
 {
     FieldTags stripped;
 
-    message.sensors_count = sensor.inputs.size();
+    message.sensors_count = inputs.size();
     message.combineFunc = blox_TempSensorCombi_SensorCombiFunc(sensor.func);
     for (uint8_t i = 0; i < message.sensors_count && i < 8; i++) {
         message.sensors[i] = inputs[i].getId();
@@ -79,14 +79,12 @@ TempSensorCombiBlock::write(const cbox::Payload& payload)
     if (res == cbox::CboxError::OK) {
         sensor.func = TempSensorCombi::CombineFunc(message.combineFunc);
         inputs.clear();
-        sensor.inputs.clear();
         inputs.reserve(message.sensors_count);
+        sensor.inputs.clear();
         sensor.inputs.reserve(message.sensors_count);
         for (uint8_t i = 0; i < message.sensors_count && i < 8; i++) {
-            inputs.emplace_back(message.sensors[i]);
-        }
-        for (auto& i : inputs) {
-            sensor.inputs.push_back(i.lockFunctor());
+            auto input = inputs.emplace_back(message.sensors[i]);
+            sensor.inputs.push_back(&input);
         }
     }
 

--- a/lib/blocks/src/TempSensorCombiBlock.cpp
+++ b/lib/blocks/src/TempSensorCombiBlock.cpp
@@ -78,13 +78,13 @@ TempSensorCombiBlock::write(const cbox::Payload& payload)
 
     if (res == cbox::CboxError::OK) {
         sensor.func = TempSensorCombi::CombineFunc(message.combineFunc);
-        inputs.clear();
-        inputs.reserve(message.sensors_count);
         sensor.inputs.clear();
         sensor.inputs.reserve(message.sensors_count);
+        inputs.clear();
+        inputs.reserve(message.sensors_count);
         for (uint8_t i = 0; i < message.sensors_count && i < 8; i++) {
             auto& input = inputs.emplace_back(message.sensors[i]);
-            sensor.inputs.push_back(&input);
+            sensor.inputs.push_back(std::ref(input));
         }
     }
 

--- a/lib/blocks/src/TempSensorCombiBlock.cpp
+++ b/lib/blocks/src/TempSensorCombiBlock.cpp
@@ -83,7 +83,7 @@ TempSensorCombiBlock::write(const cbox::Payload& payload)
         sensor.inputs.clear();
         sensor.inputs.reserve(message.sensors_count);
         for (uint8_t i = 0; i < message.sensors_count && i < 8; i++) {
-            auto input = inputs.emplace_back(message.sensors[i]);
+            auto& input = inputs.emplace_back(message.sensors[i]);
             sensor.inputs.push_back(&input);
         }
     }

--- a/lib/blocks/src/TempSensorOneWireBlock.cpp
+++ b/lib/blocks/src/TempSensorOneWireBlock.cpp
@@ -23,19 +23,19 @@
 
 TempSensorOneWireBlock::TempSensorOneWireBlock()
     : OneWireDeviceBlock()
-    , sensor(owBus.lockFunctor())
+    , sensor(owBus)
 {
 }
 
 TempSensorOneWireBlock::TempSensorOneWireBlock(cbox::obj_id_t busId)
     : OneWireDeviceBlock(busId)
-    , sensor(owBus.lockFunctor())
+    , sensor(owBus)
 {
 }
 
 TempSensorOneWireBlock::TempSensorOneWireBlock(cbox::obj_id_t busId, const OneWireAddress& addr)
     : OneWireDeviceBlock(busId)
-    , sensor(owBus.lockFunctor(), addr)
+    , sensor(owBus, addr)
 {
 }
 

--- a/lib/cbox/inc/cbox/CboxPtr.hpp
+++ b/lib/cbox/inc/cbox/CboxPtr.hpp
@@ -44,7 +44,6 @@ protected:
     {
     }
 
-    // Class can't be used directly due to the protected constructor
     // The destructor does not have to be virtual
     ~CboxPtrBase() = default;
 

--- a/lib/cbox/inc/cbox/CboxPtr.hpp
+++ b/lib/cbox/inc/cbox/CboxPtr.hpp
@@ -22,6 +22,7 @@
 #include "cbox/Application.hpp"
 #include "cbox/ObjectBase.hpp"
 #include "cbox/ObjectContainer.hpp"
+#include "control/ControlPtr.hpp"
 #include <memory>
 
 namespace cbox {
@@ -42,13 +43,13 @@ protected:
         : id(id)
     {
     }
-    ~CboxPtrBase() = default;
+    virtual ~CboxPtrBase() = default;
 
     std::shared_ptr<Object> lockObject();
 };
 
 template <typename T>
-class CboxPtr : public CboxPtrBase {
+class CboxPtr final : public CboxPtrBase, public ControlPtr<T> {
 
 public:
     explicit CboxPtr(const obj_id_t& id = 0)
@@ -56,11 +57,6 @@ public:
     {
     }
     ~CboxPtr() = default;
-
-    std::shared_ptr<T> lock()
-    {
-        return lock_as<T>();
-    }
 
     template <class U>
     std::shared_ptr<U> lock_as()
@@ -86,19 +82,14 @@ public:
         return std::const_pointer_cast<const U>(std::move(sptr));
     }
 
-    std::shared_ptr<const T> const_lock() const
+    std::shared_ptr<T> lock() override
+    {
+        return lock_as<T>();
+    }
+
+    std::shared_ptr<const T> lock() const override
     {
         return const_lock_as<T>();
-    }
-
-    std::function<std::shared_ptr<T>()> lockFunctor()
-    {
-        return [this]() { return this->lock(); };
-    }
-
-    std::function<std::shared_ptr<const T>()> lockFunctor() const
-    {
-        return [this]() { return this->const_lock(); };
     }
 };
 

--- a/lib/cbox/inc/cbox/CboxPtr.hpp
+++ b/lib/cbox/inc/cbox/CboxPtr.hpp
@@ -43,7 +43,10 @@ protected:
         : id(id)
     {
     }
-    virtual ~CboxPtrBase() = default;
+
+    // Class can't be used directly due to the protected constructor
+    // The destructor does not have to be virtual
+    ~CboxPtrBase() = default;
 
     std::shared_ptr<Object> lockObject();
 };

--- a/lib/control/inc/control/ActuatorDigital.hpp
+++ b/lib/control/inc/control/ActuatorDigital.hpp
@@ -21,6 +21,7 @@
 #pragma once
 
 #include "control/ActuatorDigitalBase.hpp"
+#include "control/ControlPtr.hpp"
 #include "control/IoArray.hpp"
 #include <cstdint>
 #include <functional>
@@ -32,13 +33,13 @@
  */
 class ActuatorDigital : public ActuatorDigitalBase {
 private:
-    const std::function<std::shared_ptr<IoArray>()> m_target;
+    ControlPtr<IoArray>& m_target;
     bool m_invert = false;
     uint8_t m_channel = 0;
     uint8_t m_desiredChannel = 0;
 
 public:
-    explicit ActuatorDigital(std::function<std::shared_ptr<IoArray>()>&& target, uint8_t chan)
+    explicit ActuatorDigital(ControlPtr<IoArray>& target, uint8_t chan)
         : m_target(target)
     {
         channel(chan);

--- a/lib/control/inc/control/ActuatorDigitalConstrained.hpp
+++ b/lib/control/inc/control/ActuatorDigitalConstrained.hpp
@@ -20,6 +20,7 @@
 #pragma once
 
 #include "control/ActuatorDigitalChangeLogged.hpp"
+#include "control/ControlPtr.hpp"
 #include "control/TicksTypes.hpp"
 #include <functional>
 #include <memory>
@@ -354,7 +355,7 @@ public:
 template <uint8_t ID>
 class Mutex : public Base {
 private:
-    const std::function<std::shared_ptr<MutexTarget>()> m_mutexTarget;
+    ControlPtr<MutexTarget>& m_mutexTarget;
     duration_millis_t m_holdAfterTurnOff;
     bool m_useCustomHoldDuration;
     // keep shared pointer to mutex, so it cannot be destroyed while locked
@@ -363,7 +364,7 @@ private:
 
 public:
     explicit Mutex(
-        std::function<std::shared_ptr<MutexTarget>()>&& mut, duration_millis_t hold, bool useCustomHold)
+        ControlPtr<MutexTarget>& mut, duration_millis_t hold, bool useCustomHold)
         : m_mutexTarget(mut)
         , m_holdAfterTurnOff(hold)
         , m_useCustomHoldDuration(useCustomHold)
@@ -401,7 +402,7 @@ public:
             return 0;
         }
         if (newState == State::Active) {
-            m_lockedMutex = m_mutexTarget(); // store shared pointer to target so it can't be deleted while locked
+            m_lockedMutex = m_mutexTarget.lock(); // store shared pointer to target so it can't be deleted while locked
             if (m_lockedMutex) {
                 m_lock = std::unique_lock<std::mutex>(m_lockedMutex->mut, std::try_to_lock);
                 if (m_lock) {

--- a/lib/control/inc/control/ActuatorOffset.hpp
+++ b/lib/control/inc/control/ActuatorOffset.hpp
@@ -20,6 +20,7 @@
 #pragma once
 
 #include "control/ActuatorAnalog.hpp"
+#include "control/ControlPtr.hpp"
 #include "control/SetpointSensorPair.hpp"
 #include <functional>
 #include <memory>
@@ -35,8 +36,8 @@ public:
     };
 
 private:
-    const std::function<std::shared_ptr<SetpointSensorPair>()> m_target;
-    const std::function<std::shared_ptr<SetpointSensorPair>()> m_reference;
+    ControlPtr<SetpointSensorPair>& m_target;
+    ControlPtr<SetpointSensorPair>& m_reference;
     value_t m_setting = 0;
     value_t m_value = 0;
     bool m_settingValid = false;
@@ -48,8 +49,8 @@ private:
 
 public:
     explicit ActuatorOffset(
-        std::function<std::shared_ptr<SetpointSensorPair>()>&& target,    // process value to manipulate
-        std::function<std::shared_ptr<SetpointSensorPair>()>&& reference) // process value to offset from
+        ControlPtr<SetpointSensorPair>& target,    // process value to manipulate
+        ControlPtr<SetpointSensorPair>& reference) // process value to offset from
         : m_target(target)
         , m_reference(reference)
     {
@@ -92,7 +93,7 @@ public:
     {
         if (m_enabled) {
 
-            if (auto targetPtr = m_target()) {
+            if (auto targetPtr = m_target.lock()) {
                 targetPtr->settingValid(v);
             }
         }
@@ -115,8 +116,8 @@ public:
         bool newTargetSettingValid = false;
         auto newTargetSetting = value_t(0);
 
-        if (auto targetPtr = m_target()) {
-            if (auto refPtr = m_reference()) {
+        if (auto targetPtr = m_target.lock()) {
+            if (auto refPtr = m_reference.lock()) {
                 if (m_selectedReference == ReferenceKind::SETTING) {
                     if (refPtr->settingValid()) {
                         newTargetSetting = refPtr->setting() + m_setting;

--- a/lib/control/inc/control/ActuatorPwm.hpp
+++ b/lib/control/inc/control/ActuatorPwm.hpp
@@ -43,7 +43,7 @@ public:
     using update_t = ticks_millis_t;
 
 private:
-    const std::function<std::shared_ptr<ActuatorDigitalConstrained>()> m_target;
+    ControlPtr<ActuatorDigitalConstrained>& m_target;
     duration_millis_t m_period;
     duration_millis_t m_dutyTime = 0;
     value_t m_dutySetting = 0;
@@ -74,7 +74,7 @@ public:
      *  @sa getPeriod(), setPeriod(), getTarget(), setTarget()
      */
     explicit ActuatorPwm(
-        std::function<std::shared_ptr<ActuatorDigitalConstrained>()>&& target,
+        ControlPtr<ActuatorDigitalConstrained>& target,
         duration_millis_t period = 4000);
 
     ActuatorPwm(const ActuatorPwm&) = delete;

--- a/lib/control/inc/control/ControlPtr.hpp
+++ b/lib/control/inc/control/ControlPtr.hpp
@@ -8,26 +8,3 @@ public:
     virtual std::shared_ptr<T> lock() = 0;
     virtual std::shared_ptr<const T> lock() const = 0;
 };
-
-template <typename SrcT, typename T>
-class ControlPtrAdapter final : public ControlPtr<T> {
-private:
-    ControlPtr<SrcT>& src;
-
-public:
-    ControlPtrAdapter(ControlPtr<SrcT>& src_)
-        : src(src_)
-    {
-    }
-    ~ControlPtrAdapter() = default;
-
-    std::shared_ptr<T> lock()
-    {
-        return src.lock();
-    }
-
-    std::shared_ptr<const T> lock() const
-    {
-        return src.lock();
-    }
-};

--- a/lib/control/inc/control/ControlPtr.hpp
+++ b/lib/control/inc/control/ControlPtr.hpp
@@ -1,0 +1,33 @@
+#pragma once
+
+#include <memory>
+
+template <typename T>
+class ControlPtr {
+public:
+    virtual std::shared_ptr<T> lock() = 0;
+    virtual std::shared_ptr<const T> lock() const = 0;
+};
+
+template <typename SrcT, typename T>
+class ControlPtrAdapter final : public ControlPtr<T> {
+private:
+    ControlPtr<SrcT>& src;
+
+public:
+    ControlPtrAdapter(ControlPtr<SrcT>& src_)
+        : src(src_)
+    {
+    }
+    ~ControlPtrAdapter() = default;
+
+    std::shared_ptr<T> lock()
+    {
+        return src.lock();
+    }
+
+    std::shared_ptr<const T> lock() const
+    {
+        return src.lock();
+    }
+};

--- a/lib/control/inc/control/ControlPtr.hpp
+++ b/lib/control/inc/control/ControlPtr.hpp
@@ -7,4 +7,7 @@ class ControlPtr {
 public:
     virtual std::shared_ptr<T> lock() = 0;
     virtual std::shared_ptr<const T> lock() const = 0;
+
+protected:
+    ~ControlPtr() = default;
 };

--- a/lib/control/inc/control/DS18B20.hpp
+++ b/lib/control/inc/control/DS18B20.hpp
@@ -67,8 +67,8 @@ public:
      *    on the bus is used.
      * /param calibration	A temperature value that is added to all readings. This can be used to calibrate the sensor.
      */
-    DS18B20(std::function<std::shared_ptr<OneWire>()>&& getBus, OneWireAddress _address = 0, const temp_t& _calibrationOffset = 0)
-        : OneWireDevice(std::move(getBus), _address)
+    DS18B20(ControlPtr<OneWire>& busPtr, OneWireAddress _address = 0, const temp_t& _calibrationOffset = 0)
+        : OneWireDevice(busPtr, _address)
         , m_calibrationOffset(_calibrationOffset)
     {
     }

--- a/lib/control/inc/control/DS2408.hpp
+++ b/lib/control/inc/control/DS2408.hpp
@@ -50,8 +50,8 @@ public:
      * Constructor initializes both caches to 0xFF.
      * This means the output latches are disabled and all pins are sensed high
      */
-    DS2408(std::function<std::shared_ptr<OneWire>()>&& getBus, OneWireAddress address = familyCode)
-        : OneWireDevice(std::move(getBus), address)
+    DS2408(ControlPtr<OneWire>& busPtr, OneWireAddress address = familyCode)
+        : OneWireDevice(busPtr, address)
         , IoArray(8)
     {
     }

--- a/lib/control/inc/control/DS2413.hpp
+++ b/lib/control/inc/control/DS2413.hpp
@@ -42,8 +42,8 @@ private:
     static constexpr uint8_t ACK_ERROR = 0xFF;
 
 public:
-    DS2413(std::function<std::shared_ptr<OneWire>()>&& getBus, OneWireAddress address = familyCode)
-        : OneWireDevice(std::move(getBus), address)
+    DS2413(ControlPtr<OneWire>& busPtr, OneWireAddress address = familyCode)
+        : OneWireDevice(busPtr, address)
         , IoArray(2)
     {
     }

--- a/lib/control/inc/control/MotorValve.hpp
+++ b/lib/control/inc/control/MotorValve.hpp
@@ -47,7 +47,7 @@ public:
     static const uint8_t chanClosingHigh = 3;
 
 private:
-    const std::function<std::shared_ptr<DS2408>()> m_target;
+    ControlPtr<DS2408>& m_target;
     uint8_t m_startChannel = 0;
     uint8_t m_desiredChannel = 0;
 
@@ -55,7 +55,7 @@ private:
     ValveState m_actualValveState = ValveState::InitIdle;
 
 public:
-    explicit MotorValve(std::function<std::shared_ptr<DS2408>()>&& target, uint8_t startChan)
+    explicit MotorValve(ControlPtr<DS2408>& target, uint8_t startChan)
         : m_target(target)
     {
         startChannel(startChan);

--- a/lib/control/inc/control/OneWireDevice.hpp
+++ b/lib/control/inc/control/OneWireDevice.hpp
@@ -19,6 +19,7 @@
 
 #pragma once
 
+#include "control/ControlPtr.hpp"
 #include "control/OneWire.hpp"
 #include "control/OneWireAddress.hpp"
 #include <functional>
@@ -26,7 +27,7 @@
 
 class OneWireDevice {
 public:
-    OneWireDevice(std::function<std::shared_ptr<OneWire>()>&& getBus_, const OneWireAddress& address_);
+    OneWireDevice(ControlPtr<OneWire>& busPtr_, const OneWireAddress& address_);
 
 protected:
     ~OneWireDevice() = default;
@@ -52,7 +53,7 @@ public:
     std::shared_ptr<OneWire> selectRom() const;
 
 protected:
-    std::function<std::shared_ptr<OneWire>()> getBus;
+    ControlPtr<OneWire>& m_bus;
     OneWireAddress m_address;
 
 private:

--- a/lib/control/inc/control/Pid.hpp
+++ b/lib/control/inc/control/Pid.hpp
@@ -19,6 +19,7 @@
 
 #pragma once
 
+#include "control/ActuatorAnalogConstrained.hpp"
 #include "control/ControlPtr.hpp"
 #include "control/ProcessValue.hpp"
 #include "control/SetpointSensorPair.hpp"
@@ -34,7 +35,7 @@ public:
 
 private:
     ControlPtr<SetpointSensorPair>& m_inputPtr;
-    ControlPtr<ProcessValue<out_t>>& m_outputPtr;
+    ControlPtr<ActuatorAnalog>& m_outputPtr;
 
     // state
     in_t m_error = in_t{0};
@@ -61,7 +62,7 @@ private:
 public:
     explicit Pid(
         ControlPtr<SetpointSensorPair>& input,
-        ControlPtr<ProcessValue<out_t>>& output)
+        ControlPtr<ActuatorAnalog>& output)
         : m_inputPtr(input)
         , m_outputPtr(output)
     {

--- a/lib/control/inc/control/Pid.hpp
+++ b/lib/control/inc/control/Pid.hpp
@@ -35,7 +35,7 @@ public:
 
 private:
     ControlPtr<SetpointSensorPair>& m_inputPtr;
-    ControlPtr<ActuatorAnalog>& m_outputPtr;
+    ControlPtr<ProcessValue<Pid::out_t>>& m_outputPtr;
 
     // state
     in_t m_error = in_t{0};
@@ -62,7 +62,7 @@ private:
 public:
     explicit Pid(
         ControlPtr<SetpointSensorPair>& input,
-        ControlPtr<ActuatorAnalog>& output)
+        ControlPtr<ProcessValue<Pid::out_t>>& output)
         : m_inputPtr(input)
         , m_outputPtr(output)
     {

--- a/lib/control/inc/control/Pid.hpp
+++ b/lib/control/inc/control/Pid.hpp
@@ -19,6 +19,7 @@
 
 #pragma once
 
+#include "control/ControlPtr.hpp"
 #include "control/ProcessValue.hpp"
 #include "control/SetpointSensorPair.hpp"
 #include <cstring>
@@ -32,8 +33,8 @@ public:
     using derivative_t = SetpointSensorPair::derivative_t;
 
 private:
-    const std::function<std::shared_ptr<SetpointSensorPair>()> m_inputPtr;
-    const std::function<std::shared_ptr<ProcessValue<out_t>>()> m_outputPtr;
+    ControlPtr<SetpointSensorPair>& m_inputPtr;
+    ControlPtr<ProcessValue<out_t>>& m_outputPtr;
 
     // state
     in_t m_error = in_t{0};
@@ -59,8 +60,8 @@ private:
 
 public:
     explicit Pid(
-        std::function<std::shared_ptr<SetpointSensorPair>()>&& input,
-        std::function<std::shared_ptr<ProcessValue<out_t>>()>&& output)
+        ControlPtr<SetpointSensorPair>& input,
+        ControlPtr<ProcessValue<out_t>>& output)
         : m_inputPtr(input)
         , m_outputPtr(output)
     {
@@ -181,7 +182,7 @@ private:
     void active(bool state)
     {
         if (m_enabled && m_active && !state) {
-            if (auto ptr = m_outputPtr()) {
+            if (auto ptr = m_outputPtr.lock()) {
                 ptr->setting(0);
                 ptr->settingValid(false);
             }

--- a/lib/control/inc/control/SetpointProfile.hpp
+++ b/lib/control/inc/control/SetpointProfile.hpp
@@ -32,7 +32,7 @@ public:
     };
 
 private:
-    const std::function<std::shared_ptr<SetpointSensorPair>()> m_target;
+    ControlPtr<SetpointSensorPair>& m_target;
     utc_seconds_t m_profileStartTime = 0;
     bool m_enabled = true;
 
@@ -40,7 +40,7 @@ private:
 
 public:
     explicit SetpointProfile(
-        std::function<std::shared_ptr<SetpointSensorPair>()>&& target) // process value to manipulate setpoint of
+        ControlPtr<SetpointSensorPair>& target) // process value to manipulate setpoint of
         : m_target(target)
     {
     }

--- a/lib/control/inc/control/SetpointSensorPair.hpp
+++ b/lib/control/inc/control/SetpointSensorPair.hpp
@@ -19,6 +19,7 @@
 
 #pragma once
 
+#include "control/ControlPtr.hpp"
 #include "control/FixedPoint.hpp"
 #include "control/FpFilterChain.hpp"
 #include "control/ProcessValue.hpp"
@@ -37,14 +38,14 @@ public:
 private:
     temp_t m_setting = 20;
     bool m_settingEnabled = false;
-    const std::function<std::shared_ptr<TempSensor>()> m_sensor;
+    ControlPtr<TempSensor>& m_sensor;
     FpFilterChain<temp_t> m_filter;
     uint8_t m_sensorFailureCount = 255; // force a reset on init
     uint8_t m_filterNr = 1;
 
 public:
     explicit SetpointSensorPair(
-        std::function<std::shared_ptr<TempSensor>()>&& _sensor)
+        ControlPtr<TempSensor>& _sensor)
         : m_sensor(_sensor)
         , m_filter(1)
     {
@@ -76,7 +77,7 @@ public:
 
     temp_t valueUnfiltered() const
     {
-        if (auto sPtr = m_sensor()) {
+        if (auto sPtr = m_sensor.lock()) {
             return sPtr->value();
         } else {
             return 0;
@@ -90,7 +91,7 @@ public:
 
     bool sensorValid() const
     {
-        if (auto sens = m_sensor()) {
+        if (auto sens = m_sensor.lock()) {
             return sens->valid();
         }
         return false;

--- a/lib/control/inc/control/TempSensorCombi.hpp
+++ b/lib/control/inc/control/TempSensorCombi.hpp
@@ -35,7 +35,7 @@ public:
         MAX = 2,
     };
 
-    std::vector<ControlPtr<TempSensor>*> inputs;
+    std::vector<std::reference_wrapper<ControlPtr<TempSensor>>> inputs;
     CombineFunc func = CombineFunc::AVG;
 
 private:

--- a/lib/control/inc/control/TempSensorCombi.hpp
+++ b/lib/control/inc/control/TempSensorCombi.hpp
@@ -19,6 +19,7 @@
 
 #pragma once
 
+#include "control/ControlPtr.hpp"
 #include "control/TempSensor.hpp"
 #include <functional>
 #include <memory>
@@ -29,13 +30,12 @@
 class TempSensorCombi : public TempSensor {
 public:
     enum class CombineFunc : uint8_t {
-
         AVG = 0,
         MIN = 1,
         MAX = 2,
     };
 
-    std::vector<std::function<std::shared_ptr<TempSensor>()>> inputs;
+    std::vector<ControlPtr<TempSensor>*> inputs;
     CombineFunc func = CombineFunc::AVG;
 
 private:

--- a/lib/control/src/ActuatorDigital.cpp
+++ b/lib/control/src/ActuatorDigital.cpp
@@ -29,7 +29,7 @@ using State = ActuatorDigitalBase::State;
 void ActuatorDigital::state(const State& v)
 {
     if (channelReady()) {
-        if (auto devPtr = m_target()) {
+        if (auto devPtr = m_target.lock()) {
             auto newState = v;
             if (m_invert) {
                 newState = invertState(v);
@@ -43,7 +43,7 @@ void ActuatorDigital::state(const State& v)
 State ActuatorDigital::state() const
 {
     if (channelReady()) {
-        if (auto devPtr = m_target()) {
+        if (auto devPtr = m_target.lock()) {
             State result = State::Unknown;
             if (devPtr->senseChannel(m_channel, result)) {
                 if (m_invert) {
@@ -59,7 +59,7 @@ State ActuatorDigital::state() const
 
 void ActuatorDigital::claimChannel()
 {
-    if (auto devPtr = m_target()) {
+    if (auto devPtr = m_target.lock()) {
         if (m_channel != 0) {
             if (!devPtr->releaseChannel(m_channel)) {
                 return;
@@ -78,7 +78,7 @@ void ActuatorDigital::claimChannel()
 
 bool ActuatorDigital::supportsFastIo() const
 {
-    if (auto devPtr = m_target()) {
+    if (auto devPtr = m_target.lock()) {
         return devPtr->supportsFastIo();
     }
     return false;

--- a/lib/control/src/MotorValve.cpp
+++ b/lib/control/src/MotorValve.cpp
@@ -118,7 +118,7 @@ void MotorValve::update()
         claimChannel();
         return;
     }
-    if (auto devPtr = m_target()) {
+    if (auto devPtr = m_target.lock()) {
         m_actualValveState = getValveState(devPtr);
 
         if (m_desiredValveState == ValveState::Closing && m_actualValveState == ValveState::Closed) {
@@ -137,7 +137,7 @@ void MotorValve::update()
 
 void MotorValve::claimChannel()
 {
-    if (auto devPtr = m_target()) {
+    if (auto devPtr = m_target.lock()) {
         if (m_startChannel != 0) {
             for (uint8_t i = 0; i < 4; ++i) {
                 devPtr->releaseChannel(m_startChannel + i);

--- a/lib/control/src/OneWireDevice.cpp
+++ b/lib/control/src/OneWireDevice.cpp
@@ -27,8 +27,8 @@
  * /param oneWire_ The oneWire bus the device is connected to
  * /param address_ The oneWire address of the device to use.
  */
-OneWireDevice::OneWireDevice(std::function<std::shared_ptr<OneWire>()>&& getBus_, const OneWireAddress& address_)
-    : getBus(getBus_)
+OneWireDevice::OneWireDevice(ControlPtr<OneWire>& busPtr_, const OneWireAddress& address_)
+    : m_bus(busPtr_)
     , m_address(address_)
 {
 }
@@ -74,7 +74,7 @@ void OneWireDevice::connected(bool _connected)
 // return valid OneWire bus if both the bus and the device can be found
 std::shared_ptr<OneWire> OneWireDevice::selectRom() const
 {
-    if (auto oneWire = getBus()) {
+    if (auto oneWire = m_bus.lock()) {
         if (oneWire->reset() && oneWire->select(m_address)) {
             return oneWire;
         };

--- a/lib/control/src/Pid.cpp
+++ b/lib/control/src/Pid.cpp
@@ -21,7 +21,7 @@
 
 void Pid::update()
 {
-    auto input = m_inputPtr();
+    auto input = m_inputPtr.lock();
     auto setpoint = in_t{0};
     if (input && input->settingValid() && input->valueValid()) {
         if (m_enabled) {
@@ -76,7 +76,7 @@ void Pid::update()
 
     // try to set the output to the desired setting
     if (m_enabled) {
-        if (auto output = m_outputPtr()) {
+        if (auto output = m_outputPtr.lock()) {
             output->settingValid(true);
             output->setting(outputValue);
 
@@ -168,7 +168,7 @@ void Pid::checkFilterLength()
     // delay for each filter between input step and max derivative: 8, 34, 85, 188, 492, 1428
     const uint16_t limits[6] = {20, 89, 179, 359, 959, 1799};
     if (!m_derivativeFilterNr) {
-        if (auto input = m_inputPtr()) {
+        if (auto input = m_inputPtr.lock()) {
             // selected filter must use an update interval a lot faster than Td to be meaningful
             // The filter delay is roughly 6x the update rate.
             m_derivativeFilterNr = 1;

--- a/lib/control/src/SetpointProfile.cpp
+++ b/lib/control/src/SetpointProfile.cpp
@@ -52,7 +52,7 @@ void SetpointProfile::update(const utc_seconds_t& time)
         } else {
             return;
         }
-        if (auto targetPtr = m_target()) {
+        if (auto targetPtr = m_target.lock()) {
             targetPtr->setting(newTemp);
             targetPtr->settingValid(true);
         }

--- a/lib/control/src/TempSensorCombi.cpp
+++ b/lib/control/src/TempSensorCombi.cpp
@@ -27,8 +27,8 @@ void TempSensorCombi::update()
     case CombineFunc::AVG: {
         auto sum = safe_elastic_fixed_point<18, 12>{0};
         uint16_t count = 0;
-        for (auto* sensorPtr : inputs) {
-            if (auto sens = sensorPtr->lock()) {
+        for (auto& ref : inputs) {
+            if (auto sens = ref.get().lock()) {
                 if (sens->valid()) {
                     ++count;
                     sum += sens->value();
@@ -44,8 +44,8 @@ void TempSensorCombi::update()
         return;
     }
     case CombineFunc::MIN: {
-        for (auto* sensorPtr : inputs) {
-            if (auto sens = sensorPtr->lock()) {
+        for (auto& ref : inputs) {
+            if (auto sens = ref.get().lock()) {
                 if (sens->valid()) {
                     if (m_valid) {
                         auto v = sens->value();
@@ -62,8 +62,8 @@ void TempSensorCombi::update()
         return;
     }
     case CombineFunc::MAX: {
-        for (auto* sensorPtr : inputs) {
-            if (auto sens = sensorPtr->lock()) {
+        for (auto& ref : inputs) {
+            if (auto sens = ref.get().lock()) {
                 if (sens->valid()) {
                     if (m_valid) {
                         auto v = sens->value();

--- a/lib/control/src/TempSensorCombi.cpp
+++ b/lib/control/src/TempSensorCombi.cpp
@@ -27,8 +27,8 @@ void TempSensorCombi::update()
     case CombineFunc::AVG: {
         auto sum = safe_elastic_fixed_point<18, 12>{0};
         uint16_t count = 0;
-        for (auto sensorLookup : inputs) {
-            if (auto sens = sensorLookup()) {
+        for (auto sensorPtr : inputs) {
+            if (auto sens = sensorPtr->lock()) {
                 if (sens->valid()) {
                     ++count;
                     sum += sens->value();
@@ -44,8 +44,8 @@ void TempSensorCombi::update()
         return;
     }
     case CombineFunc::MIN: {
-        for (auto sensorLookup : inputs) {
-            if (auto sens = sensorLookup()) {
+        for (auto sensorPtr : inputs) {
+            if (auto sens = sensorPtr->lock()) {
                 if (sens->valid()) {
                     if (m_valid) {
                         auto v = sens->value();
@@ -62,8 +62,8 @@ void TempSensorCombi::update()
         return;
     }
     case CombineFunc::MAX: {
-        for (auto sensorLookup : inputs) {
-            if (auto sens = sensorLookup()) {
+        for (auto sensorPtr : inputs) {
+            if (auto sens = sensorPtr->lock()) {
                 if (sens->valid()) {
                     if (m_valid) {
                         auto v = sens->value();

--- a/lib/control/src/TempSensorCombi.cpp
+++ b/lib/control/src/TempSensorCombi.cpp
@@ -27,7 +27,7 @@ void TempSensorCombi::update()
     case CombineFunc::AVG: {
         auto sum = safe_elastic_fixed_point<18, 12>{0};
         uint16_t count = 0;
-        for (auto sensorPtr : inputs) {
+        for (auto* sensorPtr : inputs) {
             if (auto sens = sensorPtr->lock()) {
                 if (sens->valid()) {
                     ++count;
@@ -44,7 +44,7 @@ void TempSensorCombi::update()
         return;
     }
     case CombineFunc::MIN: {
-        for (auto sensorPtr : inputs) {
+        for (auto* sensorPtr : inputs) {
             if (auto sens = sensorPtr->lock()) {
                 if (sens->valid()) {
                     if (m_valid) {
@@ -62,7 +62,7 @@ void TempSensorCombi::update()
         return;
     }
     case CombineFunc::MAX: {
-        for (auto sensorPtr : inputs) {
+        for (auto* sensorPtr : inputs) {
             if (auto sens = sensorPtr->lock()) {
                 if (sens->valid()) {
                     if (m_valid) {

--- a/platform/all/graphics/widgets/ActuatorAnalogWidget.hpp
+++ b/platform/all/graphics/widgets/ActuatorAnalogWidget.hpp
@@ -35,7 +35,7 @@ public:
     /// Updates the widget with information from the object it's representing.
     void update()
     {
-        if (auto pAct = lookup.const_lock()) {
+        if (auto pAct = lookup.lock()) {
             if (pAct->valueValid()) {
                 setValue(temp_to_string(pAct->value(), 2, tempUnit));
             } else {
@@ -50,7 +50,7 @@ public:
 
             // if (auto pwmBlock = lookup.lock_as<ActuatorPwmBlock>()) {
             //     lv_obj_set_hidden(led, false);
-            //     if (auto pwmTarget = pwmBlock->targetLookup().const_lock()) {
+            //     if (auto pwmTarget = pwmBlock->targetLookup().lock()) {
             //         switch (pwmTarget->state()) {
             //         case ActuatorPwm::State::Inactive:
             //             setLed(false);

--- a/platform/all/graphics/widgets/PidWidget.hpp
+++ b/platform/all/graphics/widgets/PidWidget.hpp
@@ -90,11 +90,11 @@ public:
     /// Updates the widget with iinputValuenformation from the object it's representing.
     void update()
     {
-        if (auto ptr = lookup.const_lock()) {
+        if (auto ptr = lookup.lock()) {
             lv_obj_clear_state(obj, LV_STATE_DISABLED);
             auto& inputLookup = ptr->getInputLookup();
             auto& outputLookup = ptr->getOutputLookup();
-            auto input = inputLookup.const_lock();
+            auto input = inputLookup.lock();
             if (input && input->valueValid()) {
                 lv_label_set_text(inputValue, temp_to_string(input->value(), 1, tempUnit).c_str());
             } else {
@@ -106,7 +106,7 @@ public:
                 lv_label_set_text(inputSetting, "-");
             }
 
-            auto output = outputLookup.const_lock();
+            auto output = outputLookup.lock();
             if (output && output->valueValid()) {
                 lv_label_set_text(outputValue, to_string_dec(output->value(), 1).c_str());
             } else {

--- a/platform/all/graphics/widgets/SetpointWidget.hpp
+++ b/platform/all/graphics/widgets/SetpointWidget.hpp
@@ -33,7 +33,7 @@ public:
     /// Updates the widget with information from the object it's representing.
     void update()
     {
-        if (auto ptr = lookup.const_lock()) {
+        if (auto ptr = lookup.lock()) {
             auto& pair = ptr->get();
 
             if (pair.valueValid()) {

--- a/platform/all/graphics/widgets/TemperatureWidget.hpp
+++ b/platform/all/graphics/widgets/TemperatureWidget.hpp
@@ -32,7 +32,7 @@ public:
     /// Updates the widget with information from the object it's representing.
     void update()
     {
-        if (auto ptr = lookup.const_lock()) {
+        if (auto ptr = lookup.lock()) {
             if (ptr->valid()) {
                 auto str = temp_to_string(ptr->value(), 1, tempUnit);
                 str.append(tempUnit == TempUnit::Fahrenheit ? "°F" : "°C");

--- a/platform/particle/d4d_display/inc/d4d_display/screens/SetpointSensorWidget.h
+++ b/platform/particle/d4d_display/inc/d4d_display/screens/SetpointSensorWidget.h
@@ -24,7 +24,7 @@
 
 class SetpointSensorWidget : public ProcessValueWidgetBase {
 private:
-    cbox::CboxPtr<SetpointSensorPairBlock> lookup;
+    cbox::CboxPtr<SetpointSensorPair> lookup;
 
 public:
     SetpointSensorWidget(WidgetWrapper& myWrapper, const cbox::obj_id_t& id);
@@ -32,12 +32,11 @@ public:
 
     virtual void update(const WidgetSettings& settings) override final;
 
-    static void
-    onClickStatic(void* thisPtr)
+    static void onClickStatic(void* thisPtr)
     {
     }
-    void
-    onClick()
+
+    void onClick()
     {
     }
 };

--- a/platform/particle/d4d_display/src/screens/ActuatorAnalogWidget.cpp
+++ b/platform/particle/d4d_display/src/screens/ActuatorAnalogWidget.cpp
@@ -30,7 +30,7 @@ ActuatorAnalogWidget::ActuatorAnalogWidget(WidgetWrapper& myWrapper, const cbox:
 
 void ActuatorAnalogWidget::update(const WidgetSettings& settings)
 {
-    if (auto pAct = lookup.const_lock()) {
+    if (auto pAct = lookup.lock()) {
         setConnected();
 
         if (pAct->valueValid()) {
@@ -47,7 +47,7 @@ void ActuatorAnalogWidget::update(const WidgetSettings& settings)
 
         char icons[2] = {0};
         if (auto pwmBlock = lookup.lock_as<ActuatorPwmBlock>()) {
-            if (auto pwmTarget = pwmBlock->targetLookup().const_lock()) {
+            if (auto pwmTarget = pwmBlock->targetLookup().lock()) {
                 switch (pwmTarget->state()) {
                 case ActuatorPwm::State::Inactive:
                     icons[0] = 0x26;

--- a/platform/particle/d4d_display/src/screens/ActuatorAnalogWidget.cpp
+++ b/platform/particle/d4d_display/src/screens/ActuatorAnalogWidget.cpp
@@ -23,7 +23,7 @@
 
 ActuatorAnalogWidget::ActuatorAnalogWidget(WidgetWrapper& myWrapper, const cbox::obj_id_t& id)
     : ProcessValueWidgetBase(myWrapper)
-    , lookup(cbox::CboxPtr<ActuatorAnalogConstrained>(id))
+    , lookup(id)
 {
     setClickHandler(this, onClickStatic);
 }

--- a/platform/particle/d4d_display/src/screens/PidWidget.cpp
+++ b/platform/particle/d4d_display/src/screens/PidWidget.cpp
@@ -129,12 +129,12 @@ void PidWidget::drawPidRects(const Pid& pid)
 
 void PidWidget::update(const WidgetSettings& settings)
 {
-    if (auto ptr = lookup.const_lock()) {
+    if (auto ptr = lookup.lock()) {
         auto& pid = ptr->get();
         auto& inputLookup = ptr->getInputLookup();
         auto& outputLookup = ptr->getOutputLookup();
         setConnected();
-        auto input = inputLookup.const_lock();
+        auto input = inputLookup.lock();
         if (input && input->valueValid()) {
             setAndEnable(&inputValue, temp_to_string(input->value(), 1, settings.tempUnit));
         } else {
@@ -146,7 +146,7 @@ void PidWidget::update(const WidgetSettings& settings)
             setAndEnable(&inputTarget, "");
         }
 
-        auto output = outputLookup.const_lock();
+        auto output = outputLookup.lock();
         if (output && output->valueValid()) {
             setAndEnable(&outputValue, to_string_dec(output->value(), 1));
         } else {
@@ -162,7 +162,7 @@ void PidWidget::update(const WidgetSettings& settings)
 
         char icons[2] = "\x28";
         if (auto pwmBlock = outputLookup.const_lock_as<ActuatorPwmBlock>()) {
-            if (auto pwmTarget = pwmBlock->targetLookup().const_lock()) {
+            if (auto pwmTarget = pwmBlock->targetLookup().lock()) {
                 switch (pwmTarget->state()) {
                 case ActuatorPwm::State::Inactive:
                     icons[0] = 0x26;

--- a/platform/particle/d4d_display/src/screens/PidWidget.cpp
+++ b/platform/particle/d4d_display/src/screens/PidWidget.cpp
@@ -97,7 +97,7 @@ PidWidget::PidWidget(WidgetWrapper& myWrapper, const cbox::obj_id_t& id)
           wrapper.scheme,       ///< Pointer on used color scheme.
           &iconsData,           ///< Pointer on runtime object data.
       }
-    , lookup(cbox::CboxPtr<PidBlock>(id))
+    , lookup(id)
 {
     wrapper.addChildren({&inputTarget, &inputValue, &outputTarget, &outputValue, &icons});
     wrapper.setEnabled(D4D_FALSE); // start widget disabled
@@ -129,10 +129,9 @@ void PidWidget::drawPidRects(const Pid& pid)
 
 void PidWidget::update(const WidgetSettings& settings)
 {
-    if (auto ptr = lookup.lock()) {
-        auto& pid = ptr->get();
-        auto& inputLookup = ptr->getInputLookup();
-        auto& outputLookup = ptr->getOutputLookup();
+    if (auto pid = lookup.lock()) {
+        auto& inputLookup = pid->getInputLookup();
+        auto& outputLookup = pid->getOutputLookup();
         setConnected();
         auto input = inputLookup.lock();
         if (input && input->valueValid()) {
@@ -158,7 +157,7 @@ void PidWidget::update(const WidgetSettings& settings)
             setAndEnable(&outputTarget, "");
         }
 
-        drawPidRects(pid);
+        drawPidRects(pid->get());
 
         char icons[2] = "\x28";
         if (auto pwmBlock = outputLookup.const_lock_as<ActuatorPwmBlock>()) {

--- a/platform/particle/d4d_display/src/screens/SetpointSensorWidget.cpp
+++ b/platform/particle/d4d_display/src/screens/SetpointSensorWidget.cpp
@@ -22,27 +22,26 @@
 
 SetpointSensorWidget::SetpointSensorWidget(WidgetWrapper& myWrapper, const cbox::obj_id_t& id)
     : ProcessValueWidgetBase(myWrapper)
-    , lookup(cbox::CboxPtr<SetpointSensorPairBlock>(id))
+    , lookup(id)
 {
     setClickHandler(this, onClickStatic);
 }
 
 void SetpointSensorWidget::update(const WidgetSettings& settings)
 {
-    if (auto ptr = lookup.lock()) {
+    if (auto setpoint = lookup.lock()) {
         setConnected();
-        auto& pair = ptr->get();
 
         char icons[3] = {0};
-        if (pair.valueValid()) {
-            setValue(temp_to_string(pair.value(), 1, settings.tempUnit));
+        if (setpoint->valueValid()) {
+            setValue(temp_to_string(setpoint->value(), 1, settings.tempUnit));
             icons[0] = '\x29';
         } else {
             setValue("");
             icons[0] = '\x2B';
         }
-        if (pair.settingValid()) {
-            setSetting(temp_to_string(pair.setting(), 1, settings.tempUnit));
+        if (setpoint->settingValid()) {
+            setSetting(temp_to_string(setpoint->setting(), 1, settings.tempUnit));
             icons[1] = '\x2A';
         } else {
             setSetting("");

--- a/platform/particle/d4d_display/src/screens/SetpointSensorWidget.cpp
+++ b/platform/particle/d4d_display/src/screens/SetpointSensorWidget.cpp
@@ -29,7 +29,7 @@ SetpointSensorWidget::SetpointSensorWidget(WidgetWrapper& myWrapper, const cbox:
 
 void SetpointSensorWidget::update(const WidgetSettings& settings)
 {
-    if (auto ptr = lookup.const_lock()) {
+    if (auto ptr = lookup.lock()) {
         setConnected();
         auto& pair = ptr->get();
 

--- a/platform/particle/d4d_display/src/screens/TempSensorWidget.cpp
+++ b/platform/particle/d4d_display/src/screens/TempSensorWidget.cpp
@@ -28,7 +28,7 @@ TempSensorWidget::TempSensorWidget(WidgetWrapper& myWrapper, const cbox::obj_id_
 
 void TempSensorWidget::update(const WidgetSettings& settings)
 {
-    if (auto ptr = lookup.const_lock()) {
+    if (auto ptr = lookup.lock()) {
         setConnected();
         char icons[2] = {0};
         if (ptr->valid()) {

--- a/platform/particle/d4d_display/src/screens/TempSensorWidget.cpp
+++ b/platform/particle/d4d_display/src/screens/TempSensorWidget.cpp
@@ -22,7 +22,7 @@
 
 TempSensorWidget::TempSensorWidget(WidgetWrapper& myWrapper, const cbox::obj_id_t& id)
     : ProcessValueWidgetBase(myWrapper)
-    , lookup(cbox::CboxPtr<TempSensor>(id))
+    , lookup(id)
 {
 }
 

--- a/test/blocks/SetpointProfileBlock_test.cpp
+++ b/test/blocks/SetpointProfileBlock_test.cpp
@@ -17,13 +17,13 @@
  * along with BrewPi.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include "AppTicks.hpp"
 #include "TestHelpers.hpp"
 #include "blocks/SetpointProfileBlock.hpp"
 #include "blocks/SetpointSensorPairBlock.hpp"
 #include "blocks/TempSensorMockBlock.hpp"
 #include "blocks/TicksBlock.hpp"
 #include "cbox/Box.hpp"
-#include "control/MockTicks.hpp"
 #include "proto/SetpointProfile_test.pb.h"
 #include "proto/SetpointSensorPair_test.pb.h"
 #include "proto/TempSensorMock_test.pb.h"
@@ -44,10 +44,8 @@ SCENARIO("A SetpointProfile block")
         auto setpointId = cbox::obj_id_t(101);
         auto profileId = cbox::obj_id_t(102);
 
-        cbox::CboxPtr<TicksBlock<TicksClass>> ticks(ticksId);
-
-        auto update = [&ticks](const cbox::update_t& now) {
-            ticks.lock()->get().ticksImpl().reset(now);
+        auto update = [](const cbox::update_t& now) {
+            ticks.ticksImpl().reset(now);
             cbox::update(now);
         };
 

--- a/test/cbox/CboxPtr_test.cpp
+++ b/test/cbox/CboxPtr_test.cpp
@@ -131,7 +131,7 @@ SCENARIO("A CboxPtr is a dynamic lookup that checks type compatibility and works
             // The offset it got matches static cast
             CHECK(static_cast<Nameable*>(nameableLiPtr.lock().get()) == ptr.get());
 
-            auto const_ptr = liPtr.const_lock_as<Nameable>();
+            auto const_ptr = liPtr.lock_as<Nameable>();
             CHECK(const_ptr != nullptr);
 
             // The offset it got matches static cast

--- a/test/cbox/makefile
+++ b/test/cbox/makefile
@@ -9,6 +9,9 @@ INCLUDE_DIRS += $(ROOT_DIR)/external_libs/expected/expected/include
 # catch test
 INCLUDE_DIRS += $(ROOT_DIR)/external_libs/device-os/third_party/catch2/catch2/single_include/catch2
 
+# lib/control (headers only)
+INCLUDE_DIRS += $(ROOT_DIR)/lib/control/inc
+
 # lib/cbox
 INCLUDE_DIRS += $(ROOT_DIR)/lib/cbox/inc
 CPPSRC += $(wildcard $(ROOT_DIR)/lib/cbox/src/*.cpp)

--- a/test/control/ActuatorAnalogConstrained_test.cpp
+++ b/test/control/ActuatorAnalogConstrained_test.cpp
@@ -91,7 +91,7 @@ SCENARIO("ActuatorAnalogConstrained test", "[constraints]")
 SCENARIO("When two analog actuators are constrained by a balancer", "[constraints]")
 {
     using value_t = ActuatorAnalog::value_t;
-    auto balancer = TestControlPtr<Balancer<2>>::make(new Balancer<2>());
+    auto balancer = TestControlPtr<Balancer<2>>(new Balancer<2>());
     ActuatorAnalogMock act1;
     act1.minSetting(0);
     act1.maxSetting(100);

--- a/test/control/ActuatorDigitalChangeLogged_test.cpp
+++ b/test/control/ActuatorDigitalChangeLogged_test.cpp
@@ -27,7 +27,7 @@
 SCENARIO("ActuatorDigitalChangeLogged test", "[ActuatorChangeLog]")
 {
     using State = ActuatorDigitalBase::State;
-    auto io = TestControlPtr<IoArray>::make(new MockIoArray());
+    auto io = TestControlPtr<IoArray>(new MockIoArray());
     ActuatorDigital mock(io, 1);
     ActuatorDigitalChangeLogged logged(mock);
     ticks_millis_t now = 1000;

--- a/test/control/ActuatorDigitalChangeLogged_test.cpp
+++ b/test/control/ActuatorDigitalChangeLogged_test.cpp
@@ -19,6 +19,7 @@
 
 #include <catch.hpp>
 
+#include "TestControlPtr.hpp"
 #include "control/ActuatorDigital.hpp"
 #include "control/ActuatorDigitalChangeLogged.hpp"
 #include "control/MockIoArray.hpp"
@@ -26,9 +27,8 @@
 SCENARIO("ActuatorDigitalChangeLogged test", "[ActuatorChangeLog]")
 {
     using State = ActuatorDigitalBase::State;
-
-    auto mockIo = std::make_shared<MockIoArray>();
-    ActuatorDigital mock([mockIo]() { return mockIo; }, 1);
+    auto io = TestControlPtr<IoArray>::make(new MockIoArray());
+    ActuatorDigital mock(io, 1);
     ActuatorDigitalChangeLogged logged(mock);
     ticks_millis_t now = 1000;
 

--- a/test/control/ActuatorDigitalConstrained_test.cpp
+++ b/test/control/ActuatorDigitalConstrained_test.cpp
@@ -31,7 +31,7 @@ SCENARIO("ActuatorDigitalConstrained", "[constraints]")
     auto now = ticks_millis_t(0);
 
     auto mockIo = std::make_shared<MockIoArray>();
-    auto io = TestControlPtr<IoArray>::make(mockIo);
+    auto io = TestControlPtr<IoArray>(mockIo);
     ActuatorDigital mock(io, 1);
     ActuatorDigitalConstrained constrained(mock);
 
@@ -135,13 +135,13 @@ SCENARIO("ActuatorDigitalConstrained", "[constraints]")
 SCENARIO("Mutex contraint", "[constraints]")
 {
     auto now = ticks_millis_t(0);
-    auto mockIo = TestControlPtr<MockIoArray>::make(new MockIoArray());
-    auto io = TestControlPtr<IoArray>::make(mockIo);
+    auto mockIo = TestControlPtr<MockIoArray>(new MockIoArray());
+    auto io = TestControlPtr<IoArray>(mockIo);
     ActuatorDigital mock1(io, 1);
     ActuatorDigitalConstrained constrained1(mock1);
     ActuatorDigital mock2(io, 2);
     ActuatorDigitalConstrained constrained2(mock2);
-    auto mut = TestControlPtr<MutexTarget>::make(new MutexTarget());
+    auto mut = TestControlPtr<MutexTarget>(new MutexTarget());
 
     constrained1.addConstraint(
         std::make_unique<ADConstraints::Mutex<3>>(mut, 0, true));

--- a/test/control/ActuatorDigitalConstrained_test.cpp
+++ b/test/control/ActuatorDigitalConstrained_test.cpp
@@ -19,6 +19,7 @@
 
 #include <catch.hpp>
 
+#include "TestControlPtr.hpp"
 #include "control/ActuatorDigital.hpp"
 #include "control/ActuatorDigitalConstrained.hpp"
 #include "control/MockIoArray.hpp"
@@ -30,7 +31,8 @@ SCENARIO("ActuatorDigitalConstrained", "[constraints]")
     auto now = ticks_millis_t(0);
 
     auto mockIo = std::make_shared<MockIoArray>();
-    ActuatorDigital mock([mockIo]() { return mockIo; }, 1);
+    auto io = TestControlPtr<IoArray>::make(mockIo);
+    ActuatorDigital mock(io, 1);
     ActuatorDigitalConstrained constrained(mock);
 
     WHEN("A minimum ON time constrained is added, the actuator cannot turn off before it has passed")
@@ -133,25 +135,18 @@ SCENARIO("ActuatorDigitalConstrained", "[constraints]")
 SCENARIO("Mutex contraint", "[constraints]")
 {
     auto now = ticks_millis_t(0);
-    auto mockIo = std::make_shared<MockIoArray>();
-    ActuatorDigital mock1([mockIo]() { return mockIo; }, 1);
+    auto mockIo = TestControlPtr<MockIoArray>::make(new MockIoArray());
+    auto io = TestControlPtr<IoArray>::make(mockIo);
+    ActuatorDigital mock1(io, 1);
     ActuatorDigitalConstrained constrained1(mock1);
-    ActuatorDigital mock2([mockIo]() { return mockIo; }, 2);
+    ActuatorDigital mock2(io, 2);
     ActuatorDigitalConstrained constrained2(mock2);
-    auto mut = std::make_shared<MutexTarget>();
+    auto mut = TestControlPtr<MutexTarget>::make(new MutexTarget());
 
-    constrained1.addConstraint(std::make_unique<ADConstraints::Mutex<3>>(
-        [&mut]() {
-            return mut;
-        },
-        0,
-        true));
-    constrained2.addConstraint(std::make_unique<ADConstraints::Mutex<3>>(
-        [&mut]() {
-            return mut;
-        },
-        0,
-        true));
+    constrained1.addConstraint(
+        std::make_unique<ADConstraints::Mutex<3>>(mut, 0, true));
+    constrained2.addConstraint(
+        std::make_unique<ADConstraints::Mutex<3>>(mut, 0, true));
 
     WHEN("Two actuators share a mutex, they cannot be active at the same time")
     {
@@ -190,16 +185,10 @@ SCENARIO("Mutex contraint", "[constraints]")
     {
         constrained1.removeAllConstraints();
         constrained2.removeAllConstraints();
-        constrained1.addConstraint(std::make_unique<ADConstraints::Mutex<3>>(
-            [&mut]() {
-                return mut;
-            },
-            1000, true));
-        constrained2.addConstraint(std::make_unique<ADConstraints::Mutex<3>>(
-            [&mut]() {
-                return mut;
-            },
-            0, true));
+        constrained1.addConstraint(
+            std::make_unique<ADConstraints::Mutex<3>>(mut, 1000, true));
+        constrained2.addConstraint(
+            std::make_unique<ADConstraints::Mutex<3>>(mut, 0, true));
 
         constrained1.desiredState(State::Active, ++now);
         CHECK(constrained1.state() == State::Active);
@@ -217,7 +206,7 @@ SCENARIO("Mutex contraint", "[constraints]")
         {
             constrained2.desiredState(State::Active, ++now);
             CHECK(constrained2.state() == State::Inactive);
-            CHECK(mut->timeRemaining() == 1000);
+            CHECK(mut.ptr->timeRemaining() == 1000);
 
             while (constrained2.state() != State::Active && now < 2000) {
                 ++now;
@@ -239,18 +228,18 @@ SCENARIO("Mutex contraint", "[constraints]")
         {
             constrained2.desiredState(State::Active, ++now);
             CHECK(constrained2.state() == State::Inactive);
-            CHECK(mut->timeRemaining() == 1000);
+            CHECK(mut.ptr->timeRemaining() == 1000);
 
             while (constrained2.state() != State::Active && now < 500) {
                 ++now;
                 constrained1.update(now);
                 constrained2.update(now);
             }
-            CHECK(mut->timeRemaining() == 502);
+            CHECK(mut.ptr->timeRemaining() == 502);
 
             constrained1.desiredState(State::Active, ++now);
             constrained1.desiredState(State::Inactive, ++now);
-            CHECK(mut->timeRemaining() == 1000);
+            CHECK(mut.ptr->timeRemaining() == 1000);
 
             while (constrained2.state() != State::Active && now < 2000) {
                 ++now;
@@ -263,7 +252,7 @@ SCENARIO("Mutex contraint", "[constraints]")
 
         THEN("When the Mutex target is unavailable the actuators cannot go active, but already active actuators will reference their old mutex until it unlocks")
         {
-            mut.reset();
+            mut.ptr.reset();
             constrained1.desiredState(State::Active, ++now);
             constrained2.desiredState(State::Active, ++now);
             CHECK(constrained1.state() == State::Active);
@@ -283,20 +272,14 @@ SCENARIO("Mutex contraint", "[constraints]")
 
     WHEN("A default extra hold time of 1000ms is set on the Mutex and only act 2 has a custom hold time of 100ms")
     {
-        mut->holdAfterTurnOff(1000);
+        mut.ptr->holdAfterTurnOff(1000);
 
         constrained1.removeAllConstraints();
         constrained2.removeAllConstraints();
-        constrained1.addConstraint(std::make_unique<ADConstraints::Mutex<3>>(
-            [&mut]() {
-                return mut;
-            },
-            0, false));
-        constrained2.addConstraint(std::make_unique<ADConstraints::Mutex<3>>(
-            [&mut]() {
-                return mut;
-            },
-            100, true));
+        constrained1.addConstraint(
+            std::make_unique<ADConstraints::Mutex<3>>(mut, 0, false));
+        constrained2.addConstraint(
+            std::make_unique<ADConstraints::Mutex<3>>(mut, 100, true));
 
         constrained1.desiredState(State::Active, ++now);
         CHECK(constrained1.state() == State::Active);
@@ -357,7 +340,7 @@ SCENARIO("Mutex contraint", "[constraints]")
     {
         WHEN("Target IO module cannot be reached")
         {
-            mockIo->connected(false); // emulate disconnect
+            mockIo.ptr->connected(false); // emulate disconnect
 
             THEN("Desired state is still set correctly")
             {
@@ -381,7 +364,7 @@ SCENARIO("Mutex contraint", "[constraints]")
                     constrained2.desiredState(State::Inactive, 2008);
                     AND_WHEN("The target is connected again")
                     {
-                        mockIo->connected(true);
+                        mockIo.ptr->connected(true);
                         THEN("Turning the actuators is still handled correctly by the mutex")
                         {
                             constrained1.desiredState(State::Active, 2009);

--- a/test/control/ActuatorOffset_test.cpp
+++ b/test/control/ActuatorOffset_test.cpp
@@ -26,15 +26,15 @@
 
 SCENARIO("ActuatorOffset offsets one setpoint from another", "[ActuatorOffset]")
 {
-    auto targetSensorMock = TestControlPtr<TempSensorMock>::make(new TempSensorMock(20.0));
-    auto referenceSensorMock = TestControlPtr<TempSensorMock>::make(new TempSensorMock(19.0));
-    auto targetSensor = TestControlPtr<TempSensor>::make(targetSensorMock);
-    auto referenceSensor = TestControlPtr<TempSensor>::make(referenceSensorMock);
+    auto targetSensorMock = TestControlPtr<TempSensorMock>(new TempSensorMock(20.0));
+    auto referenceSensorMock = TestControlPtr<TempSensorMock>(new TempSensorMock(19.0));
+    auto targetSensor = TestControlPtr<TempSensor>(targetSensorMock);
+    auto referenceSensor = TestControlPtr<TempSensor>(referenceSensorMock);
 
-    auto target = TestControlPtr<SetpointSensorPair>::make(new SetpointSensorPair(targetSensor));
+    auto target = TestControlPtr<SetpointSensorPair>(new SetpointSensorPair(targetSensor));
     target.ptr->settingValid(true);
 
-    auto reference = TestControlPtr<SetpointSensorPair>::make(new SetpointSensorPair(referenceSensor));
+    auto reference = TestControlPtr<SetpointSensorPair>(new SetpointSensorPair(referenceSensor));
     reference.ptr->settingValid(true);
 
     auto act = std::make_shared<ActuatorOffset>(target, reference);

--- a/test/control/ActuatorOffset_test.cpp
+++ b/test/control/ActuatorOffset_test.cpp
@@ -17,6 +17,7 @@
  * along with BrewPi.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include "TestControlPtr.hpp"
 #include "control/ActuatorOffset.hpp"
 #include "control/SetpointSensorPair.hpp"
 #include "control/TempSensorMock.hpp"
@@ -25,62 +26,62 @@
 
 SCENARIO("ActuatorOffset offsets one setpoint from another", "[ActuatorOffset]")
 {
-    auto targetSensor = std::make_shared<TempSensorMock>(20.0);
-    auto referenceSensor = std::make_shared<TempSensorMock>(19.0);
+    auto targetSensorMock = TestControlPtr<TempSensorMock>::make(new TempSensorMock(20.0));
+    auto referenceSensorMock = TestControlPtr<TempSensorMock>::make(new TempSensorMock(19.0));
+    auto targetSensor = TestControlPtr<TempSensor>::make(targetSensorMock);
+    auto referenceSensor = TestControlPtr<TempSensor>::make(referenceSensorMock);
 
-    auto target = std::make_shared<SetpointSensorPair>([targetSensor]() { return targetSensor; });
-    target->settingValid(true);
+    auto target = TestControlPtr<SetpointSensorPair>::make(new SetpointSensorPair(targetSensor));
+    target.ptr->settingValid(true);
 
-    auto reference = std::make_shared<SetpointSensorPair>([referenceSensor]() { return referenceSensor; });
-    reference->settingValid(true);
+    auto reference = TestControlPtr<SetpointSensorPair>::make(new SetpointSensorPair(referenceSensor));
+    reference.ptr->settingValid(true);
 
-    auto act = std::make_shared<ActuatorOffset>(
-        [target]() { return target; },
-        [reference]() { return reference; });
+    auto act = std::make_shared<ActuatorOffset>(target, reference);
 
     act->setting(0);
     act->update();
 
     WHEN("The actuator is written, the target is offset from the reference")
     {
-        reference->setting(20);
+        reference.ptr->setting(20);
         act->setting(10.0);
 
-        CHECK(reference->setting() == 20.0);
-        CHECK(target->setting() == 30.0);
+        CHECK(reference.ptr->setting() == 20.0);
+        CHECK(target.ptr->setting() == 30.0);
         CHECK(act->setting() == 10.0); // difference between setpoints is now 10
         CHECK(act->value() == 0.0);    // actual value is still zero, because targetSensor has not changed
 
-        targetSensor->setting(30.0);
-        target->resetFilter();
+        targetSensorMock.ptr->setting(30.0);
+        target.ptr->resetFilter();
         act->update();
         CHECK(act->value() == 10.0); // actual value is 10 when sensor has reached setpoint
 
         act->setting(-10.0);
-        CHECK(reference->setting() == 20.0);
-        CHECK(target->setting() == 10.0);
+        CHECK(reference.ptr->setting() == 20.0);
+        CHECK(target.ptr->setting() == 10.0);
         CHECK(act->setting() == -10.0); // difference between setpoints is now 10
         act->update();
 
         CHECK(act->value() == 10.0); // value is still 10, because targetSensor has not changed
 
-        targetSensor->setting(10.0);
-        target->resetFilter();
+        targetSensorMock.ptr->setting(10.0);
+        target.ptr->resetFilter();
         act->update();
         CHECK(act->value() == -10.0); // value is -10 when sensor has reached setpoint
 
-        reference->setting(10.0);
-        referenceSensor->setting(15.0);
-        reference->resetFilter();
-        target->setting(20.0);
-        targetSensor->setting(20.0);
-        target->resetFilter();
+        reference.ptr->setting(10.0);
+        referenceSensorMock.ptr->setting(15.0);
+        reference.ptr->resetFilter();
+        target.ptr->setting(20.0);
+        targetSensorMock.ptr->setting(20.0);
+        target.ptr->resetFilter();
         act->setting(12.0);
 
         // when using the reference setting as value to offset from (default):
         CHECK(act->value() == 10.0);   // value() returns target sensor - ref setpoint
         CHECK(act->setting() == 12.0); // setting() returns target setpoint - ref setpoint
-        CHECK(target->setting() == 22.0);
+        CHECK(target.ptr->setting() == 22.0);
 
         // when using the reference value as value to offset from:
         act->selectedReference(ActuatorOffset::ReferenceKind::VALUE);
@@ -88,7 +89,7 @@ SCENARIO("ActuatorOffset offsets one setpoint from another", "[ActuatorOffset]")
 
         CHECK(act->value() == 5.0);    // value() returns target sensor - ref sensor value
         CHECK(act->setting() == 12.0); // setting() returns target setpoint - ref sensor value
-        CHECK(target->setting() == 27.0);
+        CHECK(target.ptr->setting() == 27.0);
     }
 
     WHEN(
@@ -97,36 +98,36 @@ SCENARIO("ActuatorOffset offsets one setpoint from another", "[ActuatorOffset]")
         "the target actuator is fully valid, because the reference sensor is unused")
     {
         act->selectedReference(ActuatorOffset::ReferenceKind::SETTING);
-        target->setting(20);
-        referenceSensor->connected(false);
+        target.ptr->setting(20);
+        referenceSensorMock.ptr->connected(false);
         act->setting(12.0);
 
-        CHECK(target->setting() == 32.0);
+        CHECK(target.ptr->setting() == 32.0);
         CHECK(act->settingValid() == true);
         CHECK(act->valueValid() == true);
         CHECK(act->value() == 0);
         CHECK(act->setting() == 12.0);
-        CHECK(target->settingValid() == true);
+        CHECK(target.ptr->settingValid() == true);
 
         AND_WHEN("The reference setting becomes invalid")
         {
-            reference->settingValid(false);
+            reference.ptr->settingValid(false);
             act->update();
             THEN("The target setting is set to invalid once, but not on subsequent updates")
             {
-                CHECK(target->settingValid() == false);
+                CHECK(target.ptr->settingValid() == false);
 
-                target->settingValid(true);
-                target->setting(33);
+                target.ptr->settingValid(true);
+                target.ptr->setting(33);
                 act->update();
-                CHECK(target->settingValid() == true);
-                CHECK(target->setting() == 33);
+                CHECK(target.ptr->settingValid() == true);
+                CHECK(target.ptr->setting() == 33);
 
-                target->settingValid(true);
-                target->setting(31);
+                target.ptr->settingValid(true);
+                target.ptr->setting(31);
                 act->update();
-                CHECK(target->settingValid() == true);
-                CHECK(target->setting() == 31);
+                CHECK(target.ptr->settingValid() == true);
+                CHECK(target.ptr->setting() == 31);
             }
         }
     }
@@ -137,17 +138,17 @@ SCENARIO("ActuatorOffset offsets one setpoint from another", "[ActuatorOffset]")
         "target setpoint will be set to invalid, and actuator value is invalid and 0")
     {
         act->selectedReference(ActuatorOffset::ReferenceKind::SETTING);
-        referenceSensor->connected(true);
-        reference->settingValid(false);
+        referenceSensorMock.ptr->connected(true);
+        reference.ptr->settingValid(false);
         act->setting(12.0);
 
-        CHECK(target->setting() == 20.0); // unchanged
+        CHECK(target.ptr->setting() == 20.0); // unchanged
         CHECK(act->valueValid() == false);
         CHECK(act->settingValid() == false);
 
         CHECK(act->value() == 0);
         CHECK(act->setting() == 12.0); // setting() still returns requested offset
-        CHECK(target->settingValid() == false);
+        CHECK(target.ptr->settingValid() == false);
     }
 
     WHEN(
@@ -156,19 +157,19 @@ SCENARIO("ActuatorOffset offsets one setpoint from another", "[ActuatorOffset]")
         "target setpoint will be invalid and actuator value is 0")
     {
         act->selectedReference(ActuatorOffset::ReferenceKind::VALUE);
-        target->setting(20);
-        referenceSensor->connected(false);
+        target.ptr->setting(20);
+        referenceSensorMock.ptr->connected(false);
         for (int i = 0; i <= 10; i++) {
-            reference->update(); // will only switch to invalid after 10s disconnected
+            reference.ptr->update(); // will only switch to invalid after 10s disconnected
         }
         act->setting(12.0);
 
-        CHECK(target->setting() == 20.0); // unchanged
+        CHECK(target.ptr->setting() == 20.0); // unchanged
         CHECK(act->valueValid() == false);
         CHECK(act->settingValid() == false);
         CHECK(act->value() == 0);
         CHECK(act->setting() == 12.0); // setting() still returns requested offset
-        CHECK(target->settingValid() == false);
+        CHECK(target.ptr->settingValid() == false);
     }
 
     WHEN(
@@ -177,23 +178,23 @@ SCENARIO("ActuatorOffset offsets one setpoint from another", "[ActuatorOffset]")
         "target setpoint will be valid and actuator is fully valid")
     {
         act->selectedReference(ActuatorOffset::ReferenceKind::VALUE);
-        referenceSensor->connected(true);
-        reference->settingValid(false);
+        referenceSensorMock.ptr->connected(true);
+        reference.ptr->settingValid(false);
         act->setting(12.0);
 
-        CHECK(target->setting() == 31.0);
+        CHECK(target.ptr->setting() == 31.0);
         CHECK(act->valueValid() == true);
         CHECK(act->settingValid() == true);
         CHECK(act->value() == 1.0); // ref sensor value is 19, target sensor is 20
         CHECK(act->setting() == 12.0);
-        CHECK(target->settingValid() == true);
+        CHECK(target.ptr->settingValid() == true);
     }
 
     WHEN("The offset actuator is disabled")
     {
         act->setting(10.0);
-        CHECK(reference->setting() == 20.0);
-        CHECK(target->setting() == 30.0);
+        CHECK(reference.ptr->setting() == 20.0);
+        CHECK(target.ptr->setting() == 30.0);
         act->update();
         CHECK(act->setting() == 10.0); // difference between setpoints is 10
 
@@ -202,7 +203,7 @@ SCENARIO("ActuatorOffset offsets one setpoint from another", "[ActuatorOffset]")
 
         THEN("This action doesn't change the target")
         {
-            CHECK(target->setting() == 30.0);
+            CHECK(target.ptr->setting() == 30.0);
             CHECK(act->setting() == 10.0); // difference between setpoints is 10
         }
 
@@ -215,26 +216,26 @@ SCENARIO("ActuatorOffset offsets one setpoint from another", "[ActuatorOffset]")
         {
             act->setting(50);
             act->update();
-            CHECK(target->setting() == 30.0); // still 20
+            CHECK(target.ptr->setting() == 30.0); // still 20
             AND_THEN("the target can be changed externally")
             {
-                target->setting(40);
+                target.ptr->setting(40);
                 act->setting(50);
                 act->update();
-                CHECK(target->setting() == 40.0);
+                CHECK(target.ptr->setting() == 40.0);
             }
 
             AND_WHEN("the offset actuator is enabled again")
             {
-                target->setting(40);
+                target.ptr->setting(40);
                 act->enabled(true);
                 act->update();
                 THEN("The actuator setting affects the target again")
                 {
                     act->setting(50);
                     act->update();
-                    CHECK(target->settingValid() == true);
-                    CHECK(target->setting() == 70.0);
+                    CHECK(target.ptr->settingValid() == true);
+                    CHECK(target.ptr->setting() == 70.0);
                 }
             }
         }

--- a/test/control/ActuatorPwm_test.cpp
+++ b/test/control/ActuatorPwm_test.cpp
@@ -23,6 +23,7 @@
 #include <stdlib.h> /* srand, rand */
 
 #include "AppLogger.hpp"
+#include "TestControlPtr.hpp"
 #include "control/ActuatorAnalogConstrained.hpp"
 #include "control/ActuatorDigital.hpp"
 #include "control/ActuatorDigitalConstrained.hpp"
@@ -147,11 +148,12 @@ SCENARIO("ActuatorPWM driving mock actuator", "[pwm]")
 {
     auto now = ticks_millis_t(0);
 
-    auto mockIo = std::make_shared<MockIoArray>();
-    ActuatorDigital mock([mockIo]() { return mockIo; }, 1);
+    auto mockIo = TestControlPtr<MockIoArray>::make(new MockIoArray());
+    auto io = TestControlPtr<IoArray>::make(mockIo);
+    ActuatorDigital mock(io, 1);
 
-    auto constrained = std::make_shared<ActuatorDigitalConstrained>(mock);
-    ActuatorPwm pwm([constrained]() { return constrained; }, 4000);
+    auto constrained = TestControlPtr<ActuatorDigitalConstrained>::make(new ActuatorDigitalConstrained(mock));
+    ActuatorPwm pwm(constrained, 4000);
 
     WHEN("Actuator setting is written, setting is contrained between  0-100")
     {
@@ -306,7 +308,7 @@ SCENARIO("ActuatorPWM driving mock actuator", "[pwm]")
                 nextUpdateTime = pwm.update(now);
             }
         }
-        auto durations = constrained->activeDurations(now);
+        auto durations = constrained.ptr->activeDurations(now);
         CHECK(durations.previousActive == 2000);
     }
 
@@ -328,7 +330,7 @@ SCENARIO("ActuatorPWM driving mock actuator", "[pwm]")
             // INFO(now);
             CHECK(pwm.value() == Approx(50).margin(3));
             // INFO(double(pwm.value()));
-            auto durations = constrained->activeDurations(now);
+            auto durations = constrained.ptr->activeDurations(now);
             CHECK(durations.previousActive >= 2000);
             CHECK(durations.previousActive <= 2250);
             CHECK(durations.previousPeriod >= 3500);
@@ -460,7 +462,7 @@ SCENARIO("ActuatorPWM driving mock actuator", "[pwm]")
         "the PWM actuator is set to 60% after being 1% for a long time, "
         "with a  minimum ON time constraint active, the high time is not strechted beyond 1.5x normal duration")
     {
-        constrained->addConstraint(std::make_unique<ADConstraints::MinOnTime<2>>(1000)); // 1 second
+        constrained.ptr->addConstraint(std::make_unique<ADConstraints::MinOnTime<2>>(1000)); // 1 second
         pwm.setting(1);
         while (now < 100000 || mock.state() == State::Inactive) {
             now = pwm.update(now);
@@ -481,7 +483,7 @@ SCENARIO("ActuatorPWM driving mock actuator", "[pwm]")
         "the PWM actuator is set to 40% after being 99% for a long time, "
         "with a  minimum OFF time constraint active, the low time is not strechted beyond 1.5x normal duration")
     {
-        constrained->addConstraint(std::make_unique<ADConstraints::MinOffTime<1>>(1000)); // 1 second
+        constrained.ptr->addConstraint(std::make_unique<ADConstraints::MinOffTime<1>>(1000)); // 1 second
         pwm.setting(99);
         while (now < 100000 || mock.state() == State::Active) {
             now = pwm.update(now);
@@ -800,9 +802,9 @@ SCENARIO("ActuatorPWM driving mock actuator", "[pwm]")
     WHEN("PWM actuator target is constrained with a minimal ON time and minimum OFF time, average is still correct")
     {
         // values typical for a fridge compressor
-        pwm.period(2400000);                                                                // 40 minutes
-        constrained->addConstraint(std::make_unique<ADConstraints::MinOnTime<2>>(300000));  // 5 minutes
-        constrained->addConstraint(std::make_unique<ADConstraints::MinOffTime<1>>(600000)); // 10 minutes
+        pwm.period(2400000);                                                                    // 40 minutes
+        constrained.ptr->addConstraint(std::make_unique<ADConstraints::MinOnTime<2>>(300000));  // 5 minutes
+        constrained.ptr->addConstraint(std::make_unique<ADConstraints::MinOffTime<1>>(600000)); // 10 minutes
 
         // use max delay of 5000 here to speed up tests
         CHECK(randomIntervalTest(10, pwm, mock, 50.0, 5000, now) == Approx(50.0).margin(0.5));
@@ -816,9 +818,9 @@ SCENARIO("ActuatorPWM driving mock actuator", "[pwm]")
 
     WHEN("The actuator has been set to 30% duty and switches to 20% with minimum ON time at 40% duty")
     {
-        pwm.period(10000);                                                               // 10s
-        constrained->addConstraint(std::make_unique<ADConstraints::MinOnTime<2>>(4000)); // 4 s
-        pwm.setting(30);                                                                 // will result in 4s on, 13.3s period
+        pwm.period(10000);                                                                   // 10s
+        constrained.ptr->addConstraint(std::make_unique<ADConstraints::MinOnTime<2>>(4000)); // 4 s
+        pwm.setting(30);                                                                     // will result in 4s on, 13.3s period
 
         auto nextUpdate = pwm.update(now);
 
@@ -826,7 +828,7 @@ SCENARIO("ActuatorPWM driving mock actuator", "[pwm]")
             now = pwm.update(now);
         }
 
-        auto durations = constrained->activeDurations(now);
+        auto durations = constrained.ptr->activeDurations(now);
         CHECK(durations.previousPeriod == Approx(13333).margin(10));
 
         pwm.setting(20);
@@ -838,7 +840,7 @@ SCENARIO("ActuatorPWM driving mock actuator", "[pwm]")
                 nextUpdate = pwm.update(now);
                 now = nextUpdate;
             }
-            auto durations = constrained->activeDurations(now);
+            auto durations = constrained.ptr->activeDurations(now);
             CHECK(durations.previousActive == 4000);
 
             AND_THEN("The next low time is stretched to 1.5x the previous one")
@@ -851,7 +853,7 @@ SCENARIO("ActuatorPWM driving mock actuator", "[pwm]")
                     nextUpdate = pwm.update(now);
                     now = nextUpdate;
                 }
-                durations = constrained->activeDurations(now);
+                durations = constrained.ptr->activeDurations(now);
                 CHECK(durations.previousPeriod == Approx(18000).margin(10)); // 9333 * 1.5 + 4000
             }
         }
@@ -862,7 +864,7 @@ SCENARIO("ActuatorPWM driving mock actuator", "[pwm]")
             }
 
             CHECK(pwm.value() == Approx(20.0).margin(0.001));
-            auto durations = constrained->activeDurations(now);
+            auto durations = constrained.ptr->activeDurations(now);
             CHECK(double(durations.previousActive) / double(durations.previousPeriod) == Approx(0.2).margin(0.0001));
             AND_THEN("The stretched periods will have expected length")
             {
@@ -871,7 +873,7 @@ SCENARIO("ActuatorPWM driving mock actuator", "[pwm]")
                     now += 100;
                     pwm.update(now);
                 }
-                durations = constrained->activeDurations(now);
+                durations = constrained.ptr->activeDurations(now);
                 CHECK(durations.previousPeriod == Approx(20000).margin(2));
 
                 // finish another period
@@ -886,7 +888,7 @@ SCENARIO("ActuatorPWM driving mock actuator", "[pwm]")
                     pwm.update(now);
                 }
 
-                durations = constrained->activeDurations(now);
+                durations = constrained.ptr->activeDurations(now);
 
                 CHECK(durations.previousPeriod == Approx(20000).margin(2));
             }
@@ -895,8 +897,8 @@ SCENARIO("ActuatorPWM driving mock actuator", "[pwm]")
 
     WHEN("PWM actuator target is constrained with a minimal ON time")
     {
-        pwm.period(10000);                                                               // 10s
-        constrained->addConstraint(std::make_unique<ADConstraints::MinOnTime<2>>(2000)); // 2 s
+        pwm.period(10000);                                                                   // 10s
+        constrained.ptr->addConstraint(std::make_unique<ADConstraints::MinOnTime<2>>(2000)); // 2 s
         pwm.setting(10);
         auto nextUpdate = pwm.update(now);
         THEN("the achieved value is always correct once adjusted")
@@ -927,8 +929,8 @@ SCENARIO("ActuatorPWM driving mock actuator", "[pwm]")
     WHEN("The target actuator returns an unknown state, the value is marked invalid")
     {
         pwm.setting(10);
-        mockIo->setChannelError(1, true);
-        constrained->update(now);
+        mockIo.ptr->setChannelError(1, true);
+        constrained.ptr->update(now);
         pwm.update(now);
 
         CHECK(pwm.valueValid() == false);
@@ -967,30 +969,25 @@ SCENARIO("Two PWM actuators driving mutually exclusive digital actuators")
     auto now = ticks_millis_t(0);
     auto period = duration_millis_t(4000);
 
-    auto mockIo = std::make_shared<MockIoArray>();
-    ActuatorDigital mock1([mockIo]() { return mockIo; }, 1);
+    auto mockIo = TestControlPtr<MockIoArray>::make(new MockIoArray());
+    auto io = TestControlPtr<IoArray>::make(mockIo);
+    ActuatorDigital mock1(io, 1);
 
-    auto constrainedMock1 = std::make_shared<ActuatorDigitalConstrained>(mock1);
-    ActuatorPwm pwm1([constrainedMock1]() { return constrainedMock1; }, 4000);
+    auto constrainedMock1 = TestControlPtr<ActuatorDigitalConstrained>::make(new ActuatorDigitalConstrained(mock1));
+    ActuatorPwm pwm1(constrainedMock1, 4000);
     ActuatorAnalogConstrained constrainedPwm1(pwm1);
-    ActuatorDigital mock2([mockIo]() { return mockIo; }, 2);
-    auto constrainedMock2 = std::make_shared<ActuatorDigitalConstrained>(mock2);
-    ActuatorPwm pwm2([constrainedMock2]() { return constrainedMock2; }, 4000);
+    ActuatorDigital mock2(io, 2);
+    auto constrainedMock2 = TestControlPtr<ActuatorDigitalConstrained>::make(new ActuatorDigitalConstrained(mock2));
+    ActuatorPwm pwm2(constrainedMock2, 4000);
     ActuatorAnalogConstrained constrainedPwm2(pwm2);
 
-    auto mut = std::make_shared<MutexTarget>();
-    auto balancer = std::make_shared<Balancer<2>>();
+    auto mut = TestControlPtr<MutexTarget>::make(new MutexTarget());
+    auto balancer = TestControlPtr<Balancer<2>>::make(new Balancer<2>());
 
-    constrainedMock1->addConstraint(std::make_unique<ADConstraints::Mutex<3>>(
-        [mut]() {
-            return mut;
-        },
-        0,
-        true));
-    constrainedMock2->addConstraint(std::make_unique<ADConstraints::Mutex<3>>(
-        [mut]() {
-            return mut;
-        },
+    constrainedMock1.ptr->addConstraint(
+        std::make_unique<ADConstraints::Mutex<3>>(mut, 0, true));
+    constrainedMock2.ptr->addConstraint(std::make_unique<ADConstraints::Mutex<3>>(
+        mut,
         0,
         true));
 
@@ -1018,14 +1015,14 @@ SCENARIO("Two PWM actuators driving mutually exclusive digital actuators")
             }
             if (now >= nextUpdate3) {
                 nextUpdate3 = now + 1000;
-                balancer->update();
+                balancer.ptr->update();
             }
             now += 100;
         }
 
         constrainedPwm1.setting(duty1);
         constrainedPwm2.setting(duty2);
-        balancer->update();
+        balancer.ptr->update();
         pwm1.update(now);
         pwm2.update(now);
 
@@ -1046,7 +1043,7 @@ SCENARIO("Two PWM actuators driving mutually exclusive digital actuators")
             }
             if (now >= nextUpdate3) {
                 nextUpdate3 = now + 1000;
-                balancer->update();
+                balancer.ptr->update();
             }
             now++;
         }
@@ -1071,7 +1068,7 @@ SCENARIO("Two PWM actuators driving mutually exclusive digital actuators")
             }
             if (now >= nextUpdate3) {
                 nextUpdate3 = now + 1000;
-                balancer->update();
+                balancer.ptr->update();
                 // check that the reported value is close enough at all times
                 // CHECK(pwm1.value() == Approx(duty1).margin(1));
                 // CHECK(pwm2.value() == Approx(duty2).margin(1));
@@ -1108,8 +1105,10 @@ SCENARIO("Two PWM actuators driving mutually exclusive digital actuators")
 
     WHEN("A balancing constraint is added")
     {
-        constrainedPwm1.addConstraint(std::make_unique<AAConstraints::Balanced<2>>([balancer]() { return balancer; }));
-        constrainedPwm2.addConstraint(std::make_unique<AAConstraints::Balanced<2>>([balancer]() { return balancer; }));
+        constrainedPwm1.addConstraint(
+            std::make_unique<AAConstraints::Balanced<2>>(balancer));
+        constrainedPwm2.addConstraint(
+            std::make_unique<AAConstraints::Balanced<2>>(balancer));
 
         THEN("Achieved duty cycle matches the setting if the total is under 100")
         {
@@ -1152,9 +1151,9 @@ SCENARIO("Two PWM actuators driving mutually exclusive digital actuators")
 
             constrainedPwm1.update();
             constrainedPwm2.update();
-            balancer->update();
+            balancer.ptr->update();
 
-            CHECK(balancer->clients()[0].requested == 0);
+            CHECK(balancer.ptr->clients()[0].requested == 0);
         }
     }
 
@@ -1168,20 +1167,12 @@ SCENARIO("Two PWM actuators driving mutually exclusive digital actuators")
         pwm1.update(now);
         pwm2.update(now);
 
-        constrainedMock1->removeAllConstraints();
-        constrainedMock1->addConstraint(std::make_unique<ADConstraints::Mutex<3>>(
-            [mut]() {
-                return mut;
-            },
-            5 * period,
-            true));
-        constrainedMock2->removeAllConstraints();
-        constrainedMock2->addConstraint(std::make_unique<ADConstraints::Mutex<3>>(
-            [mut]() {
-                return mut;
-            },
-            5 * period,
-            true));
+        constrainedMock1.ptr->removeAllConstraints();
+        constrainedMock1.ptr->addConstraint(
+            std::make_unique<ADConstraints::Mutex<3>>(mut, 5 * period, true));
+        constrainedMock2.ptr->removeAllConstraints();
+        constrainedMock2.ptr->addConstraint(
+            std::make_unique<ADConstraints::Mutex<3>>(mut, 5 * period, true));
 
         auto start = now;
         auto turnOffPwm1 = now + 50 * period;
@@ -1207,20 +1198,12 @@ SCENARIO("Two PWM actuators driving mutually exclusive digital actuators")
 
     WHEN("A PWM actuator that with a blocked target is set to 100%, followed by 0%, the desired state of the target goes from high to low")
     {
-        constrainedMock1->removeAllConstraints();
-        constrainedMock1->addConstraint(std::make_unique<ADConstraints::Mutex<3>>(
-            [mut]() {
-                return mut;
-            },
-            5 * period,
-            true));
-        constrainedMock2->removeAllConstraints();
-        constrainedMock2->addConstraint(std::make_unique<ADConstraints::Mutex<3>>(
-            [mut]() {
-                return mut;
-            },
-            5 * period,
-            true));
+        constrainedMock1.ptr->removeAllConstraints();
+        constrainedMock1.ptr->addConstraint(
+            std::make_unique<ADConstraints::Mutex<3>>(mut, 5 * period, true));
+        constrainedMock2.ptr->removeAllConstraints();
+        constrainedMock2.ptr->addConstraint(
+            std::make_unique<ADConstraints::Mutex<3>>(mut, 5 * period, true));
 
         constrainedPwm1.setting(100);
         constrainedPwm2.setting(100);
@@ -1230,10 +1213,10 @@ SCENARIO("Two PWM actuators driving mutually exclusive digital actuators")
         pwm2.update(now++);
 
         // actuator 1 now holds the mutex
-        CHECK(constrainedMock1->desiredState() == State::Active);
-        CHECK(constrainedMock2->desiredState() == State::Active);
-        CHECK(constrainedMock1->state() == State::Active);
-        CHECK(constrainedMock2->state() == State::Inactive);
+        CHECK(constrainedMock1.ptr->desiredState() == State::Active);
+        CHECK(constrainedMock2.ptr->desiredState() == State::Active);
+        CHECK(constrainedMock1.ptr->state() == State::Active);
+        CHECK(constrainedMock2.ptr->state() == State::Inactive);
 
         constrainedPwm1.setting(0);
         constrainedPwm2.setting(100);
@@ -1245,10 +1228,10 @@ SCENARIO("Two PWM actuators driving mutually exclusive digital actuators")
 
         // actuator 1 still holds the mutex, due to the wait time
 
-        CHECK(constrainedMock1->desiredState() == State::Inactive);
-        CHECK(constrainedMock2->desiredState() == State::Active);
-        CHECK(constrainedMock1->state() == State::Inactive);
-        CHECK(constrainedMock2->state() == State::Inactive);
+        CHECK(constrainedMock1.ptr->desiredState() == State::Inactive);
+        CHECK(constrainedMock2.ptr->desiredState() == State::Active);
+        CHECK(constrainedMock1.ptr->state() == State::Inactive);
+        CHECK(constrainedMock2.ptr->state() == State::Inactive);
 
         constrainedPwm1.setting(0);
         constrainedPwm2.setting(0);
@@ -1259,10 +1242,10 @@ SCENARIO("Two PWM actuators driving mutually exclusive digital actuators")
         pwm2.update(now++);
 
         // actuator 1 still holds the mutex, but actuator 2 should have an updated desired state
-        CHECK(constrainedMock1->desiredState() == State::Inactive);
-        CHECK(constrainedMock2->desiredState() == State::Inactive);
-        CHECK(constrainedMock1->state() == State::Inactive);
-        CHECK(constrainedMock2->state() == State::Inactive);
+        CHECK(constrainedMock1.ptr->desiredState() == State::Inactive);
+        CHECK(constrainedMock2.ptr->desiredState() == State::Inactive);
+        CHECK(constrainedMock1.ptr->state() == State::Inactive);
+        CHECK(constrainedMock2.ptr->state() == State::Inactive);
     }
 }
 
@@ -1271,28 +1254,21 @@ SCENARIO("A PWM actuator driving a target with delayed ON and OFF time", "[pwm]"
     auto now = ticks_millis_t(0);
     auto period = duration_millis_t(4000);
 
-    auto mockIo = std::make_shared<MockIoArray>();
-    ActuatorDigital mock1([mockIo]() { return mockIo; }, 1);
+    auto mockIo = TestControlPtr<MockIoArray>::make(new MockIoArray());
+    auto io = TestControlPtr<IoArray>::make(mockIo);
+    ActuatorDigital mock1(io, 1);
 
-    auto constrainedMock1 = std::make_shared<ActuatorDigitalConstrained>(mock1);
-    ActuatorPwm pwm1([constrainedMock1]() { return constrainedMock1; }, 4000);
+    auto constrainedMock1 = TestControlPtr<ActuatorDigitalConstrained>::make(new ActuatorDigitalConstrained(mock1));
+    ActuatorPwm pwm1(constrainedMock1, 4000);
     ActuatorAnalogConstrained constrainedPwm1(pwm1);
 
-    auto mut = std::make_shared<MutexTarget>();
-    auto balancer = std::make_shared<Balancer<2>>();
+    auto mut = TestControlPtr<MutexTarget>::make(new MutexTarget());
+    auto balancer = TestControlPtr<Balancer<2>>::make(new Balancer<2>());
 
-    constrainedMock1->addConstraint(std::make_unique<ADConstraints::Mutex<3>>(
-        [mut]() {
-            return mut;
-        },
-        0,
-        true));
-    constrainedMock1->addConstraint(std::make_unique<ADConstraints::Mutex<3>>(
-        [mut]() {
-            return mut;
-        },
-        0,
-        true));
+    constrainedMock1.ptr->addConstraint(
+        std::make_unique<ADConstraints::Mutex<3>>(mut, 0, true));
+    constrainedMock1.ptr->addConstraint(
+        std::make_unique<ADConstraints::Mutex<3>>(mut, 0, true));
 
     WHEN("A PWM actuator is held back by constraints that delay toggling ON and off, the period doesn't stretch more than 3x this delay")
     {
@@ -1310,17 +1286,17 @@ SCENARIO("A PWM actuator driving a target with delayed ON and OFF time", "[pwm]"
         constrainedPwm1.update();
         pwm1.update(now);
 
-        constrainedMock1->removeAllConstraints();
-        constrainedMock1->addConstraint(std::make_unique<ADConstraints::DelayedOn<4>>(
+        constrainedMock1.ptr->removeAllConstraints();
+        constrainedMock1.ptr->addConstraint(std::make_unique<ADConstraints::DelayedOn<4>>(
             1000));
-        constrainedMock1->addConstraint(std::make_unique<ADConstraints::DelayedOff<5>>(
+        constrainedMock1.ptr->addConstraint(std::make_unique<ADConstraints::DelayedOff<5>>(
             1000));
 
         auto end = now + 100 * period;
 
         while (now <= end) {
             now = pwm1.update(now);
-            auto durations = constrainedMock1->activeDurations(now);
+            auto durations = constrainedMock1.ptr->activeDurations(now);
             REQUIRE(durations.previousPeriod <= period + 3000);
         }
     }
@@ -1330,15 +1306,16 @@ SCENARIO("ActuatorPWM driving mock DS2413 actuator", "[pwm]")
 {
     auto now = ticks_millis_t(0);
     OneWireMockDriver mockOw;
-    auto ow = std::make_shared<OneWire>(mockOw);
+    auto ow = TestControlPtr<OneWire>::make(new OneWire(mockOw));
     auto addr = OneWireAddress(0x0644'4444'4444'443A);
     auto ds2413mock = std::make_shared<DS2413Mock>(addr);
     mockOw.attach(ds2413mock); // DS2413
-    auto ds = std::make_shared<DS2413>([&ow]() { return ow; }, addr);
-    ActuatorDigital act([ds]() { return ds; }, 1);
-    ds->update(); // connected update happens here
-    auto constrained = std::make_shared<ActuatorDigitalConstrained>(act);
-    ActuatorPwm pwm([constrained]() { return constrained; }, 4000);
+    auto ds = TestControlPtr<DS2413>::make(new DS2413(ow, addr));
+    auto io = TestControlPtr<IoArray>::make(ds);
+    ActuatorDigital act(io, 1);
+    ds.ptr->update(); // connected update happens here
+    auto constrained = TestControlPtr<ActuatorDigitalConstrained>::make(new ActuatorDigitalConstrained(act));
+    ActuatorPwm pwm(constrained, 4000);
 
     WHEN("update is called without delays, the average duty cycle is correct")
     {
@@ -1368,7 +1345,7 @@ SCENARIO("ActuatorPWM driving mock DS2413 actuator", "[pwm]")
         std::generate(readBitFlips.begin(), readBitFlips.end(), nextReadFlip);
 
         auto everySecond = [&ds]() {
-            ds->update(); // reconnects happen in this object, so need to include the 1s update
+            ds.ptr->update(); // reconnects happen in this object, so need to include the 1s update
         };
 
         logger::clear();
@@ -1401,15 +1378,15 @@ SCENARIO("ActuatorPWM driving mock DS2408 motor valve", "[pwm]")
 {
     auto now = ticks_millis_t(0);
     OneWireMockDriver mockOw;
-    auto ow = std::make_shared<OneWire>(mockOw);
+    auto ow = TestControlPtr<OneWire>::make(new OneWire(mockOw));
     auto addr = OneWireAddress(0xDA55'5555'5555'5529);
     auto ds2408mock = std::make_shared<DS2408Mock>(addr);
     mockOw.attach(ds2408mock);
-    auto ds = std::make_shared<DS2408>([&ow]() { return ow; }, addr);
-    MotorValve act([ds]() { return ds; }, 1);
+    auto ds = TestControlPtr<DS2408>::make(new DS2408(ow, addr));
+    MotorValve act(ds, 1);
 
-    auto constrained = std::make_shared<ActuatorDigitalConstrained>(act);
-    ActuatorPwm pwm([constrained]() { return constrained; }, 4000);
+    auto constrained = TestControlPtr<ActuatorDigitalConstrained>::make(new ActuatorDigitalConstrained(act));
+    ActuatorPwm pwm(constrained, 4000);
 
     WHEN("update is called without delays, the average duty cycle is correct")
     {
@@ -1439,7 +1416,7 @@ SCENARIO("ActuatorPWM driving mock DS2408 motor valve", "[pwm]")
         std::generate(readBitFlips.begin(), readBitFlips.end(), nextReadFlip);
 
         auto everySecond = [&ds]() {
-            ds->update(); // reconnects happen in this object, so need to include the 1s update
+            ds.ptr->update(); // reconnects happen in this object, so need to include the 1s update
         };
 
         logger::clear();

--- a/test/control/ActuatorPwm_test.cpp
+++ b/test/control/ActuatorPwm_test.cpp
@@ -148,11 +148,11 @@ SCENARIO("ActuatorPWM driving mock actuator", "[pwm]")
 {
     auto now = ticks_millis_t(0);
 
-    auto mockIo = TestControlPtr<MockIoArray>::make(new MockIoArray());
-    auto io = TestControlPtr<IoArray>::make(mockIo);
+    auto mockIo = TestControlPtr<MockIoArray>(new MockIoArray());
+    auto io = TestControlPtr<IoArray>(mockIo);
     ActuatorDigital mock(io, 1);
 
-    auto constrained = TestControlPtr<ActuatorDigitalConstrained>::make(new ActuatorDigitalConstrained(mock));
+    auto constrained = TestControlPtr<ActuatorDigitalConstrained>(new ActuatorDigitalConstrained(mock));
     ActuatorPwm pwm(constrained, 4000);
 
     WHEN("Actuator setting is written, setting is contrained between  0-100")
@@ -969,20 +969,20 @@ SCENARIO("Two PWM actuators driving mutually exclusive digital actuators")
     auto now = ticks_millis_t(0);
     auto period = duration_millis_t(4000);
 
-    auto mockIo = TestControlPtr<MockIoArray>::make(new MockIoArray());
-    auto io = TestControlPtr<IoArray>::make(mockIo);
+    auto mockIo = TestControlPtr<MockIoArray>(new MockIoArray());
+    auto io = TestControlPtr<IoArray>(mockIo);
     ActuatorDigital mock1(io, 1);
 
-    auto constrainedMock1 = TestControlPtr<ActuatorDigitalConstrained>::make(new ActuatorDigitalConstrained(mock1));
+    auto constrainedMock1 = TestControlPtr<ActuatorDigitalConstrained>(new ActuatorDigitalConstrained(mock1));
     ActuatorPwm pwm1(constrainedMock1, 4000);
     ActuatorAnalogConstrained constrainedPwm1(pwm1);
     ActuatorDigital mock2(io, 2);
-    auto constrainedMock2 = TestControlPtr<ActuatorDigitalConstrained>::make(new ActuatorDigitalConstrained(mock2));
+    auto constrainedMock2 = TestControlPtr<ActuatorDigitalConstrained>(new ActuatorDigitalConstrained(mock2));
     ActuatorPwm pwm2(constrainedMock2, 4000);
     ActuatorAnalogConstrained constrainedPwm2(pwm2);
 
-    auto mut = TestControlPtr<MutexTarget>::make(new MutexTarget());
-    auto balancer = TestControlPtr<Balancer<2>>::make(new Balancer<2>());
+    auto mut = TestControlPtr<MutexTarget>(new MutexTarget());
+    auto balancer = TestControlPtr<Balancer<2>>(new Balancer<2>());
 
     constrainedMock1.ptr->addConstraint(
         std::make_unique<ADConstraints::Mutex<3>>(mut, 0, true));
@@ -1254,16 +1254,16 @@ SCENARIO("A PWM actuator driving a target with delayed ON and OFF time", "[pwm]"
     auto now = ticks_millis_t(0);
     auto period = duration_millis_t(4000);
 
-    auto mockIo = TestControlPtr<MockIoArray>::make(new MockIoArray());
-    auto io = TestControlPtr<IoArray>::make(mockIo);
+    auto mockIo = TestControlPtr<MockIoArray>(new MockIoArray());
+    auto io = TestControlPtr<IoArray>(mockIo);
     ActuatorDigital mock1(io, 1);
 
-    auto constrainedMock1 = TestControlPtr<ActuatorDigitalConstrained>::make(new ActuatorDigitalConstrained(mock1));
+    auto constrainedMock1 = TestControlPtr<ActuatorDigitalConstrained>(new ActuatorDigitalConstrained(mock1));
     ActuatorPwm pwm1(constrainedMock1, 4000);
     ActuatorAnalogConstrained constrainedPwm1(pwm1);
 
-    auto mut = TestControlPtr<MutexTarget>::make(new MutexTarget());
-    auto balancer = TestControlPtr<Balancer<2>>::make(new Balancer<2>());
+    auto mut = TestControlPtr<MutexTarget>(new MutexTarget());
+    auto balancer = TestControlPtr<Balancer<2>>(new Balancer<2>());
 
     constrainedMock1.ptr->addConstraint(
         std::make_unique<ADConstraints::Mutex<3>>(mut, 0, true));
@@ -1306,15 +1306,15 @@ SCENARIO("ActuatorPWM driving mock DS2413 actuator", "[pwm]")
 {
     auto now = ticks_millis_t(0);
     OneWireMockDriver mockOw;
-    auto ow = TestControlPtr<OneWire>::make(new OneWire(mockOw));
+    auto ow = TestControlPtr<OneWire>(new OneWire(mockOw));
     auto addr = OneWireAddress(0x0644'4444'4444'443A);
     auto ds2413mock = std::make_shared<DS2413Mock>(addr);
     mockOw.attach(ds2413mock); // DS2413
-    auto ds = TestControlPtr<DS2413>::make(new DS2413(ow, addr));
-    auto io = TestControlPtr<IoArray>::make(ds);
+    auto ds = TestControlPtr<DS2413>(new DS2413(ow, addr));
+    auto io = TestControlPtr<IoArray>(ds);
     ActuatorDigital act(io, 1);
     ds.ptr->update(); // connected update happens here
-    auto constrained = TestControlPtr<ActuatorDigitalConstrained>::make(new ActuatorDigitalConstrained(act));
+    auto constrained = TestControlPtr<ActuatorDigitalConstrained>(new ActuatorDigitalConstrained(act));
     ActuatorPwm pwm(constrained, 4000);
 
     WHEN("update is called without delays, the average duty cycle is correct")
@@ -1378,14 +1378,14 @@ SCENARIO("ActuatorPWM driving mock DS2408 motor valve", "[pwm]")
 {
     auto now = ticks_millis_t(0);
     OneWireMockDriver mockOw;
-    auto ow = TestControlPtr<OneWire>::make(new OneWire(mockOw));
+    auto ow = TestControlPtr<OneWire>(new OneWire(mockOw));
     auto addr = OneWireAddress(0xDA55'5555'5555'5529);
     auto ds2408mock = std::make_shared<DS2408Mock>(addr);
     mockOw.attach(ds2408mock);
-    auto ds = TestControlPtr<DS2408>::make(new DS2408(ow, addr));
+    auto ds = TestControlPtr<DS2408>(new DS2408(ow, addr));
     MotorValve act(ds, 1);
 
-    auto constrained = TestControlPtr<ActuatorDigitalConstrained>::make(new ActuatorDigitalConstrained(act));
+    auto constrained = TestControlPtr<ActuatorDigitalConstrained>(new ActuatorDigitalConstrained(act));
     ActuatorPwm pwm(constrained, 4000);
 
     WHEN("update is called without delays, the average duty cycle is correct")

--- a/test/control/OneWireMock_test.cpp
+++ b/test/control/OneWireMock_test.cpp
@@ -19,6 +19,7 @@
 
 #include <catch.hpp>
 
+#include "TestControlPtr.hpp"
 #include "control/DS18B20.hpp"
 #include "control/DS18B20Mock.hpp"
 #include "control/DS2408.hpp"
@@ -49,19 +50,19 @@ makeValidAddress(OneWireAddress addr)
 SCENARIO("A mocked OneWire bus and mocked slaves", "[onewire]")
 {
     OneWireMockDriver owMock;
-    auto ow = std::make_shared<OneWire>(owMock);
-    ow->init();
+    auto ow = TestControlPtr<OneWire>::make(new OneWire(owMock));
+    ow.ptr->init();
 
     WHEN("No devices are on the bus, reset returns false")
     {
-        CHECK(ow->reset() == false);
+        CHECK(ow.ptr->reset() == false);
     }
 
     WHEN("No devices are on the bus, search returns false")
     {
         OneWireAddress addr(0);
-        ow->reset_search();
-        CHECK(ow->search(addr) == false);
+        ow.ptr->reset_search();
+        CHECK(ow.ptr->search(addr) == false);
     }
 
     WHEN("A mock DS18B20 is attached")
@@ -71,58 +72,58 @@ SCENARIO("A mocked OneWire bus and mocked slaves", "[onewire]")
         owMock.attach(mockSensor);
         THEN("Reset returns a presence")
         {
-            CHECK(ow->reset() == true);
+            CHECK(ow.ptr->reset() == true);
         }
 
         THEN("It can be found with a bus search")
         {
             OneWireAddress addr(0);
-            ow->reset();
-            bool found = ow->search(addr);
+            ow.ptr->reset();
+            bool found = ow.ptr->search(addr);
             CHECK(found == true);
             CHECK(addr == addr1);
         }
 
         THEN("A read without issueing a command returns 0xFF")
         {
-            ow->reset();
+            ow.ptr->reset();
             uint8_t v = 0;
-            ow->read(v);
+            ow.ptr->read(v);
             CHECK(v == 0xFF);
         }
 
         THEN("An invalid command is ignored")
         {
-            ow->reset();
-            ow->write(0xFE);
+            ow.ptr->reset();
+            ow.ptr->write(0xFE);
             uint8_t v = 0;
-            ow->read(v);
+            ow.ptr->read(v);
             CHECK(v == 0xFF);
         }
 
         THEN("With a single device on the bus, a read ROM command can return its address")
         {
             OneWireAddress addr(0);
-            ow->reset();
-            ow->write(0x33);
-            ow->read_bytes(&addr[0], 8);
+            ow.ptr->reset();
+            ow.ptr->write(0x33);
+            ow.ptr->read_bytes(&addr[0], 8);
             CHECK(addr == addr1);
         }
 
         THEN("With a single device on the bus, a skip ROM command can select it without knowing the address")
         {
             OneWireAddress addr(0);
-            ow->reset();
-            ow->skip();      // skip selecting by address
-            ow->write(0xB4); // read power supply
+            ow.ptr->reset();
+            ow.ptr->skip();      // skip selecting by address
+            ow.ptr->write(0xB4); // read power supply
             uint8_t v = 0;
-            ow->read(v);
+            ow.ptr->read(v);
             CHECK(v == 0x80);
         }
 
         THEN("A OneWire sensor can use it on the fake bus")
         {
-            DS18B20 sensor([&ow]() { return ow; }, addr1);
+            DS18B20 sensor(ow, addr1);
             sensor.update();
             CHECK(sensor.valid() == false); // a reset will be detected, triggering a re-init
             sensor.update();
@@ -142,7 +143,7 @@ SCENARIO("A mocked OneWire bus and mocked slaves", "[onewire]")
 
         WHEN("The sensor is disconnected")
         {
-            DS18B20 sensor([&ow]() { return ow; }, addr1);
+            DS18B20 sensor(ow, addr1);
             mockSensor->setConnected(false);
             sensor.update();
             sensor.update();
@@ -164,7 +165,7 @@ SCENARIO("A mocked OneWire bus and mocked slaves", "[onewire]")
 
         WHEN("Communication bitflips when reading the sensor occur")
         {
-            DS18B20 sensor([&ow]() { return ow; }, addr1);
+            DS18B20 sensor(ow, addr1);
             mockSensor->setTemperature(temp_t{21.0});
             sensor.update();
             sensor.update();
@@ -193,23 +194,23 @@ SCENARIO("A mocked OneWire bus and mocked slaves", "[onewire]")
             auto mockSensor2 = std::make_shared<DS18B20Mock>(addr2);
             owMock.attach(mockSensor2);
 
-            DS18B20 sensor1([&ow]() { return ow; }, addr1);
-            DS18B20 sensor2([&ow]() { return ow; }, addr2);
+            DS18B20 sensor1(ow, addr1);
+            DS18B20 sensor2(ow, addr2);
 
             THEN("A bus search finds two sensors")
             {
                 OneWireAddress addr(0);
-                ow->reset();
-                ow->reset_search();
-                bool found = ow->search(addr);
+                ow.ptr->reset();
+                ow.ptr->reset_search();
+                bool found = ow.ptr->search(addr);
                 CHECK(found == true);
                 CHECK(addr == OneWireAddress(addr1));
 
-                found = ow->search(addr);
+                found = ow.ptr->search(addr);
                 CHECK(found == true);
                 CHECK(addr == OneWireAddress(addr2));
 
-                found = ow->search(addr);
+                found = ow.ptr->search(addr);
                 CHECK(found == false);
             }
 
@@ -240,21 +241,21 @@ SCENARIO("A mocked OneWire bus and mocked slaves", "[onewire]")
         owMock.attach(ds1mock);
         THEN("Reset returns a presence")
         {
-            CHECK(ow->reset() == true);
+            CHECK(ow.ptr->reset() == true);
         }
 
         THEN("It can be found with a bus search")
         {
             OneWireAddress addr(0);
-            ow->reset();
-            bool found = ow->search(addr);
+            ow.ptr->reset();
+            bool found = ow.ptr->search(addr);
             CHECK(found == true);
             CHECK(addr == addr3);
         }
 
         THEN("A DS2413 class can use it as output")
         {
-            DS2413 ds1([&ow]() { return ow; }, addr3);
+            DS2413 ds1(ow, addr3);
 
             ActuatorDigitalBase::State result;
             ds1.update();
@@ -285,7 +286,7 @@ SCENARIO("A mocked OneWire bus and mocked slaves", "[onewire]")
 
         THEN("A DS2413 class can use it as input")
         {
-            DS2413 ds1([&ow]() { return ow; }, addr3);
+            DS2413 ds1(ow, addr3);
             ds1.update();
 
             ActuatorDigitalBase::State result;
@@ -325,21 +326,21 @@ SCENARIO("A mocked OneWire bus and mocked slaves", "[onewire]")
         owMock.attach(ds2408mock);
         THEN("Reset returns a presence")
         {
-            CHECK(ow->reset() == true);
+            CHECK(ow.ptr->reset() == true);
         }
 
         THEN("It can be found with a bus search")
         {
             OneWireAddress addr(0);
-            ow->reset();
-            bool found = ow->search(addr);
+            ow.ptr->reset();
+            bool found = ow.ptr->search(addr);
             CHECK(found == true);
             CHECK(addr == addr4);
         }
 
         THEN("A DS2408 class can use it as output driver")
         {
-            DS2408 ds1([&ow]() { return ow; }, addr4);
+            DS2408 ds1(ow, addr4);
 
             ActuatorDigitalBase::State result;
             ds1.update();
@@ -370,7 +371,7 @@ SCENARIO("A mocked OneWire bus and mocked slaves", "[onewire]")
 
         THEN("A DS2408 class can use it as input on some pins and output on others")
         {
-            DS2408 ds1([&ow]() { return ow; }, addr4);
+            DS2408 ds1(ow, addr4);
 
             ActuatorDigitalBase::State result;
             ds1.update();
@@ -432,82 +433,82 @@ SCENARIO("A mocked OneWire bus and mocked slaves", "[onewire]")
 
         THEN("A bus search finds 5 devices")
         {
-            ow->reset_search();
+            ow.ptr->reset_search();
 
             OneWireAddress addr(0);
-            bool found = ow->search(addr);
+            bool found = ow.ptr->search(addr);
             CHECK(found == true);
             CHECK(addr == addrSensor2);
 
             addr = 0;
-            found = ow->search(addr);
+            found = ow.ptr->search(addr);
             CHECK(found == true);
             CHECK(addr == addrSensor1);
 
             addr = 0;
-            found = ow->search(addr);
+            found = ow.ptr->search(addr);
             CHECK(found == true);
             CHECK(addr == addrSensor3);
 
             addr = 0;
-            found = ow->search(addr);
+            found = ow.ptr->search(addr);
             CHECK(found == true);
             CHECK(addr == addrDS2413);
 
             addr = 0;
-            found = ow->search(addr);
+            found = ow.ptr->search(addr);
             CHECK(found == true);
             CHECK(addr == addrDS2408);
 
             addr = 0;
-            found = ow->search(addr);
+            found = ow.ptr->search(addr);
             CHECK(found == false);
             CHECK(addr == OneWireAddress(0));
         }
 
         THEN("Then target search can select only one family code to be found")
         {
-            ow->target_search(DS18B20Mock::family_code);
+            ow.ptr->target_search(DS18B20Mock::family_code);
 
             OneWireAddress addr(0);
-            bool found = ow->search(addr);
+            bool found = ow.ptr->search(addr);
             CHECK(found == true);
             CHECK(addr == addrSensor2);
 
             addr = 0;
-            found = ow->search(addr);
+            found = ow.ptr->search(addr);
             CHECK(found == true);
             CHECK(addr == addrSensor1);
 
             addr = 0;
-            found = ow->search(addr);
+            found = ow.ptr->search(addr);
             CHECK(found == true);
             CHECK(addr == addrSensor3);
 
             addr = 0;
-            found = ow->search(addr);
+            found = ow.ptr->search(addr);
             CHECK(found == false);
             CHECK(addr == OneWireAddress(0));
 
-            ow->target_search(DS2413Mock::family_code);
+            ow.ptr->target_search(DS2413Mock::family_code);
             addr = 0;
-            found = ow->search(addr);
+            found = ow.ptr->search(addr);
             CHECK(found == true);
             CHECK(addr == addrDS2413);
 
             addr = 0;
-            found = ow->search(addr);
+            found = ow.ptr->search(addr);
             CHECK(found == false);
             CHECK(addr == OneWireAddress(0));
 
-            ow->target_search(DS2408Mock::family_code);
+            ow.ptr->target_search(DS2408Mock::family_code);
             addr = 0;
-            found = ow->search(addr);
+            found = ow.ptr->search(addr);
             CHECK(found == true);
             CHECK(addr == addrDS2408);
 
             addr = 0;
-            found = ow->search(addr);
+            found = ow.ptr->search(addr);
             CHECK(found == false);
             CHECK(addr == OneWireAddress(0));
         }

--- a/test/control/OneWireMock_test.cpp
+++ b/test/control/OneWireMock_test.cpp
@@ -50,7 +50,7 @@ makeValidAddress(OneWireAddress addr)
 SCENARIO("A mocked OneWire bus and mocked slaves", "[onewire]")
 {
     OneWireMockDriver owMock;
-    auto ow = TestControlPtr<OneWire>::make(new OneWire(owMock));
+    auto ow = TestControlPtr<OneWire>(new OneWire(owMock));
     ow.ptr->init();
 
     WHEN("No devices are on the bus, reset returns false")

--- a/test/control/Pid_test.cpp
+++ b/test/control/Pid_test.cpp
@@ -35,15 +35,15 @@
 
 SCENARIO("PID Test with mock actuator", "[pid]")
 {
-    auto sensorMock = TestControlPtr<TempSensorMock>::make(new TempSensorMock(20.0));
-    auto sensor = TestControlPtr<TempSensor>::make(sensorMock);
+    auto sensorMock = TestControlPtr<TempSensorMock>(new TempSensorMock(20.0));
+    auto sensor = TestControlPtr<TempSensor>(sensorMock);
 
-    auto setpoint = TestControlPtr<SetpointSensorPair>::make(new SetpointSensorPair(sensor));
+    auto setpoint = TestControlPtr<SetpointSensorPair>(new SetpointSensorPair(sensor));
     setpoint.ptr->setting(20);
     setpoint.ptr->settingValid(true);
 
-    auto actuatorMock = TestControlPtr<ActuatorAnalogMock>::make(new ActuatorAnalogMock());
-    auto actuator = TestControlPtr<ProcessValue<Pid::out_t>>::make(actuatorMock);
+    auto actuatorMock = TestControlPtr<ActuatorAnalogMock>(new ActuatorAnalogMock());
+    auto actuator = TestControlPtr<ProcessValue<Pid::out_t>>(actuatorMock);
 
     Pid pid(setpoint, actuator);
     pid.enabled(true);
@@ -445,23 +445,23 @@ SCENARIO("PID Test with mock actuator", "[pid]")
 
 SCENARIO("PID Test with offset actuator", "[pid]")
 {
-    auto sensorMock = TestControlPtr<TempSensorMock>::make(new TempSensorMock(65.0));
-    auto referenceMock = TestControlPtr<TempSensorMock>::make(new TempSensorMock(65.0));
+    auto sensorMock = TestControlPtr<TempSensorMock>(new TempSensorMock(65.0));
+    auto referenceMock = TestControlPtr<TempSensorMock>(new TempSensorMock(65.0));
 
     // auto targetSensorPtr = TestControlPtr(std::static_pointer_cast<TempSensor>(targetSensor));
-    auto targetSensor = TestControlPtr<TempSensor>::make(sensorMock);
-    auto referenceSensor = TestControlPtr<TempSensor>::make(referenceMock);
+    auto targetSensor = TestControlPtr<TempSensor>(sensorMock);
+    auto referenceSensor = TestControlPtr<TempSensor>(referenceMock);
 
-    auto target = TestControlPtr<SetpointSensorPair>::make(new SetpointSensorPair(targetSensor));
+    auto target = TestControlPtr<SetpointSensorPair>(new SetpointSensorPair(targetSensor));
     target.ptr->setting(65);
     target.ptr->settingValid(true);
 
-    auto reference = TestControlPtr<SetpointSensorPair>::make(new SetpointSensorPair(referenceSensor));
+    auto reference = TestControlPtr<SetpointSensorPair>(new SetpointSensorPair(referenceSensor));
     reference.ptr->setting(67);
     reference.ptr->settingValid(true);
 
-    auto actuator = TestControlPtr<ActuatorOffset>::make(new ActuatorOffset(target, reference));
-    auto output = TestControlPtr<ProcessValue<Pid::out_t>>::make(actuator);
+    auto actuator = TestControlPtr<ActuatorOffset>(new ActuatorOffset(target, reference));
+    auto output = TestControlPtr<ProcessValue<Pid::out_t>>(actuator);
 
     Pid pid(reference, output);
     pid.enabled(true);
@@ -546,24 +546,24 @@ SCENARIO("PID Test with offset actuator", "[pid]")
 SCENARIO("PID Test with PWM actuator", "[pid]")
 {
     auto now = ticks_millis_t(0);
-    auto sensorMock = TestControlPtr<TempSensorMock>::make(new TempSensorMock(20.0));
-    auto sensor = TestControlPtr<TempSensor>::make(sensorMock);
+    auto sensorMock = TestControlPtr<TempSensorMock>(new TempSensorMock(20.0));
+    auto sensor = TestControlPtr<TempSensor>(sensorMock);
 
-    auto setpoint = TestControlPtr<SetpointSensorPair>::make(new SetpointSensorPair(sensor));
+    auto setpoint = TestControlPtr<SetpointSensorPair>(new SetpointSensorPair(sensor));
     setpoint.ptr->settingValid(true);
     setpoint.ptr->setting(20);
     setpoint.ptr->filterChoice(1);
     setpoint.ptr->filterThreshold(5);
 
-    auto mockIo = TestControlPtr<MockIoArray>::make(new MockIoArray());
-    auto io = TestControlPtr<IoArray>::make(mockIo);
+    auto mockIo = TestControlPtr<MockIoArray>(new MockIoArray());
+    auto io = TestControlPtr<IoArray>(mockIo);
     ActuatorDigital mock(io, 1);
-    auto constrainedDigital = TestControlPtr<ActuatorDigitalConstrained>::make(new ActuatorDigitalConstrained(mock));
+    auto constrainedDigital = TestControlPtr<ActuatorDigitalConstrained>(new ActuatorDigitalConstrained(mock));
 
     ActuatorPwm pwm(constrainedDigital, 4000);
 
-    auto actuator = TestControlPtr<ActuatorAnalogConstrained>::make(new ActuatorAnalogConstrained(pwm));
-    auto output = TestControlPtr<ProcessValue<Pid::out_t>>::make(actuator);
+    auto actuator = TestControlPtr<ActuatorAnalogConstrained>(new ActuatorAnalogConstrained(pwm));
+    auto output = TestControlPtr<ProcessValue<Pid::out_t>>(actuator);
     Pid pid(setpoint, output);
 
     pid.enabled(true);

--- a/test/control/SetpointProfile_test.cpp
+++ b/test/control/SetpointProfile_test.cpp
@@ -28,8 +28,8 @@
 
 SCENARIO("SetpointProfile test", "[SetpointProfile]")
 {
-    auto sensor = TestControlPtr<TempSensor>::make(new TempSensorMock(20.0));
-    auto setpoint = TestControlPtr<SetpointSensorPair>::make(new SetpointSensorPair(sensor));
+    auto sensor = TestControlPtr<TempSensor>(new TempSensorMock(20.0));
+    auto setpoint = TestControlPtr<SetpointSensorPair>(new SetpointSensorPair(sensor));
     setpoint.ptr->setting(99);
     setpoint.ptr->settingValid(true);
     SetpointProfile profile(setpoint);

--- a/test/control/SetpointProfile_test.cpp
+++ b/test/control/SetpointProfile_test.cpp
@@ -19,6 +19,7 @@
 
 #include <catch.hpp>
 
+#include "TestControlPtr.hpp"
 #include "control/SetpointProfile.hpp"
 #include "control/SetpointSensorPair.hpp"
 #include "control/TempSensorMock.hpp"
@@ -27,20 +28,20 @@
 
 SCENARIO("SetpointProfile test", "[SetpointProfile]")
 {
-    auto sensor = std::make_shared<TempSensorMock>(20.0);
-    auto sspair = std::make_shared<SetpointSensorPair>([sensor]() { return sensor; });
-    sspair->setting(99);
-    sspair->settingValid(true);
-    SetpointProfile profile([&sspair]() { return sspair; });
+    auto sensor = TestControlPtr<TempSensor>::make(new TempSensorMock(20.0));
+    auto setpoint = TestControlPtr<SetpointSensorPair>::make(new SetpointSensorPair(sensor));
+    setpoint.ptr->setting(99);
+    setpoint.ptr->settingValid(true);
+    SetpointProfile profile(setpoint);
 
     WHEN("the profile has no values, it does not change the setpoint")
     {
-        CHECK(sspair->setting() == Approx(99).margin(0.001));
+        CHECK(setpoint.ptr->setting() == Approx(99).margin(0.001));
         CHECK(profile.isDriving() == false);
 
         profile.update(0);
 
-        CHECK(sspair->setting() == Approx(99).margin(0.001));
+        CHECK(setpoint.ptr->setting() == Approx(99).margin(0.001));
         CHECK(profile.isDriving() == false);
     }
 
@@ -55,10 +56,10 @@ SCENARIO("SetpointProfile test", "[SetpointProfile]")
             THEN("The profile doesn't change the setpoint, but does indicate it as driving")
             {
                 profile.update(1);
-                CHECK(sspair->setting() == Approx(99).margin(0.001));
+                CHECK(setpoint.ptr->setting() == Approx(99).margin(0.001));
                 CHECK(profile.isDriving() == true);
                 profile.update(5);
-                CHECK(sspair->setting() == Approx(99).margin(0.001));
+                CHECK(setpoint.ptr->setting() == Approx(99).margin(0.001));
                 CHECK(profile.isDriving() == true);
             }
         }
@@ -67,7 +68,7 @@ SCENARIO("SetpointProfile test", "[SetpointProfile]")
             profile.update(2000);
             THEN("The profile sets the setpoint to this value")
             {
-                CHECK(sspair->setting() == Approx(10).margin(0.001));
+                CHECK(setpoint.ptr->setting() == Approx(10).margin(0.001));
                 CHECK(profile.isDriving() == true);
             }
         }
@@ -82,36 +83,36 @@ SCENARIO("SetpointProfile test", "[SetpointProfile]")
         AND_WHEN("The time is before the first point, it doesn't change the setpoint, but it is shown as driving")
         {
             profile.update(5);
-            CHECK(sspair->setting() == Approx(99).margin(0.001));
+            CHECK(setpoint.ptr->setting() == Approx(99).margin(0.001));
             CHECK(profile.isDriving() == true);
         }
 
         AND_WHEN("The time is after the last point, the last temp is used")
         {
             profile.update(22);
-            CHECK(sspair->setting() == Approx(20).margin(0.001));
+            CHECK(setpoint.ptr->setting() == Approx(20).margin(0.001));
             CHECK(profile.isDriving() == true);
         }
 
         AND_WHEN("The time between the 2 points, it is correctly interpolated")
         {
             profile.update(12);
-            CHECK(sspair->setting() == Approx(11).margin(0.001));
+            CHECK(setpoint.ptr->setting() == Approx(11).margin(0.001));
             CHECK(profile.isDriving() == true);
 
             profile.update(16);
-            CHECK(sspair->setting() == Approx(15).margin(0.001));
+            CHECK(setpoint.ptr->setting() == Approx(15).margin(0.001));
             CHECK(profile.isDriving() == true);
         }
 
         AND_WHEN("The time is exactly at a point, that temp is used")
         {
             profile.update(11);
-            CHECK(sspair->setting() == Approx(10).margin(0.001));
+            CHECK(setpoint.ptr->setting() == Approx(10).margin(0.001));
             CHECK(profile.isDriving() == true);
 
             profile.update(21);
-            CHECK(sspair->setting() == Approx(20).margin(0.001));
+            CHECK(setpoint.ptr->setting() == Approx(20).margin(0.001));
             CHECK(profile.isDriving() == true);
         }
     }
@@ -126,48 +127,48 @@ SCENARIO("SetpointProfile test", "[SetpointProfile]")
         AND_WHEN("The time is before the first point, it doesn't change the setpoint but is indicated as driving")
         {
             profile.update(5);
-            CHECK(sspair->setting() == Approx(99).margin(0.001));
+            CHECK(setpoint.ptr->setting() == Approx(99).margin(0.001));
             CHECK(profile.isDriving() == true);
         }
 
         AND_WHEN("The time is after the last point, the last temp is used")
         {
             profile.update(32);
-            CHECK(sspair->setting() == Approx(40).margin(0.001));
+            CHECK(setpoint.ptr->setting() == Approx(40).margin(0.001));
             CHECK(profile.isDriving() == true);
         }
 
         AND_WHEN("The time between the 2 points, it is correctly interpolated")
         {
             profile.update(12);
-            CHECK(sspair->setting() == Approx(11).margin(0.001));
+            CHECK(setpoint.ptr->setting() == Approx(11).margin(0.001));
             CHECK(profile.isDriving() == true);
 
             profile.update(16);
-            CHECK(sspair->setting() == Approx(15).margin(0.001));
+            CHECK(setpoint.ptr->setting() == Approx(15).margin(0.001));
             CHECK(profile.isDriving() == true);
 
             profile.update(22);
-            CHECK(sspair->setting() == Approx(22).margin(0.001));
+            CHECK(setpoint.ptr->setting() == Approx(22).margin(0.001));
             CHECK(profile.isDriving() == true);
 
             profile.update(30);
-            CHECK(sspair->setting() == Approx(38).margin(0.001));
+            CHECK(setpoint.ptr->setting() == Approx(38).margin(0.001));
             CHECK(profile.isDriving() == true);
         }
 
         AND_WHEN("The time is exactly at a point, that temp is used")
         {
             profile.update(11);
-            CHECK(sspair->setting() == Approx(10).margin(0.001));
+            CHECK(setpoint.ptr->setting() == Approx(10).margin(0.001));
             CHECK(profile.isDriving() == true);
 
             profile.update(21);
-            CHECK(sspair->setting() == Approx(20).margin(0.001));
+            CHECK(setpoint.ptr->setting() == Approx(20).margin(0.001));
             CHECK(profile.isDriving() == true);
 
             profile.update(31);
-            CHECK(sspair->setting() == Approx(40).margin(0.001));
+            CHECK(setpoint.ptr->setting() == Approx(40).margin(0.001));
             CHECK(profile.isDriving() == true);
         }
     }
@@ -183,18 +184,18 @@ SCENARIO("SetpointProfile test", "[SetpointProfile]")
         AND_WHEN("The time is before the step, it is correctly interpolated with the first point of the step")
         {
             profile.update(12);
-            CHECK(sspair->setting() == Approx(11).margin(0.001));
+            CHECK(setpoint.ptr->setting() == Approx(11).margin(0.001));
             CHECK(profile.isDriving() == true);
 
             profile.update(16);
-            CHECK(sspair->setting() == Approx(15).margin(0.001));
+            CHECK(setpoint.ptr->setting() == Approx(15).margin(0.001));
             CHECK(profile.isDriving() == true);
         }
 
         AND_WHEN("The time is at the step (rounded down to whole seconds), it is equal to the last point of the step")
         {
             profile.update(21);
-            CHECK(sspair->setting() == Approx(30).margin(0.001));
+            CHECK(setpoint.ptr->setting() == Approx(30).margin(0.001));
             ;
             CHECK(profile.isDriving() == true);
         }
@@ -203,11 +204,11 @@ SCENARIO("SetpointProfile test", "[SetpointProfile]")
         {
 
             profile.update(22);
-            CHECK(sspair->setting() == Approx(31).margin(0.001));
+            CHECK(setpoint.ptr->setting() == Approx(31).margin(0.001));
             CHECK(profile.isDriving() == true);
 
             profile.update(31);
-            CHECK(sspair->setting() == Approx(40).margin(0.001));
+            CHECK(setpoint.ptr->setting() == Approx(40).margin(0.001));
             ;
             CHECK(profile.isDriving() == true);
         }
@@ -220,7 +221,7 @@ SCENARIO("SetpointProfile test", "[SetpointProfile]")
         profile.addPoint(SetpointProfile::Point{utc_seconds_t(11), temp_t(20)});
 
         profile.update(0);
-        CHECK(sspair->setting() == Approx(99).margin(0.001));
+        CHECK(setpoint.ptr->setting() == Approx(99).margin(0.001));
         ;
 
         CHECK(profile.isDriving() == true);

--- a/test/control/SetpointSensorPair_test.cpp
+++ b/test/control/SetpointSensorPair_test.cpp
@@ -17,6 +17,7 @@
  * along with BrewPi.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include "TestControlPtr.hpp"
 #include "control/SetpointSensorPair.hpp"
 #include "control/TempSensorMock.hpp"
 #include <catch.hpp>
@@ -26,13 +27,10 @@ SCENARIO("SetpointSensorPair test")
 {
     WHEN("A SetpointSensorPair is constructed")
     {
-        // create with make_shared to adhere to the expected interface of the pair
-        // usually the lookup functions are some sort of weak_pointers, we now use a simple lambda
-        auto sensor = std::make_shared<TempSensorMock>(21.0);
+        auto sensor = TestControlPtr<TempSensor>::make(new TempSensorMock(21.0));
+        SetpointSensorPair setpoint(sensor);
 
-        SetpointSensorPair pair([sensor]() { return sensor; });
-
-        CHECK(pair.setting() == 20.0);
-        CHECK(pair.value() == 21.0);
+        CHECK(setpoint.setting() == 20.0);
+        CHECK(setpoint.value() == 21.0);
     }
 }

--- a/test/control/SetpointSensorPair_test.cpp
+++ b/test/control/SetpointSensorPair_test.cpp
@@ -27,7 +27,7 @@ SCENARIO("SetpointSensorPair test")
 {
     WHEN("A SetpointSensorPair is constructed")
     {
-        auto sensor = TestControlPtr<TempSensor>::make(new TempSensorMock(21.0));
+        auto sensor = TestControlPtr<TempSensor>(new TempSensorMock(21.0));
         SetpointSensorPair setpoint(sensor);
 
         CHECK(setpoint.setting() == 20.0);

--- a/test/control/TempSensorCombi_test.cpp
+++ b/test/control/TempSensorCombi_test.cpp
@@ -61,7 +61,10 @@ SCENARIO("TempSensorCombiTest", "[TempSensorCombi]")
         auto input3 = TestControlPtr<TempSensor>(mock3);
         auto input4 = TestControlPtr<TempSensor>(mock4);
 
-        combined.inputs = {&input1, &input2, &input3, &input4};
+        combined.inputs = {std::ref(input1),
+                           std::ref(input2),
+                           std::ref(input3),
+                           std::ref(input4)};
 
         THEN("The average is returned when AVG is selected")
         {

--- a/test/control/TempSensorCombi_test.cpp
+++ b/test/control/TempSensorCombi_test.cpp
@@ -19,6 +19,7 @@
 
 #include <catch.hpp>
 
+#include "TestControlPtr.hpp"
 #include "control/TempSensorCombi.hpp"
 #include "control/TempSensorMock.hpp"
 
@@ -50,17 +51,17 @@ SCENARIO("TempSensorCombiTest", "[TempSensorCombi]")
     WHEN("4 sensors are added to the combi sensor")
     {
         TempSensorCombi combined;
-        auto mock1 = std::make_shared<TempSensorMock>(20);
-        auto mock2 = std::make_shared<TempSensorMock>(18);
-        auto mock3 = std::make_shared<TempSensorMock>(26);
-        auto mock4 = std::make_shared<TempSensorMock>(22);
-        combined.inputs = {
-            [mock1]() { return mock1; },
-            [mock2]() { return mock2; },
-            [mock3]() { return mock3; },
-            [mock4]() { return mock4; },
+        auto mock1 = TestControlPtr<TempSensorMock>::make(new TempSensorMock(20));
+        auto mock2 = TestControlPtr<TempSensorMock>::make(new TempSensorMock(18));
+        auto mock3 = TestControlPtr<TempSensorMock>::make(new TempSensorMock(26));
+        auto mock4 = TestControlPtr<TempSensorMock>::make(new TempSensorMock(22));
 
-        };
+        auto input1 = TestControlPtr<TempSensor>::make(mock1);
+        auto input2 = TestControlPtr<TempSensor>::make(mock2);
+        auto input3 = TestControlPtr<TempSensor>::make(mock3);
+        auto input4 = TestControlPtr<TempSensor>::make(mock4);
+
+        combined.inputs = {&input1, &input2, &input3, &input4};
 
         THEN("The average is returned when AVG is selected")
         {
@@ -88,8 +89,8 @@ SCENARIO("TempSensorCombiTest", "[TempSensorCombi]")
 
         AND_WHEN("2 of the 4 sensors are not valid, they are ignored")
         {
-            mock2->connected(false);
-            mock3->connected(false);
+            mock2.ptr->connected(false);
+            mock3.ptr->connected(false);
 
             THEN("The average is returned when AVG is selected")
             {

--- a/test/control/TempSensorCombi_test.cpp
+++ b/test/control/TempSensorCombi_test.cpp
@@ -51,15 +51,15 @@ SCENARIO("TempSensorCombiTest", "[TempSensorCombi]")
     WHEN("4 sensors are added to the combi sensor")
     {
         TempSensorCombi combined;
-        auto mock1 = TestControlPtr<TempSensorMock>::make(new TempSensorMock(20));
-        auto mock2 = TestControlPtr<TempSensorMock>::make(new TempSensorMock(18));
-        auto mock3 = TestControlPtr<TempSensorMock>::make(new TempSensorMock(26));
-        auto mock4 = TestControlPtr<TempSensorMock>::make(new TempSensorMock(22));
+        auto mock1 = TestControlPtr<TempSensorMock>(new TempSensorMock(20));
+        auto mock2 = TestControlPtr<TempSensorMock>(new TempSensorMock(18));
+        auto mock3 = TestControlPtr<TempSensorMock>(new TempSensorMock(26));
+        auto mock4 = TestControlPtr<TempSensorMock>(new TempSensorMock(22));
 
-        auto input1 = TestControlPtr<TempSensor>::make(mock1);
-        auto input2 = TestControlPtr<TempSensor>::make(mock2);
-        auto input3 = TestControlPtr<TempSensor>::make(mock3);
-        auto input4 = TestControlPtr<TempSensor>::make(mock4);
+        auto input1 = TestControlPtr<TempSensor>(mock1);
+        auto input2 = TestControlPtr<TempSensor>(mock2);
+        auto input3 = TestControlPtr<TempSensor>(mock3);
+        auto input4 = TestControlPtr<TempSensor>(mock4);
 
         combined.inputs = {&input1, &input2, &input3, &input4};
 

--- a/test/control/makefile
+++ b/test/control/makefile
@@ -23,7 +23,30 @@ INCLUDE_DIRS += $(ROOT_DIR)/test/shared
 CPPSRC += test/shared/AppLogger.cpp
 
 # test/control
-CPPSRC += $(wildcard $(ROOT_DIR)/test/control/*.cpp)
+CPPSRC += $(ROOT_DIR)/test/control/runner.cpp
+CPPSRC += $(ROOT_DIR)/test/control/ActuatorAnalogConstrained_test.cpp
+CPPSRC += $(ROOT_DIR)/test/control/ActuatorAnalogMock_test.cpp
+CPPSRC += $(ROOT_DIR)/test/control/ActuatorDigitalChangeLogged_test.cpp
+CPPSRC += $(ROOT_DIR)/test/control/ActuatorDigitalConstrained_test.cpp
+CPPSRC += $(ROOT_DIR)/test/control/ActuatorOffset_test.cpp
+CPPSRC += $(ROOT_DIR)/test/control/ActuatorPwm_test.cpp
+CPPSRC += $(ROOT_DIR)/test/control/ADS124S08_test.cpp
+CPPSRC += $(ROOT_DIR)/test/control/FilterChain_test.cpp
+CPPSRC += $(ROOT_DIR)/test/control/FixedPoint_test.cpp
+CPPSRC += $(ROOT_DIR)/test/control/FpFilterChain_test.cpp
+CPPSRC += $(ROOT_DIR)/test/control/hal_spi_test.cpp
+CPPSRC += $(ROOT_DIR)/test/control/IiFilter_test.cpp
+CPPSRC += $(ROOT_DIR)/test/control/IntervalHelperTest.cpp
+CPPSRC += $(ROOT_DIR)/test/control/OneWireMock_test.cpp
+CPPSRC += $(ROOT_DIR)/test/control/Pid_test.cpp
+CPPSRC += $(ROOT_DIR)/test/control/ringBuffer_test.cpp
+CPPSRC += $(ROOT_DIR)/test/control/SetpointProfile_test.cpp
+CPPSRC += $(ROOT_DIR)/test/control/SetpointSensorPair_test.cpp
+CPPSRC += $(ROOT_DIR)/test/control/staticAllocator_test.cpp
+CPPSRC += $(ROOT_DIR)/test/control/Temperature_to_string_test.cpp
+CPPSRC += $(ROOT_DIR)/test/control/TempSensorCombi_test.cpp
+CPPSRC += $(ROOT_DIR)/test/control/TempSensorMock_test.cpp
+
 
 CFLAGS += -DPLATFORM_ID=3
 

--- a/test/shared/TestControlPtr.hpp
+++ b/test/shared/TestControlPtr.hpp
@@ -1,0 +1,64 @@
+#pragma once
+
+#include "control/ControlPtr.hpp"
+
+/**
+ * Simple implementation of ControlPtr that allows for easy initialization
+ * and access to the backing shared_ptr.
+ *
+ * TestControlPtr is constructed using the make() factory function.
+ * make() accepts one of three overloads:
+ * - A raw pointer. TestControlPtr will take ownership, and wrap it in a shared_ptr.
+ * - A shared pointer. This will be statically cast to shared_ptr<T> and copied.
+ * - Another TestControlPtr. The ptr member will be statically cast to shared_ptr<T> and copied.
+ *
+ * With this approach, new objects are created from raw pointers,
+ * and previously shared pointers can be mirrored with a different (but compatible) type.
+ *
+ *     TestControlPtr<Derived> derived = TestControlPtr<Derived>::make(new Derived());
+ *     TestControlPtr<Base> base = TestControlPtr<Base>::make(derived);
+ *
+ * In the above snippet, we now have one unique `Derived` object,
+ * tracked by a shared_ptr<Derived>, and a shared_ptr<Base>.
+ *
+ */
+template <typename T>
+class TestControlPtr final : public ControlPtr<T> {
+public:
+    std::shared_ptr<T> ptr;
+
+protected:
+    TestControlPtr(std::shared_ptr<T>&& ptr_)
+        : ptr(ptr_)
+    {
+    }
+
+public:
+    std::shared_ptr<T> lock() override
+    {
+        return ptr;
+    }
+
+    std::shared_ptr<const T> lock() const override
+    {
+        return ptr;
+    }
+
+    template <typename SrcT>
+    static TestControlPtr<T> make(SrcT* arg)
+    {
+        return TestControlPtr<T>(std::shared_ptr<T>(arg));
+    }
+
+    template <typename SrcT>
+    static TestControlPtr<T> make(std::shared_ptr<SrcT>& arg)
+    {
+        return TestControlPtr<T>(std::static_pointer_cast<T>(arg));
+    }
+
+    template <typename SrcT>
+    static TestControlPtr<T> make(TestControlPtr<SrcT>& arg)
+    {
+        return TestControlPtr<T>(std::static_pointer_cast<T>(arg.ptr));
+    }
+};

--- a/test/shared/TestControlPtr.hpp
+++ b/test/shared/TestControlPtr.hpp
@@ -2,38 +2,34 @@
 
 #include "control/ControlPtr.hpp"
 
-/**
- * Simple implementation of ControlPtr that allows for easy initialization
- * and access to the backing shared_ptr.
- *
- * TestControlPtr is constructed using the make() factory function.
- * make() accepts one of three overloads:
- * - A raw pointer. TestControlPtr will take ownership, and wrap it in a shared_ptr.
- * - A shared pointer. This will be statically cast to shared_ptr<T> and copied.
- * - Another TestControlPtr. The ptr member will be statically cast to shared_ptr<T> and copied.
- *
- * With this approach, new objects are created from raw pointers,
- * and previously shared pointers can be mirrored with a different (but compatible) type.
- *
- *     TestControlPtr<Derived> derived = TestControlPtr<Derived>::make(new Derived());
- *     TestControlPtr<Base> base = TestControlPtr<Base>::make(derived);
- *
- * In the above snippet, we now have one unique `Derived` object,
- * tracked by a shared_ptr<Derived>, and a shared_ptr<Base>.
- *
- */
 template <typename T>
 class TestControlPtr final : public ControlPtr<T> {
 public:
     std::shared_ptr<T> ptr;
 
-protected:
-    TestControlPtr(std::shared_ptr<T>&& ptr_)
-        : ptr(ptr_)
+    TestControlPtr<T>(T* arg)
+        : ptr(std::shared_ptr<T>(arg))
     {
     }
 
-public:
+    template <typename SrcT>
+    TestControlPtr<T>(SrcT* arg)
+        : ptr(std::shared_ptr<T>(arg))
+    {
+    }
+
+    template <typename SrcT>
+    TestControlPtr<T>(std::shared_ptr<SrcT> arg)
+        : ptr(std::static_pointer_cast<T>(std::move(arg)))
+    {
+    }
+
+    template <typename SrcT>
+    TestControlPtr<T>(const TestControlPtr<SrcT>& arg)
+        : ptr(std::static_pointer_cast<T>(arg.ptr))
+    {
+    }
+
     std::shared_ptr<T> lock() override
     {
         return ptr;
@@ -42,23 +38,5 @@ public:
     std::shared_ptr<const T> lock() const override
     {
         return ptr;
-    }
-
-    template <typename SrcT>
-    static TestControlPtr<T> make(SrcT* arg)
-    {
-        return TestControlPtr<T>(std::shared_ptr<T>(arg));
-    }
-
-    template <typename SrcT>
-    static TestControlPtr<T> make(std::shared_ptr<SrcT>& arg)
-    {
-        return TestControlPtr<T>(std::static_pointer_cast<T>(arg));
-    }
-
-    template <typename SrcT>
-    static TestControlPtr<T> make(TestControlPtr<SrcT>& arg)
-    {
-        return TestControlPtr<T>(std::static_pointer_cast<T>(arg.ptr));
     }
 };

--- a/test/shared/TestObjects.hpp
+++ b/test/shared/TestObjects.hpp
@@ -289,8 +289,8 @@ public:
             return cbox::CboxError::NETWORK_WRITE_ERROR;
         }
 
-        auto sptr1 = ptr1.const_lock();
-        auto sptr2 = ptr2.const_lock();
+        auto sptr1 = ptr1.lock();
+        auto sptr2 = ptr2.lock();
         bool valid1 = bool(sptr1);
         bool valid2 = bool(sptr2);
         uint32_t value1 = 0;


### PR DESCRIPTION
- control / blocks implementation of ControlPtr
- use ActuatorAnalog as output type in Pid
- update control tests to use ControlPtr
- use ProcessValue<Pid::out_t> as PID output ptr
