### PR TITLE
code quality improvements for onewire search

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -25,6 +25,7 @@
     "huizhou.githd",
     "letmaik.git-tree-compare",
     "foxundermoon.shell-format",
+    "GitHub.vscode-pull-request-github",
   ],
   // Use 'forwardPorts' to make a list of ports inside the container available locally.
   // "forwardPorts": [],

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -60,5 +60,9 @@
   "[dockerfile]": {
     "editor.formatOnSave": false
   },
-  "remote.localPortHost": "allInterfaces"
+  "remote.localPortHost": "allInterfaces",
+  "disasexpl.associations": {
+    "**/*.c": "${workspaceFolder}/build/target/user/platform-8-m/firmware/${relativeFileDirname}/${fileBasenameNoExtension}.s",
+    "**/*.cpp": "${workspaceFolder}/build/target/user/platform-8-m/firmware/${relativeFileDirname}/${fileBasenameNoExtension}.s"
+  },
 }

--- a/app/brewblox-esp/main/I2cScanningFactory.cpp
+++ b/app/brewblox-esp/main/I2cScanningFactory.cpp
@@ -35,7 +35,7 @@ uint8_t find_next(uint8_t lastAddress)
         if (!err) {
             uint8_t pos = (address & uint8_t{0x3}) + 1;
             auto samePosition = [&pos](const std::shared_ptr<cbox::Object>& obj) {
-                if (auto ptr = cbox::asInterface<IoModule>(obj)) {
+                if (auto ptr = obj->asInterface<IoModule>()) {
                     return ptr->modulePosition() == pos;
                 };
                 return false;

--- a/app/brewblox-esp/main/blocks/ExpOwGpioBlock.cpp
+++ b/app/brewblox-esp/main/blocks/ExpOwGpioBlock.cpp
@@ -131,7 +131,7 @@ ExpOwGpioBlock::updateHandler(const cbox::update_t& now)
 
 void* ExpOwGpioBlock::implements(cbox::obj_type_t iface)
 {
-    if (iface == brewblox_BlockType_OneWireGpioModule) {
+    if (iface == staticTypeId()) {
         return this; // me!
     }
 

--- a/lib/blocks/CMakeLists.txt
+++ b/lib/blocks/CMakeLists.txt
@@ -17,6 +17,7 @@ idf_component_register(
     src/MotorValveBlock.cpp
     src/MutexBlock.cpp
     src/OneWireBusBlock.cpp
+    src/OneWireScanningFactory.cpp
     src/PidBlock.cpp
     src/SetpointProfileBlock.cpp
     src/SetpointSensorPairBlock.cpp

--- a/lib/blocks/inc/blocks/DS2408Block.hpp
+++ b/lib/blocks/inc/blocks/DS2408Block.hpp
@@ -44,9 +44,9 @@ public:
     {
     }
 
-    DS2408Block(cbox::obj_id_t busId, const OneWireAddress& addr)
+    DS2408Block(cbox::obj_id_t busId, OneWireAddress addr)
         : OneWireDeviceBlock(busId)
-        , device(owBus, addr)
+        , device(owBus, std::move(addr))
     {
     }
 

--- a/lib/blocks/inc/blocks/DS2413Block.hpp
+++ b/lib/blocks/inc/blocks/DS2413Block.hpp
@@ -42,9 +42,9 @@ public:
     {
     }
 
-    DS2413Block(cbox::obj_id_t busId, const OneWireAddress& addr)
+    DS2413Block(cbox::obj_id_t busId, OneWireAddress addr)
         : OneWireDeviceBlock(busId)
-        , device(owBus, addr)
+        , device(owBus, std::move(addr))
     {
     }
 

--- a/lib/blocks/inc/blocks/OneWireDeviceBlock.hpp
+++ b/lib/blocks/inc/blocks/OneWireDeviceBlock.hpp
@@ -19,7 +19,7 @@ public:
     {
     }
 
-    cbox::obj_id_t getBusId()
+    cbox::obj_id_t getBusId() const
     {
         return owBus.getId();
     }

--- a/lib/blocks/inc/blocks/OneWireMultiScanningFactory.hpp
+++ b/lib/blocks/inc/blocks/OneWireMultiScanningFactory.hpp
@@ -35,7 +35,7 @@ public:
     virtual std::shared_ptr<cbox::Object> scan() override final
     {
         for (auto obj_it = cbox::objects.cbegin(); obj_it != cbox::objects.cend(); ++obj_it) {
-            if (cbox::asInterface<OneWire>(*obj_it) == nullptr) {
+            if ((*obj_it)->asInterface<OneWire>() == nullptr) {
                 continue; // not a OneWire bus
             }
             // use a bus scanner to find new devices on this bus

--- a/lib/blocks/inc/blocks/OneWireMultiScanningFactory.hpp
+++ b/lib/blocks/inc/blocks/OneWireMultiScanningFactory.hpp
@@ -21,6 +21,7 @@
 
 #include "OneWireScanningFactory.hpp"
 #include "cbox/Application.hpp"
+#include "cbox/Box.hpp"
 #include "cbox/CboxPtr.hpp"
 
 class OneWireMultiScanningFactory : public cbox::ScanningFactory {

--- a/lib/blocks/inc/blocks/OneWireMultiScanningFactory.hpp
+++ b/lib/blocks/inc/blocks/OneWireMultiScanningFactory.hpp
@@ -45,6 +45,6 @@ public:
             }
             // go to next bus
         }
-        return nullptr; // no new OneWire devices on any bus
+        return {}; // no new OneWire devices on any bus
     }
 };

--- a/lib/blocks/inc/blocks/OneWireScanningFactory.hpp
+++ b/lib/blocks/inc/blocks/OneWireScanningFactory.hpp
@@ -18,21 +18,9 @@
  */
 
 #pragma once
-
-#include "blocks/DS2408Block.hpp"
-#include "blocks/DS2413Block.hpp"
-#include "blocks/TempSensorOneWireBlock.hpp"
-#include "blox_hal/hal_delay.hpp"
-#include "cbox/Application.hpp"
-#include "cbox/Box.hpp"
 #include "cbox/CboxPtr.hpp"
-#include "cbox/Object.hpp"
-#include "cbox/ObjectContainer.hpp"
 #include "cbox/ScanningFactory.hpp"
 #include "control/OneWire.hpp"
-#include "control/OneWireAddress.hpp"
-#include "control/OneWireDevice.hpp"
-#include <memory>
 
 class OneWireScanningFactory : public cbox::ScanningFactory {
 private:

--- a/lib/blocks/inc/blocks/TempSensorOneWireBlock.hpp
+++ b/lib/blocks/inc/blocks/TempSensorOneWireBlock.hpp
@@ -12,7 +12,7 @@ private:
 public:
     TempSensorOneWireBlock();
     TempSensorOneWireBlock(cbox::obj_id_t busId);
-    TempSensorOneWireBlock(cbox::obj_id_t busId, const OneWireAddress& addr);
+    TempSensorOneWireBlock(cbox::obj_id_t busId, OneWireAddress addr);
     ~TempSensorOneWireBlock() = default;
 
     cbox::CboxError read(const cbox::PayloadCallback& callback) const override;

--- a/lib/blocks/src/ActuatorAnalogMockBlock.cpp
+++ b/lib/blocks/src/ActuatorAnalogMockBlock.cpp
@@ -77,7 +77,7 @@ cbox::CboxError ActuatorAnalogMockBlock::write(const cbox::Payload& payload)
 
 void* ActuatorAnalogMockBlock::implements(cbox::obj_type_t iface)
 {
-    if (iface == brewblox_BlockType_ActuatorAnalogMock) {
+    if (iface == staticTypeId()) {
         return this; // me!
     }
     if (iface == cbox::interfaceId<ActuatorAnalogConstrained>()) {

--- a/lib/blocks/src/ActuatorLogicBlock.cpp
+++ b/lib/blocks/src/ActuatorLogicBlock.cpp
@@ -165,7 +165,7 @@ ActuatorLogicBlock::updateHandler(const cbox::update_t& now)
 
 void* ActuatorLogicBlock::implements(cbox::obj_type_t iface)
 {
-    if (iface == brewblox_BlockType_ActuatorLogic) {
+    if (iface == staticTypeId()) {
         return this; // me!
     }
     return nullptr;

--- a/lib/blocks/src/ActuatorOffsetBlock.cpp
+++ b/lib/blocks/src/ActuatorOffsetBlock.cpp
@@ -89,7 +89,7 @@ ActuatorOffsetBlock::updateHandler(const cbox::update_t& now)
 
 void* ActuatorOffsetBlock::implements(cbox::obj_type_t iface)
 {
-    if (iface == brewblox_BlockType_ActuatorOffset) {
+    if (iface == staticTypeId()) {
         return this; // me!
     }
     if (iface == cbox::interfaceId<ActuatorAnalogConstrained>()) {

--- a/lib/blocks/src/ActuatorPwmBlock.cpp
+++ b/lib/blocks/src/ActuatorPwmBlock.cpp
@@ -103,7 +103,7 @@ ActuatorPwmBlock::updateHandler(const cbox::update_t& now)
 
 void* ActuatorPwmBlock::implements(cbox::obj_type_t iface)
 {
-    if (iface == brewblox_BlockType_ActuatorPwm) {
+    if (iface == staticTypeId()) {
         return this; // me!
     }
     if (iface == cbox::interfaceId<ActuatorAnalogConstrained>()) {

--- a/lib/blocks/src/BalancerBlock.cpp
+++ b/lib/blocks/src/BalancerBlock.cpp
@@ -62,7 +62,7 @@ cbox::update_t BalancerBlock::updateHandler(const cbox::update_t& now)
 
 void* BalancerBlock::implements(cbox::obj_type_t iface)
 {
-    if (iface == brewblox_BlockType_Balancer) {
+    if (iface == staticTypeId()) {
         return this; // me!
     }
     if (iface == cbox::interfaceId<Balancer_t>()) {

--- a/lib/blocks/src/DS2408Block.cpp
+++ b/lib/blocks/src/DS2408Block.cpp
@@ -97,7 +97,7 @@ DS2408Block::updateHandler(const cbox::update_t& now)
 
 void* DS2408Block::implements(cbox::obj_type_t iface)
 {
-    if (iface == brewblox_BlockType_DS2408) {
+    if (iface == staticTypeId()) {
         return this; // me!
     }
     if (iface == cbox::interfaceId<IoArray>()) {

--- a/lib/blocks/src/DS2413Block.cpp
+++ b/lib/blocks/src/DS2413Block.cpp
@@ -84,7 +84,7 @@ DS2413Block::updateHandler(const cbox::update_t& now)
 
 void* DS2413Block::implements(cbox::obj_type_t iface)
 {
-    if (iface == brewblox_BlockType_DS2413) {
+    if (iface == staticTypeId()) {
         return this; // me!
     }
     if (iface == cbox::interfaceId<IoArray>()) {

--- a/lib/blocks/src/DigitalActuatorBlock.cpp
+++ b/lib/blocks/src/DigitalActuatorBlock.cpp
@@ -82,7 +82,7 @@ DigitalActuatorBlock::updateHandler(const cbox::update_t& now)
 
 void* DigitalActuatorBlock::implements(cbox::obj_type_t iface)
 {
-    if (iface == brewblox_BlockType_DigitalActuator) {
+    if (iface == staticTypeId()) {
         return this; // me!
     }
     if (iface == cbox::interfaceId<ActuatorDigitalConstrained>()) {

--- a/lib/blocks/src/MockPinsBlock.cpp
+++ b/lib/blocks/src/MockPinsBlock.cpp
@@ -60,7 +60,7 @@ MockPinsBlock::write(const cbox::Payload&)
 
 void* MockPinsBlock::implements(cbox::obj_type_t iface)
 {
-    if (iface == brewblox_BlockType_MockPins) {
+    if (iface == staticTypeId()) {
         return this; // me!
     }
     if (iface == cbox::interfaceId<IoArray>()) {

--- a/lib/blocks/src/MotorValveBlock.cpp
+++ b/lib/blocks/src/MotorValveBlock.cpp
@@ -104,7 +104,7 @@ MotorValveBlock::updateHandler(const cbox::update_t& now)
 
 void* MotorValveBlock::implements(cbox::obj_type_t iface)
 {
-    if (iface == brewblox_BlockType_MotorValve) {
+    if (iface == staticTypeId()) {
         return this; // me!
     }
     if (iface == cbox::interfaceId<ActuatorDigitalConstrained>()) {

--- a/lib/blocks/src/MutexBlock.cpp
+++ b/lib/blocks/src/MutexBlock.cpp
@@ -57,7 +57,7 @@ MutexBlock::write(const cbox::Payload& payload)
 
 void* MutexBlock::implements(cbox::obj_type_t iface)
 {
-    if (iface == brewblox_BlockType_Mutex) {
+    if (iface == staticTypeId()) {
         return this; // me!
     }
     if (iface == cbox::interfaceId<MutexTarget>()) {

--- a/lib/blocks/src/OneWireBusBlock.cpp
+++ b/lib/blocks/src/OneWireBusBlock.cpp
@@ -23,7 +23,7 @@
 #include "pb_encode.h"
 #include <limits>
 
-bool streamAdresses(pb_ostream_t* stream, const pb_field_t* field, void* const* arg)
+bool searchAndEncodeAdresses(pb_ostream_t* stream, const pb_field_t* field, void* const* arg)
 {
     OneWire* busPtr = reinterpret_cast<OneWire*>(*arg);
     if (busPtr == nullptr) {
@@ -33,8 +33,8 @@ bool streamAdresses(pb_ostream_t* stream, const pb_field_t* field, void* const* 
         if (!pb_encode_tag_for_field(stream, field)) {
             return false;
         }
-        auto addr = uint64_t(address);
-        if (!pb_encode_fixed64(stream, &addr)) {
+        auto rawAddress = uint64_t(address);
+        if (!pb_encode_fixed64(stream, &rawAddress)) {
             return false;
         }
     }
@@ -77,7 +77,7 @@ OneWireBusBlock::read(const cbox::PayloadCallback& callback) const
         if (command.data) {
             bus.target_search(command.data);
         }
-        message.address.funcs.encode = &streamAdresses;
+        message.address.funcs.encode = &searchAndEncodeAdresses;
         break;
     }
     // commands are one-shot - once the command is done clear it.

--- a/lib/blocks/src/OneWireBusBlock.cpp
+++ b/lib/blocks/src/OneWireBusBlock.cpp
@@ -25,16 +25,15 @@
 
 bool streamAdresses(pb_ostream_t* stream, const pb_field_t* field, void* const* arg)
 {
-    OneWireAddress address;
     OneWire* busPtr = reinterpret_cast<OneWire*>(*arg);
     if (busPtr == nullptr) {
         return false;
     }
-    while (busPtr->search(address)) {
+    while (auto address = busPtr->search()) {
         if (!pb_encode_tag_for_field(stream, field)) {
             return false;
         }
-        uint64_t addr = uint64_t(address);
+        auto addr = uint64_t(address);
         if (!pb_encode_fixed64(stream, &addr)) {
             return false;
         }

--- a/lib/blocks/src/OneWireBusBlock.cpp
+++ b/lib/blocks/src/OneWireBusBlock.cpp
@@ -124,7 +124,7 @@ OneWireBusBlock::write(const cbox::Payload& payload)
 
 void* OneWireBusBlock::implements(cbox::obj_type_t iface)
 {
-    if (iface == brewblox_BlockType_OneWireBus) {
+    if (iface == staticTypeId()) {
         return this; // me!
     }
     if (iface == cbox::interfaceId<OneWire>()) {

--- a/lib/blocks/src/OneWireScanningFactory.cpp
+++ b/lib/blocks/src/OneWireScanningFactory.cpp
@@ -17,9 +17,9 @@
  * along with Brewblox.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include "blocks/OneWireScanningFactory.hpp"
 #include "blocks/DS2408Block.hpp"
 #include "blocks/DS2413Block.hpp"
-#include "blocks/OneWireScanningFactory.hpp"
 #include "blocks/TempSensorOneWireBlock.hpp"
 #include "blox_hal/hal_delay.hpp"
 #include "cbox/Box.hpp"

--- a/lib/blocks/src/OneWireScanningFactory.cpp
+++ b/lib/blocks/src/OneWireScanningFactory.cpp
@@ -36,8 +36,10 @@ std::shared_ptr<cbox::Object> OneWireScanningFactory::scan()
         bus->reset_search();
         while (auto newAddr = bus->search()) {
             auto existing = std::find_if(cbox::objects.begin(), cbox::objects.end(), [&newAddr](const std::shared_ptr<cbox::Object>& obj) {
-                auto devicePtr = obj->asInterface<OneWireDevice>();
-                return (devicePtr != nullptr) && devicePtr->address() == newAddr;
+                if (auto devicePtr = obj->asInterface<OneWireDevice>()) {
+                    return devicePtr->address() == newAddr;
+                };
+                return false;
             });
 
             if (existing == cbox::objects.cend()) {

--- a/lib/blocks/src/OneWireScanningFactory.cpp
+++ b/lib/blocks/src/OneWireScanningFactory.cpp
@@ -36,7 +36,7 @@ std::shared_ptr<cbox::Object> OneWireScanningFactory::scan()
         bus->reset_search();
         while (auto newAddr = bus->search()) {
             auto existing = std::find_if(cbox::objects.begin(), cbox::objects.end(), [&newAddr](const std::shared_ptr<cbox::Object>& obj) {
-                auto devicePtr = cbox::asInterface<OneWireDevice>(obj);
+                auto devicePtr = obj->asInterface<OneWireDevice>();
                 return (devicePtr != nullptr) && devicePtr->address() == newAddr;
             });
 
@@ -57,7 +57,7 @@ std::shared_ptr<cbox::Object> OneWireScanningFactory::scan()
             } else {
                 // device already exists
                 // ensure that the bus id is correct in case it was plugged into a different module
-                if (auto blockPtr = cbox::asInterface<OneWireDeviceBlock>(*existing)) {
+                if (auto blockPtr = (*existing)->asInterface<OneWireDeviceBlock>()) {
                     blockPtr->setBusId(busId);
                 }
             }

--- a/lib/blocks/src/OneWireScannningFactory.cpp
+++ b/lib/blocks/src/OneWireScannningFactory.cpp
@@ -17,8 +17,17 @@
  * along with Brewblox.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include "blocks/DS2408Block.hpp"
+#include "blocks/DS2413Block.hpp"
 #include "blocks/OneWireScanningFactory.hpp"
+#include "blocks/TempSensorOneWireBlock.hpp"
+#include "blox_hal/hal_delay.hpp"
+#include "cbox/Box.hpp"
+#include "cbox/Object.hpp"
+#include "control/OneWireAddress.hpp"
+#include "control/OneWireDevice.hpp"
 #include <algorithm>
+#include <memory>
 
 std::shared_ptr<cbox::Object> OneWireScanningFactory::scan()
 {

--- a/lib/blocks/src/OneWireScannningFactory.cpp
+++ b/lib/blocks/src/OneWireScannningFactory.cpp
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2022 BrewPi B.V.
+ *
+ * This file is part of Brewblox.
+ *
+ * Brewblox is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Brewblox is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Brewblox.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "blocks/OneWireScanningFactory.hpp"
+#include <algorithm>
+
+std::shared_ptr<cbox::Object> OneWireScanningFactory::scan()
+{
+    if (auto bus = busPtr.lock()) {
+        auto busId = busPtr.getId();
+        bus->reset_search();
+        while (auto newAddr = bus->search()) {
+            auto existing = std::find_if(cbox::objects.begin(), cbox::objects.end(), [&newAddr](const std::shared_ptr<cbox::Object>& obj) {
+                auto devicePtr = cbox::asInterface<OneWireDevice>(obj);
+                return (devicePtr != nullptr) && devicePtr->address() == newAddr;
+            });
+
+            if (existing == cbox::objects.cend()) {
+                // create new object
+                uint8_t familyCode = newAddr[0];
+                switch (familyCode) {
+                case DS18B20::familyCode: {
+                    return std::shared_ptr<cbox::Object>(new TempSensorOneWireBlock(busId, std::move(newAddr)));
+                }
+                case DS2413::familyCode: {
+                    return std::shared_ptr<cbox::Object>(new DS2413Block(busId, std::move(newAddr)));
+                }
+                case DS2408::familyCode: {
+                    return std::shared_ptr<cbox::Object>(new DS2408Block(busId, std::move(newAddr)));
+                }
+                }
+            } else {
+                // device already exists
+                // ensure that the bus id is correct in case it was plugged into a different module
+                if (auto blockPtr = cbox::asInterface<OneWireDeviceBlock>(*existing)) {
+                    blockPtr->setBusId(busId);
+                }
+            }
+            hal_yield();
+        }
+    }
+    return {};
+}

--- a/lib/blocks/src/PidBlock.cpp
+++ b/lib/blocks/src/PidBlock.cpp
@@ -195,7 +195,7 @@ PidBlock::updateHandler(const cbox::update_t& now)
 
 void* PidBlock::implements(cbox::obj_type_t iface)
 {
-    if (iface == brewblox_BlockType_Pid) {
+    if (iface == staticTypeId()) {
         return this; // me!
     }
     return nullptr;

--- a/lib/blocks/src/SetpointProfileBlock.cpp
+++ b/lib/blocks/src/SetpointProfileBlock.cpp
@@ -123,7 +123,7 @@ SetpointProfileBlock::updateHandler(const cbox::update_t& now)
 
 void* SetpointProfileBlock::implements(cbox::obj_type_t iface)
 {
-    if (iface == brewblox_BlockType_SetpointProfile) {
+    if (iface == staticTypeId()) {
         return this; // me!
     }
 

--- a/lib/blocks/src/SetpointSensorPairBlock.cpp
+++ b/lib/blocks/src/SetpointSensorPairBlock.cpp
@@ -116,7 +116,7 @@ SetpointSensorPairBlock::updateHandler(const cbox::update_t& now)
 
 void* SetpointSensorPairBlock::implements(cbox::obj_type_t iface)
 {
-    if (iface == brewblox_BlockType_SetpointSensorPair) {
+    if (iface == staticTypeId()) {
         return this; // me!
     }
     if (iface == cbox::interfaceId<ProcessValue<temp_t>>()) {

--- a/lib/blocks/src/TempSensorCombiBlock.cpp
+++ b/lib/blocks/src/TempSensorCombiBlock.cpp
@@ -99,7 +99,7 @@ cbox::update_t TempSensorCombiBlock::updateHandler(const cbox::update_t& now)
 
 void* TempSensorCombiBlock::implements(cbox::obj_type_t iface)
 {
-    if (iface == brewblox_BlockType_TempSensorCombi) {
+    if (iface == staticTypeId()) {
         return this; // me!
     }
     if (iface == cbox::interfaceId<TempSensor>()) {

--- a/lib/blocks/src/TempSensorMockBlock.cpp
+++ b/lib/blocks/src/TempSensorMockBlock.cpp
@@ -139,7 +139,7 @@ cbox::update_t TempSensorMockBlock::updateHandler(const cbox::update_t& now)
 
 void* TempSensorMockBlock::implements(cbox::obj_type_t iface)
 {
-    if (iface == brewblox_BlockType_TempSensorMock) {
+    if (iface == staticTypeId()) {
         return this; // me!
     }
     if (iface == cbox::interfaceId<TempSensor>()) {

--- a/lib/blocks/src/TempSensorOneWireBlock.cpp
+++ b/lib/blocks/src/TempSensorOneWireBlock.cpp
@@ -33,9 +33,9 @@ TempSensorOneWireBlock::TempSensorOneWireBlock(cbox::obj_id_t busId)
 {
 }
 
-TempSensorOneWireBlock::TempSensorOneWireBlock(cbox::obj_id_t busId, const OneWireAddress& addr)
+TempSensorOneWireBlock::TempSensorOneWireBlock(cbox::obj_id_t busId, OneWireAddress addr)
     : OneWireDeviceBlock(busId)
-    , sensor(owBus, addr)
+    , sensor(owBus, std::move(addr))
 {
 }
 

--- a/lib/blocks/src/TempSensorOneWireBlock.cpp
+++ b/lib/blocks/src/TempSensorOneWireBlock.cpp
@@ -109,7 +109,7 @@ cbox::update_t TempSensorOneWireBlock::updateHandler(const cbox::update_t& now)
 
 void* TempSensorOneWireBlock::implements(cbox::obj_type_t iface)
 {
-    if (iface == brewblox_BlockType_TempSensorOneWire) {
+    if (iface == staticTypeId()) {
         return this; // me!
     }
     if (iface == cbox::interfaceId<TempSensor>()) {

--- a/lib/cbox/inc/cbox/CboxPtr.hpp
+++ b/lib/cbox/inc/cbox/CboxPtr.hpp
@@ -70,7 +70,7 @@ public:
             // do not point to the same address. The pointer that is returned is of the address that implements
             // the interface.
             // create a shared_ptr by re-using the ref counting block, but for the offset pointer.
-            return std::shared_ptr<U>(std::move(sptr), reinterpret_cast<U*>(sptr->implements(interfaceId<U>())));
+            return std::shared_ptr<U>(std::move(sptr), sptr->asInterface<U>());
         }
         // return empty share pointer
         return std::shared_ptr<U>();

--- a/lib/cbox/inc/cbox/Object.hpp
+++ b/lib/cbox/inc/cbox/Object.hpp
@@ -85,6 +85,18 @@ protected:
         return now + 1000;
     }
 
+private:
+    /**
+     * checks whether the class implements a certain interface. If it does, it returns the this pointer implementing it
+     * @param iface: typeId of the interface requested
+     */
+    virtual void* implements(obj_type_t iface) = 0;
+
+    const void* implements(obj_type_t iface) const
+    {
+        return const_cast<Object*>(this)->implements(iface);
+    }
+
 public:
     Object() = default;
     virtual ~Object() = default;
@@ -132,17 +144,6 @@ public:
     virtual CboxError loadFromCache()
     {
         return CboxError::OK;
-    }
-
-    /**
-     * checks whether the class implements a certain interface. If it does, it returns the this pointer implementing it
-     * @param iface: typeId of the interface requested
-     */
-    virtual void* implements(obj_type_t iface) = 0;
-
-    const void* implements(obj_type_t iface) const
-    {
-        return const_cast<Object*>(this)->implements(iface);
     }
 
     template <typename T>

--- a/lib/cbox/inc/cbox/Object.hpp
+++ b/lib/cbox/inc/cbox/Object.hpp
@@ -27,6 +27,38 @@ namespace cbox {
 
 using update_t = uint32_t;
 
+class Object;
+
+// any type can be assigned a typeid by explicit template instantiation
+// this allows objects to implement returning a pointer for that type, without needing to inherit from it
+template <typename T>
+obj_type_t interfaceIdImpl();
+
+// for objects, the object id is the interface id
+template <typename T>
+obj_type_t interfaceId(typename std::enable_if_t<std::is_base_of<Object, T>::value>* = 0)
+{
+    return T::staticTypeId();
+}
+
+#if !defined(PLATFORM_ID) || PLATFORM_ID == 3 // check that ID is unique if building for cross platform (tests)
+uint16_t throwIdNotUnique(uint16_t id);
+#endif
+
+// for interface, we check uniqueness on first use, if compiling with gcc (test code)
+template <typename T>
+obj_type_t interfaceId(typename std::enable_if_t<!std::is_base_of<Object, T>::value>* = 0)
+{
+#if !defined(PLATFORM_ID) || PLATFORM_ID == 3
+    static auto uniqueId = throwIdNotUnique(interfaceIdImpl<T>());
+    return uniqueId;
+
+#else
+
+    return interfaceIdImpl<T>();
+#endif
+}
+
 class Object {
 private:
     update_t _nextUpdateTime{0}; // ignore update() calls before this time
@@ -107,6 +139,23 @@ public:
      * @param iface: typeId of the interface requested
      */
     virtual void* implements(obj_type_t iface) = 0;
+
+    const void* implements(obj_type_t iface) const
+    {
+        return const_cast<Object*>(this)->implements(iface);
+    }
+
+    template <typename T>
+    T* asInterface()
+    {
+        return reinterpret_cast<T*>(implements(interfaceId<T>()));
+    }
+
+    template <typename T>
+    const T* asInterface() const
+    {
+        return reinterpret_cast<const T*>(implements(interfaceId<T>()));
+    }
 
     /**
      * update the object, returns timestamp at which the object wants to be updated again (in ms).

--- a/lib/cbox/inc/cbox/ObjectBase.hpp
+++ b/lib/cbox/inc/cbox/ObjectBase.hpp
@@ -97,6 +97,12 @@ T* asInterface(Object& obj)
 }
 
 template <class T>
+const T* asInterface(const Object& obj)
+{
+    return reinterpret_cast<const T*>(obj.implements(interfaceId<T>()));
+}
+
+template <class T>
 T* asInterface(std::shared_ptr<Object>& obj)
 {
     if (obj) {

--- a/lib/cbox/inc/cbox/ObjectBase.hpp
+++ b/lib/cbox/inc/cbox/ObjectBase.hpp
@@ -25,11 +25,6 @@
 
 namespace cbox {
 
-#if !defined(PLATFORM_ID) || PLATFORM_ID == 3
-uint16_t
-throwIdNotUnique(uint16_t id);
-#endif
-
 template <uint16_t id>
 class ObjectBase : public Object {
 public:
@@ -62,62 +57,5 @@ public:
         return nullptr;
     }
 };
-
-// any type can be assigned a typeid by explicit template instantiation
-// this allows objects to implement returning a pointer for that type, without needing to inherit from it
-template <typename T>
-obj_type_t
-interfaceIdImpl();
-
-// for objects, the object id is the interface id
-template <typename T>
-obj_type_t
-interfaceId(typename std::enable_if_t<std::is_base_of<Object, T>::value>* = 0)
-{
-    return T::staticTypeId();
-}
-
-// for interface, we check uniqueness on first use, if compiling with gcc (test code)
-template <typename T>
-obj_type_t
-interfaceId(typename std::enable_if_t<!std::is_base_of<Object, T>::value>* = 0)
-{
-#if !defined(PLATFORM_ID) || PLATFORM_ID == 3 // check that ID is unique if building for cross platform (tests)
-    static auto uniqueId = throwIdNotUnique(interfaceIdImpl<T>());
-    return uniqueId;
-#else
-    return interfaceIdImpl<T>();
-#endif
-}
-
-template <class T>
-T* asInterface(Object& obj)
-{
-    return reinterpret_cast<T*>(obj.implements(interfaceId<T>()));
-}
-
-template <class T>
-const T* asInterface(const Object& obj)
-{
-    return reinterpret_cast<const T*>(obj.implements(interfaceId<T>()));
-}
-
-template <class T>
-T* asInterface(std::shared_ptr<Object>& obj)
-{
-    if (obj) {
-        return reinterpret_cast<T*>(obj->implements(interfaceId<T>()));
-    }
-    return nullptr;
-}
-
-template <class T>
-const T* asInterface(const std::shared_ptr<Object>& obj)
-{
-    if (obj) {
-        return reinterpret_cast<const T*>(obj->implements(interfaceId<T>()));
-    }
-    return nullptr;
-}
 
 } // end namespace cbox

--- a/lib/cbox/inc/cbox/ObjectContainer.hpp
+++ b/lib/cbox/inc/cbox/ObjectContainer.hpp
@@ -80,7 +80,16 @@ public:
 
     CboxError remove(obj_id_t id);
 
-    // only const iterators are exposed. We don't want the caller to be able to modify the container
+    Iterator begin()
+    {
+        return contained.begin();
+    }
+
+    Iterator end()
+    {
+        return contained.end();
+    }
+
     CIterator cbegin() const
     {
         return contained.cbegin();

--- a/lib/control/inc/control/DS18B20.hpp
+++ b/lib/control/inc/control/DS18B20.hpp
@@ -68,7 +68,7 @@ public:
      * /param calibration	A temperature value that is added to all readings. This can be used to calibrate the sensor.
      */
     DS18B20(ControlPtr<OneWire>& busPtr, OneWireAddress _address = 0, const temp_t& _calibrationOffset = 0)
-        : OneWireDevice(busPtr, _address)
+        : OneWireDevice(busPtr, std::move(_address))
         , m_calibrationOffset(_calibrationOffset)
     {
     }

--- a/lib/control/inc/control/DS2408.hpp
+++ b/lib/control/inc/control/DS2408.hpp
@@ -51,7 +51,7 @@ public:
      * This means the output latches are disabled and all pins are sensed high
      */
     DS2408(ControlPtr<OneWire>& busPtr, OneWireAddress address = familyCode)
-        : OneWireDevice(busPtr, address)
+        : OneWireDevice(busPtr, std::move(address))
         , IoArray(8)
     {
     }

--- a/lib/control/inc/control/DS2413.hpp
+++ b/lib/control/inc/control/DS2413.hpp
@@ -43,7 +43,7 @@ private:
 
 public:
     DS2413(ControlPtr<OneWire>& busPtr, OneWireAddress address = familyCode)
-        : OneWireDevice(busPtr, address)
+        : OneWireDevice(busPtr, std::move(address))
         , IoArray(2)
     {
     }

--- a/lib/control/inc/control/OneWire.hpp
+++ b/lib/control/inc/control/OneWire.hpp
@@ -75,15 +75,15 @@ public:
     // Setup the search to find the device type 'family_code' on the next search
     void target_search(uint8_t family_code);
 
-    // Look for the next device. Returns true if a new address has been
-    // returned. A zero might mean that the bus is shorted, there are
+    // Look for the next device. Returns non-zero address if a new address has been
+    // found. A zero might mean that the bus is shorted, there are
     // no devices, or you have already retrieved all of them.  It
     // might be a good idea to check the CRC to make sure you didn't
     // get garbage.  The order is deterministic. You will always get
     // the same devices in the same order.
     // When the last device has been return, reset_search or target_search has to be called
     // to reset the search.
-    bool search(OneWireAddress& newAddr);
+    OneWireAddress search();
 
     // Checks the driver for a short on the bus
     bool shortDetected()

--- a/lib/control/inc/control/OneWireAddress.hpp
+++ b/lib/control/inc/control/OneWireAddress.hpp
@@ -49,7 +49,7 @@ public:
         return asUint8ptr()[i];
     }
 
-    bool getBit(uint8_t i)
+    bool getBit(uint8_t i) const
     {
         uint64_t mask = uint64_t{0x01} << i;
         return (mask & uint64_t(address)) > 0;
@@ -65,7 +65,7 @@ public:
         }
     }
 
-    operator uint64_t()
+    operator const uint64_t&() const
     {
         return address;
     }

--- a/lib/control/inc/control/OneWireDevice.hpp
+++ b/lib/control/inc/control/OneWireDevice.hpp
@@ -26,20 +26,18 @@
 #include <memory>
 
 class OneWireDevice {
-public:
-    OneWireDevice(ControlPtr<OneWire>& busPtr_, const OneWireAddress& address_);
-
 protected:
+    OneWireDevice(ControlPtr<OneWire>& busPtr_, OneWireAddress&& address_);
     ~OneWireDevice() = default;
 
 public:
-    OneWireAddress address() const
+    const OneWireAddress& address() const
     {
         return m_address;
     }
-    void address(const OneWireAddress& addr)
+    void address(OneWireAddress addr)
     {
-        m_address = addr;
+        m_address = std::move(addr);
     }
 
     bool connected() const

--- a/lib/control/src/OneWire.cpp
+++ b/lib/control/src/OneWire.cpp
@@ -183,10 +183,9 @@ void OneWire::target_search(uint8_t family_code)
     lastDeviceFlag = false;
 }
 
-bool OneWire::search(OneWireAddress& newAddr)
+OneWireAddress OneWire::search()
 {
     uint8_t id_bit_nr = 0;
-    bool search_result = false;
     bool search_direction = true;
     bool id_bit, cmp_id_bit;
     uint8_t last_zero = 64;
@@ -237,13 +236,9 @@ bool OneWire::search(OneWireAddress& newAddr)
                 // no discrepancies or discrepancy is for device outside of target_search
                 lastDeviceFlag = true;
             };
-            search_result = true;
+            return ROM_NO;
         }
     }
 
-    if (search_result) {
-        newAddr = ROM_NO;
-    }
-
-    return search_result;
+    return 0;
 }

--- a/lib/control/src/OneWireDevice.cpp
+++ b/lib/control/src/OneWireDevice.cpp
@@ -27,7 +27,7 @@
  * /param oneWire_ The oneWire bus the device is connected to
  * /param address_ The oneWire address of the device to use.
  */
-OneWireDevice::OneWireDevice(ControlPtr<OneWire>& busPtr_, const OneWireAddress& address_)
+OneWireDevice::OneWireDevice(ControlPtr<OneWire>& busPtr_, OneWireAddress&& address_)
     : m_bus(busPtr_)
     , m_address(address_)
 {

--- a/platform/particle/spark/src/Spark2PinsBlock.cpp
+++ b/platform/particle/spark/src/Spark2PinsBlock.cpp
@@ -115,7 +115,7 @@ cbox::CboxError Spark2PinsBlock::write(const cbox::Payload& payload)
 
 void* Spark2PinsBlock::implements(cbox::obj_type_t iface)
 {
-    if (iface == brewblox_BlockType_Spark2Pins) {
+    if (iface == staticTypeId()) {
         return this; // me!
     }
     if (iface == cbox::interfaceId<IoArray>()) {

--- a/platform/particle/spark/src/Spark3PinsBlock.cpp
+++ b/platform/particle/spark/src/Spark3PinsBlock.cpp
@@ -128,7 +128,7 @@ cbox::CboxError Spark3PinsBlock::write(const cbox::Payload& payload)
 
 void* Spark3PinsBlock::implements(cbox::obj_type_t iface)
 {
-    if (iface == brewblox_BlockType_Spark3Pins) {
+    if (iface == staticTypeId()) {
         return this; // me!
     }
     if (iface == cbox::interfaceId<IoArray>()) {

--- a/test/blocks/AutoDiscover_test.cpp
+++ b/test/blocks/AutoDiscover_test.cpp
@@ -42,7 +42,7 @@ SCENARIO("Auto discovery of OneWire devices")
 
         THEN("New objects are discovered")
         {
-            CHECK(discoverCmd.responses.size() == 5);
+            REQUIRE(discoverCmd.responses.size() == 5);
             CHECK(discoverCmd.responses.at(0).blockType == TempSensorOneWireBlock::staticTypeId());
             CHECK(discoverCmd.responses.at(1).blockType == TempSensorOneWireBlock::staticTypeId());
             CHECK(discoverCmd.responses.at(2).blockType == TempSensorOneWireBlock::staticTypeId());

--- a/test/cbox/LongIntScanningFactory.hpp
+++ b/test/cbox/LongIntScanningFactory.hpp
@@ -26,7 +26,7 @@ public:
         for (auto& value : candidates) {
             bool found = false;
             for (auto existing = objects.cbegin(); existing != objects.cend(); ++existing) {
-                auto ptrIfCorrectType = cbox::asInterface<LongIntObject>(*existing);
+                auto ptrIfCorrectType = (*existing)->asInterface<LongIntObject>();
                 if (ptrIfCorrectType == nullptr) {
                     continue; // not the right type, no match
                 }

--- a/test/cbox/LongIntScanningFactory.hpp
+++ b/test/cbox/LongIntScanningFactory.hpp
@@ -2,6 +2,7 @@
 #include "cbox/Box.hpp"
 #include "cbox/Object.hpp"
 #include "cbox/ScanningFactory.hpp"
+#include <algorithm>
 #include <memory>
 #include <vector>
 
@@ -24,18 +25,13 @@ public:
     virtual std::shared_ptr<Object> scan() override final
     {
         for (auto& value : candidates) {
-            bool found = false;
-            for (auto existing = objects.cbegin(); existing != objects.cend(); ++existing) {
-                auto ptrIfCorrectType = (*existing)->asInterface<LongIntObject>();
-                if (ptrIfCorrectType == nullptr) {
-                    continue; // not the right type, no match
-                }
-                if (ptrIfCorrectType->value() == value) {
-                    found = true; // object with value already exists
-                    break;
-                }
-            }
-            if (!found) {
+            auto existing = std::find_if(objects.cbegin(), objects.cend(), [value](const std::shared_ptr<Object>& obj) {
+                if (auto ptrIfCorrectType = obj->asInterface<LongIntObject>()) {
+                    return ptrIfCorrectType->value() == value;
+                };
+                return false;
+            });
+            if (existing == objects.cend()) {
                 // create new object
                 return std::make_shared<LongIntObject>(value);
             }

--- a/test/cbox/LongIntScanningFactory.hpp
+++ b/test/cbox/LongIntScanningFactory.hpp
@@ -26,7 +26,7 @@ public:
         for (auto& value : candidates) {
             bool found = false;
             for (auto existing = objects.cbegin(); existing != objects.cend(); ++existing) {
-                LongIntObject* ptrIfCorrectType = reinterpret_cast<LongIntObject*>((*existing)->implements(LongIntObject::staticTypeId()));
+                auto ptrIfCorrectType = cbox::asInterface<LongIntObject>(*existing);
                 if (ptrIfCorrectType == nullptr) {
                     continue; // not the right type, no match
                 }

--- a/test/control/OneWireMock_test.cpp
+++ b/test/control/OneWireMock_test.cpp
@@ -58,11 +58,11 @@ SCENARIO("A mocked OneWire bus and mocked slaves", "[onewire]")
         CHECK(ow.ptr->reset() == false);
     }
 
-    WHEN("No devices are on the bus, search returns false")
+    WHEN("No devices are on the bus, search returns 0")
     {
         OneWireAddress addr(0);
         ow.ptr->reset_search();
-        CHECK(ow.ptr->search(addr) == false);
+        CHECK(ow.ptr->search() == OneWireAddress{0});
     }
 
     WHEN("A mock DS18B20 is attached")
@@ -79,8 +79,7 @@ SCENARIO("A mocked OneWire bus and mocked slaves", "[onewire]")
         {
             OneWireAddress addr(0);
             ow.ptr->reset();
-            bool found = ow.ptr->search(addr);
-            CHECK(found == true);
+            addr = ow.ptr->search();
             CHECK(addr == addr1);
         }
 
@@ -202,16 +201,13 @@ SCENARIO("A mocked OneWire bus and mocked slaves", "[onewire]")
                 OneWireAddress addr(0);
                 ow.ptr->reset();
                 ow.ptr->reset_search();
-                bool found = ow.ptr->search(addr);
-                CHECK(found == true);
+                addr = ow.ptr->search();
                 CHECK(addr == OneWireAddress(addr1));
 
-                found = ow.ptr->search(addr);
-                CHECK(found == true);
+                addr = ow.ptr->search();
                 CHECK(addr == OneWireAddress(addr2));
 
-                found = ow.ptr->search(addr);
-                CHECK(found == false);
+                addr = ow.ptr->search();
             }
 
             sensor1.update();
@@ -248,8 +244,7 @@ SCENARIO("A mocked OneWire bus and mocked slaves", "[onewire]")
         {
             OneWireAddress addr(0);
             ow.ptr->reset();
-            bool found = ow.ptr->search(addr);
-            CHECK(found == true);
+            addr = ow.ptr->search();
             CHECK(addr == addr3);
         }
 
@@ -333,8 +328,7 @@ SCENARIO("A mocked OneWire bus and mocked slaves", "[onewire]")
         {
             OneWireAddress addr(0);
             ow.ptr->reset();
-            bool found = ow.ptr->search(addr);
-            CHECK(found == true);
+            addr = ow.ptr->search();
             CHECK(addr == addr4);
         }
 
@@ -436,33 +430,22 @@ SCENARIO("A mocked OneWire bus and mocked slaves", "[onewire]")
             ow.ptr->reset_search();
 
             OneWireAddress addr(0);
-            bool found = ow.ptr->search(addr);
-            CHECK(found == true);
+            addr = ow.ptr->search();
             CHECK(addr == addrSensor2);
 
-            addr = 0;
-            found = ow.ptr->search(addr);
-            CHECK(found == true);
+            addr = ow.ptr->search();
             CHECK(addr == addrSensor1);
 
-            addr = 0;
-            found = ow.ptr->search(addr);
-            CHECK(found == true);
+            addr = ow.ptr->search();
             CHECK(addr == addrSensor3);
 
-            addr = 0;
-            found = ow.ptr->search(addr);
-            CHECK(found == true);
+            addr = ow.ptr->search();
             CHECK(addr == addrDS2413);
 
-            addr = 0;
-            found = ow.ptr->search(addr);
-            CHECK(found == true);
+            addr = ow.ptr->search();
             CHECK(addr == addrDS2408);
 
-            addr = 0;
-            found = ow.ptr->search(addr);
-            CHECK(found == false);
+            addr = ow.ptr->search();
             CHECK(addr == OneWireAddress(0));
         }
 
@@ -471,45 +454,30 @@ SCENARIO("A mocked OneWire bus and mocked slaves", "[onewire]")
             ow.ptr->target_search(DS18B20Mock::family_code);
 
             OneWireAddress addr(0);
-            bool found = ow.ptr->search(addr);
-            CHECK(found == true);
+            addr = ow.ptr->search();
             CHECK(addr == addrSensor2);
 
-            addr = 0;
-            found = ow.ptr->search(addr);
-            CHECK(found == true);
+            addr = ow.ptr->search();
             CHECK(addr == addrSensor1);
 
-            addr = 0;
-            found = ow.ptr->search(addr);
-            CHECK(found == true);
+            addr = ow.ptr->search();
             CHECK(addr == addrSensor3);
 
-            addr = 0;
-            found = ow.ptr->search(addr);
-            CHECK(found == false);
+            addr = ow.ptr->search();
             CHECK(addr == OneWireAddress(0));
 
             ow.ptr->target_search(DS2413Mock::family_code);
-            addr = 0;
-            found = ow.ptr->search(addr);
-            CHECK(found == true);
+            addr = ow.ptr->search();
             CHECK(addr == addrDS2413);
 
-            addr = 0;
-            found = ow.ptr->search(addr);
-            CHECK(found == false);
+            addr = ow.ptr->search();
             CHECK(addr == OneWireAddress(0));
 
             ow.ptr->target_search(DS2408Mock::family_code);
-            addr = 0;
-            found = ow.ptr->search(addr);
-            CHECK(found == true);
+            addr = ow.ptr->search();
             CHECK(addr == addrDS2408);
 
-            addr = 0;
-            found = ow.ptr->search(addr);
-            CHECK(found == false);
+            addr = ow.ptr->search();
             CHECK(addr == OneWireAddress(0));
         }
     }


### PR DESCRIPTION
- search returns address instead of taking address as non-const ref
- when iterating over the object container, use the correct constness
- add config for disassembly explorer 