### PR TITLE
Eeprom block can grow into adjecent disposed block

### DIFF
--- a/lib/cbox/inc/cbox/EepromBlock.hpp
+++ b/lib/cbox/inc/cbox/EepromBlock.hpp
@@ -98,9 +98,21 @@ public:
         _pos = _start + blockHeaderLength + objectHeaderLength;
     }
 
+    bool inRange(uint16_t count)
+    {
+        return _pos + count <= _start + _accessible_size;
+    }
+
+    void skip(uint16_t count)
+    {
+        if (inRange(count)) {
+            _pos += count;
+        }
+    }
+
     void put(uint8_t value)
     {
-        if (_pos < _start + _accessible_size) {
+        if (inRange(1)) {
             _eeprom.get().writeByte(_pos, value);
             ++_pos;
         }
@@ -108,7 +120,7 @@ public:
 
     void put(const std::vector<uint8_t>& bytes)
     {
-        if (_pos + bytes.size() <= _start + _accessible_size) {
+        if (inRange(bytes.size())) {
             _eeprom.get().writeBlock(_pos, bytes.data(), bytes.size());
             _pos += bytes.size();
         }
@@ -120,7 +132,7 @@ public:
     template <typename T>
     void put(const T& t)
     {
-        if (_pos + sizeof(T) <= _start + _accessible_size) {
+        if (inRange(sizeof(T))) {
             _eeprom.get().put<T>(_pos, t);
             _pos += sizeof(T);
         }
@@ -132,7 +144,7 @@ public:
     template <typename T>
     void get(T& t)
     {
-        if (_pos + sizeof(T) <= _start + _accessible_size) {
+        if (inRange(sizeof(T))) {
             _eeprom.get().get<T>(_pos, t);
             _pos += sizeof(T);
         }
@@ -140,7 +152,7 @@ public:
 
     void get(std::vector<uint8_t>& bytes)
     {
-        if (_pos + bytes.size() <= _start + _accessible_size) {
+        if (inRange(bytes.size())) {
             _eeprom.get().readBlock(bytes.data(), _pos, bytes.size());
             _pos += bytes.size();
         }

--- a/lib/cbox/inc/cbox/EepromObjectStorage.hpp
+++ b/lib/cbox/inc/cbox/EepromObjectStorage.hpp
@@ -74,6 +74,7 @@ protected:
     void init();
     bool moveDisposedBackwards();
     void mergeDisposedBlocks();
+    void shrinkOverallocatedBlocks();
 
     static CboxError eepromToPayload(const PayloadCallback& callback,
                                      EepromBlock& block);

--- a/lib/cbox/src/EepromObjectStorage.cpp
+++ b/lib/cbox/src/EepromObjectStorage.cpp
@@ -186,7 +186,6 @@ void EepromObjectStorage::defrag()
     // ensure no invalid objects with ID zero remain in eeprom
     // these are only temporary while relocating data
     disposeObject(0);
-    shrinkOverallocatedBlocks();
     do {
         mergeDisposedBlocks();
     } while (moveDisposedBackwards());
@@ -252,6 +251,7 @@ std::optional<EepromBlock> EepromObjectStorage::getNewObject(uint16_t objectLeng
             return block;
         }
         // not enough space
+        shrinkOverallocatedBlocks();
         auto space = freeSpace();
         if (space.total < provisioned) {
             return std::nullopt;

--- a/test/cbox/EepromObjectStorage_test.cpp
+++ b/test/cbox/EepromObjectStorage_test.cpp
@@ -625,7 +625,7 @@ SCENARIO("Storing and retrieving blocks with EEPROM storage")
                         CHECK(CboxError::OK == saveObjectToStorage(obj_id_t(id), obj));
                         auto received = std::make_shared<LongIntVectorObject>();
 
-                        THEN("Its size is reduced during a defrag")
+                        THEN("Its size is reduced if needed to create a new object")
                         {
                             auto blockOpt = storage.getExistingObject(id, true);
                             REQUIRE(blockOpt.has_value());
@@ -633,7 +633,8 @@ SCENARIO("Storing and retrieving blocks with EEPROM storage")
                             uint16_t expectedWrittenLength = 2 + 3 * 4 + 4; // data + flags + type + crc
                             CHECK((*blockOpt).getWrittenLength() == expectedWrittenLength);
 
-                            storage.defrag();
+                            auto res = saveObjectToStorage(obj_id_t(id + 1), big);
+                            CHECK(res == CboxError::OK);
 
                             auto blockOpt2 = storage.getExistingObject(id, true);
                             REQUIRE(blockOpt2.has_value());


### PR DESCRIPTION
This implements a missing detail in EEPROM block storage.
When an object grows beyond its allocated size but is followed by a disposed block, it can absorb part of that block instead of being relocated.

This required some test hardening and other changes to make it work well. The next block could be created directly from the current position in many places, instead of doing a search.
