### PR TITLE
Fix slowness when DS2413 or DS2408 is not connected

### DIFF
--- a/app/brewblox-particle/build.mk
+++ b/app/brewblox-particle/build.mk
@@ -119,7 +119,8 @@ endif
 
 ifeq ($(PLATFORM_ID),3)
 ifeq ("$(TEST_BUILD)","y") # coverage, address sanitizer, undefined behavior
-include $(SOURCE_PATH)/test/checkers.mk # sanitizer and gcov
+include $(SOURCE_PATH)/test/sanitize.mk # sanitizer and gcov
+# include $(SOURCE_PATH)/test/coverage.mk # sanitizer and gcov
 endif
 endif
 

--- a/lib/blocks/src/ActuatorPwmBlock.cpp
+++ b/lib/blocks/src/ActuatorPwmBlock.cpp
@@ -80,7 +80,7 @@ ActuatorPwmBlock::write(const cbox::Payload& payload)
         if (parser.hasField(blox_ActuatorPwm_Block_constrainedBy_tag)) {
             setAnalogConstraints(message.constrainedBy, constrained);
         }
-        if (parser.hasField(blox_ActuatorPwm_Block_setting_tag)) {
+        if (parser.hasField(blox_ActuatorPwm_Block_desiredSetting_tag)) {
             constrained.setting(cnl::wrap<ActuatorAnalog::value_t>(message.desiredSetting));
         }
         if (parser.hasField(blox_ActuatorPwm_Block_enabled_tag)) {

--- a/lib/cbox/src/EepromObjectStorage.cpp
+++ b/lib/cbox/src/EepromObjectStorage.cpp
@@ -133,8 +133,9 @@ CboxError EepromObjectStorage::loadAllObjects(const PayloadCallback& callback)
         if (err == CboxError::STORAGE_READ_ERROR) {
             return err; // only stop on read errors
         }
-        if (err != CboxError::OK) {
-            return err; // TODO should continue and only log error
+        if (err == CboxError::STORAGE_CRC_ERROR) {
+            // dispose block. We cannot trust it due to the CRC error and cannot recover this
+            (*objOpt).setBlockType(EepromBlockType::disposed_block);
         }
         pos = blockData.end();
     };

--- a/lib/cbox/src/ObjectContainer.cpp
+++ b/lib/cbox/src/ObjectContainer.cpp
@@ -100,8 +100,14 @@ CboxError ObjectContainer::remove(obj_id_t id)
     }
     // find existing object
     auto p = findPosition(id);
-    contained.erase(p.first, p.second); // doesn't remove anything if no objects found (first == second)
-    return p.first == p.second ? CboxError::INVALID_BLOCK_ID : CboxError::OK;
+    if (p.first != p.second) {
+        // create extra shared pointer to delay destruction during container access
+        // destructors might do lookups in container
+        auto temp = *p.first;
+        contained.erase(p.first, p.second);
+        return CboxError::OK;
+    }
+    return CboxError::INVALID_BLOCK_ID;
 }
 
 // remove all non-system objects from the container

--- a/lib/control/src/DS2408.cpp
+++ b/lib/control/src/DS2408.cpp
@@ -39,51 +39,54 @@ constexpr uint8_t bitMask(uint8_t channel)
 
 bool DS2408::writeNeeded() const
 {
-    return !connected() || desiredLatches != latches;
+    return dirty || desiredLatches != latches;
 }
-
 bool DS2408::update()
 {
-    bool success = false;
+    bool success = true;
     if (auto oneWire = selectRom()) {
         // Compute the 1-Wire CRC16 and compare it against the received CRC.
         // Put everything in one buffer so we can compute the CRC easily.
         uint8_t buf[13];
 
+        dirty = true;
         buf[0] = READ_PIO_REG;            // Read PIO Registers
         buf[1] = ADDRESS_PIO_STATE_LOWER; // LSB address
         buf[2] = ADDRESS_UPPER;           // MSB address
-        oneWire->write_bytes(buf, 3);     // Write 3 cmd bytes
-        oneWire->read_bytes(&buf[3], 10); // Read 6 data bytes, 2 0xFF, CRC16
 
-        uint16_t crcCalculated = OneWireCrc16(buf, 11);
-        // device sends CRC inverted
-        uint16_t crcReceived = ~((uint16_t(buf[12]) << 8) | uint16_t(buf[11]));
-        success = crcCalculated == crcReceived;
+        if (oneWire->write_bytes(buf, 3)) {         // Write 3 cmd bytes
+            if (oneWire->read_bytes(&buf[3], 10)) { // Read 6 data bytes, 2 0xFF, CRC16
+                uint16_t crcCalculated = OneWireCrc16(buf, 11);
+                // device sends CRC inverted
+                uint16_t crcReceived = ~((uint16_t(buf[12]) << 8) | uint16_t(buf[11]));
+                success = crcCalculated == crcReceived;
 
-        if (success) {
-            pins = buf[3];
-            latches = buf[4];
-            activity = buf[5];
-            cond_search_mask = buf[6];
-            cond_search_pol = buf[7];
-            status = buf[8];
-            dirty = false;
-        }
-        connected(success);
-        if (writeNeeded()) {
-            oneWire->reset();
-            oneWire->select(m_address);
-
-            uint8_t bytes[3] = {ACCESS_WRITE, desiredLatches, uint8_t(~desiredLatches)};
-
-            if (oneWire->write_bytes(bytes, 3)) {
-                /* Acknowledgement byte, 0xAA for success, 0xFF for failure. */
-                uint8_t ack;
-                if (oneWire->read(ack) && ack == ACK_SUCCESS) {
-                    success = success && oneWire->read(pins);
+                if (success) {
+                    pins = buf[3];
+                    latches = buf[4];
+                    activity = buf[5];
+                    cond_search_mask = buf[6];
+                    cond_search_pol = buf[7];
+                    status = buf[8];
+                    dirty = false;
                 }
-            };
+                connected(success);
+            }
+        }
+
+        if (writeNeeded()) {
+            success = false;
+            if (oneWire->reset() && oneWire->select(m_address)) {
+                uint8_t bytes[3] = {ACCESS_WRITE, desiredLatches, uint8_t(~desiredLatches)};
+
+                if (oneWire->write_bytes(bytes, 3)) {
+                    /* Acknowledgement byte, 0xAA for success, 0xFF for failure. */
+                    uint8_t ack;
+                    if (oneWire->read(ack) && ack == ACK_SUCCESS) {
+                        success = oneWire->read(pins);
+                    }
+                };
+            }
         }
 
         oneWire->reset();
@@ -139,9 +142,9 @@ IoValue::variant DS2408::writeChannelImpl(uint8_t channel, IoValue::variant val)
         return IoValue::Error::UNSUPPORTED_VALUE;
     }
 
-    if (writeNeeded()) {
+    if (dirty || desiredLatches != latches) {
         // only directly update when connected, to prevent disconnected devices to continuously try to update
-        // they will reconnect in the normal update tick, which should happen every second
+        // they will reconnect in the normal 1s update tick, which should happen every second
         update();
     }
     return readChannelImpl(channel);

--- a/lib/control/src/MotorValve.cpp
+++ b/lib/control/src/MotorValve.cpp
@@ -111,7 +111,10 @@ void MotorValve::update()
         // Periodic retry to claim channel in case target didn't exist
         // at earlier tries
         claimChannel();
-        return;
+        if (!channelReady()) {
+            return;
+        }
+        state(State::Inactive);
     }
     if (auto devPtr = m_target.lock()) {
         m_actualValveState = getValveState(devPtr);

--- a/test/control/ActuatorPwm_test.cpp
+++ b/test/control/ActuatorPwm_test.cpp
@@ -84,6 +84,7 @@ randomIntervalTest(
                 << std::endl;
     }
 
+    auto lastValidState = State::Active;
     for (int i = 0; i < numPeriods + 4; i++) {
         do {
             now += 1 + std::rand() % delayMax;
@@ -94,7 +95,11 @@ randomIntervalTest(
                 lastOneSecondUpdate = now;
                 everySecond();
             }
-        } while (target.state() == State::Active);
+            auto state = target.state();
+            if (state != State::Unknown) {
+                lastValidState = state;
+            }
+        } while (lastValidState == State::Active);
         highToLowTime = now;
         ticks_millis_t highTime = highToLowTime - lowToHighTime;
         if (i >= 4) {
@@ -109,7 +114,11 @@ randomIntervalTest(
                 lastOneSecondUpdate = now;
                 everySecond();
             }
-        } while (target.state() == State::Inactive);
+            auto state = target.state();
+            if (state != State::Unknown) {
+                lastValidState = state;
+            }
+        } while (lastValidState == State::Inactive);
         lowToHighTime = now;
         ticks_millis_t lowTime = lowToHighTime - highToLowTime;
         if (i >= 4) {
@@ -1315,13 +1324,17 @@ SCENARIO("ActuatorPWM driving mock DS2413 actuator", "[pwm]")
     auto constrained = TestControlPtr<ActuatorDigitalConstrained>(new ActuatorDigitalConstrained(act));
     ActuatorPwm pwm(constrained, 4000);
 
+    auto everySecond = [&ds]() {
+        ds.ptr->update(); // reconnects happen in this object, so need to include the 1s update
+    };
+
     WHEN("update is called without delays, the average duty cycle is correct")
     {
-        CHECK(randomIntervalTest(100, pwm, act, 49.0, 1, now) == Approx(49.0).margin(0.2));
-        CHECK(randomIntervalTest(100, pwm, act, 50.0, 1, now) == Approx(50.0).margin(0.2));
-        CHECK(randomIntervalTest(100, pwm, act, 51.0, 1, now) == Approx(51.0).margin(0.2));
-        CHECK(randomIntervalTest(100, pwm, act, 2.0, 1, now) == Approx(2.0).margin(0.2));
-        CHECK(randomIntervalTest(100, pwm, act, 98.0, 1, now) == Approx(98.0).margin(0.2));
+        CHECK(randomIntervalTest(100, pwm, act, 49.0, 1, now, everySecond) == Approx(49.0).margin(0.2));
+        CHECK(randomIntervalTest(100, pwm, act, 50.0, 1, now, everySecond) == Approx(50.0).margin(0.2));
+        CHECK(randomIntervalTest(100, pwm, act, 51.0, 1, now, everySecond) == Approx(51.0).margin(0.2));
+        CHECK(randomIntervalTest(100, pwm, act, 2.0, 1, now, everySecond) == Approx(2.0).margin(0.2));
+        CHECK(randomIntervalTest(100, pwm, act, 98.0, 1, now, everySecond) == Approx(98.0).margin(0.2));
     }
 
     WHEN("Communication errors occur on the bus, the PWM values are still correct")
@@ -1342,26 +1355,22 @@ SCENARIO("ActuatorPWM driving mock DS2413 actuator", "[pwm]")
         std::vector<uint32_t> readBitFlips(100);
         std::generate(readBitFlips.begin(), readBitFlips.end(), nextReadFlip);
 
-        auto everySecond = [&ds]() {
-            ds.ptr->update(); // reconnects happen in this object, so need to include the 1s update
-        };
-
         logger::clear();
         ds2413mock->flipWrittenBits(writeBitFlips);
         ds2413mock->flipReadBits(readBitFlips);
-        CHECK(randomIntervalTest(200, pwm, act, 49.0, 1, now, everySecond) == Approx(49.0).margin(1));
+        CHECK(randomIntervalTest(100, pwm, act, 49.0, 1, now, everySecond) == Approx(49.0).margin(0.2));
         ds2413mock->flipWrittenBits(writeBitFlips);
         ds2413mock->flipReadBits(readBitFlips);
-        CHECK(randomIntervalTest(200, pwm, act, 50.0, 1, now, everySecond) == Approx(50.0).margin(1));
+        CHECK(randomIntervalTest(100, pwm, act, 50.0, 1, now, everySecond) == Approx(50.0).margin(0.2));
         ds2413mock->flipWrittenBits(writeBitFlips);
         ds2413mock->flipReadBits(readBitFlips);
-        CHECK(randomIntervalTest(200, pwm, act, 51.0, 1, now, everySecond) == Approx(51.0).margin(1));
+        CHECK(randomIntervalTest(100, pwm, act, 51.0, 1, now, everySecond) == Approx(51.0).margin(0.2));
         ds2413mock->flipWrittenBits(writeBitFlips);
         ds2413mock->flipReadBits(readBitFlips);
-        CHECK(randomIntervalTest(200, pwm, act, 2.0, 1, now, everySecond) == Approx(2.0).margin(1));
+        CHECK(randomIntervalTest(100, pwm, act, 2.0, 1, now, everySecond) == Approx(2.0).margin(0.2));
         ds2413mock->flipWrittenBits(writeBitFlips);
         ds2413mock->flipReadBits(readBitFlips);
-        CHECK(randomIntervalTest(200, pwm, act, 98.0, 1, now, everySecond) == Approx(98.0).margin(1));
+        CHECK(randomIntervalTest(100, pwm, act, 98.0, 1, now, everySecond) == Approx(98.0).margin(0.2));
 
         AND_THEN("The log contains disconnect and reconnect logs")
         {
@@ -1381,20 +1390,24 @@ SCENARIO("ActuatorPWM driving mock DS2408 motor valve", "[pwm]")
     auto ds2408mock = std::make_shared<DS2408Mock>(addr);
     mockOw.attach(ds2408mock);
     auto ds = TestControlPtr<DS2408>(new DS2408(ow, addr));
-    auto dsIo = TestControlPtr<IoArray>(new DS2408(ow, addr));
+    auto dsIo = TestControlPtr<IoArray>(ds);
     ds.ptr->update(); // connected update happens here
     MotorValve act(dsIo, 1);
 
     auto constrained = TestControlPtr<ActuatorDigitalConstrained>(new ActuatorDigitalConstrained(act));
     ActuatorPwm pwm(constrained, 4000);
 
+    auto everySecond = [&ds, &act]() {
+        ds.ptr->update(); // reconnects happen in this object, so need to include the 1s update
+    };
+
     WHEN("update is called without delays, the average duty cycle is correct")
     {
-        CHECK(randomIntervalTest(100, pwm, act, 49.0, 1, now) == Approx(49.0).margin(0.2));
-        CHECK(randomIntervalTest(100, pwm, act, 50.0, 1, now) == Approx(50.0).margin(0.2));
-        CHECK(randomIntervalTest(100, pwm, act, 51.0, 1, now) == Approx(51.0).margin(0.2));
-        CHECK(randomIntervalTest(100, pwm, act, 2.0, 1, now) == Approx(2.0).margin(0.2));
-        CHECK(randomIntervalTest(100, pwm, act, 98.0, 1, now) == Approx(98.0).margin(0.2));
+        CHECK(randomIntervalTest(100, pwm, act, 49.0, 1, now, everySecond) == Approx(49.0).margin(0.2));
+        CHECK(randomIntervalTest(100, pwm, act, 50.0, 1, now, everySecond) == Approx(50.0).margin(0.2));
+        CHECK(randomIntervalTest(100, pwm, act, 51.0, 1, now, everySecond) == Approx(51.0).margin(0.2));
+        CHECK(randomIntervalTest(100, pwm, act, 2.0, 1, now, everySecond) == Approx(2.0).margin(0.2));
+        CHECK(randomIntervalTest(100, pwm, act, 98.0, 1, now, everySecond) == Approx(98.0).margin(0.2));
     }
 
     WHEN("Communication errors occur on the bus, the PWM values are still correct")
@@ -1414,10 +1427,6 @@ SCENARIO("ActuatorPWM driving mock DS2408 motor valve", "[pwm]")
         };
         std::vector<uint32_t> readBitFlips(100);
         std::generate(readBitFlips.begin(), readBitFlips.end(), nextReadFlip);
-
-        auto everySecond = [&ds]() {
-            ds.ptr->update(); // reconnects happen in this object, so need to include the 1s update
-        };
 
         logger::clear();
         ds2408mock->flipWrittenBits(writeBitFlips);

--- a/test/control/ActuatorPwm_test.cpp
+++ b/test/control/ActuatorPwm_test.cpp
@@ -1349,19 +1349,19 @@ SCENARIO("ActuatorPWM driving mock DS2413 actuator", "[pwm]")
         logger::clear();
         ds2413mock->flipWrittenBits(writeBitFlips);
         ds2413mock->flipReadBits(readBitFlips);
-        CHECK(randomIntervalTest(100, pwm, act, 49.0, 1, now, everySecond) == Approx(49.0).margin(0.2));
+        CHECK(randomIntervalTest(200, pwm, act, 49.0, 1, now, everySecond) == Approx(49.0).margin(1));
         ds2413mock->flipWrittenBits(writeBitFlips);
         ds2413mock->flipReadBits(readBitFlips);
-        CHECK(randomIntervalTest(100, pwm, act, 50.0, 1, now, everySecond) == Approx(50.0).margin(0.2));
+        CHECK(randomIntervalTest(200, pwm, act, 50.0, 1, now, everySecond) == Approx(50.0).margin(1));
         ds2413mock->flipWrittenBits(writeBitFlips);
         ds2413mock->flipReadBits(readBitFlips);
-        CHECK(randomIntervalTest(100, pwm, act, 51.0, 1, now, everySecond) == Approx(51.0).margin(0.2));
+        CHECK(randomIntervalTest(200, pwm, act, 51.0, 1, now, everySecond) == Approx(51.0).margin(1));
         ds2413mock->flipWrittenBits(writeBitFlips);
         ds2413mock->flipReadBits(readBitFlips);
-        CHECK(randomIntervalTest(100, pwm, act, 2.0, 1, now, everySecond) == Approx(2.0).margin(0.2));
+        CHECK(randomIntervalTest(200, pwm, act, 2.0, 1, now, everySecond) == Approx(2.0).margin(1));
         ds2413mock->flipWrittenBits(writeBitFlips);
         ds2413mock->flipReadBits(readBitFlips);
-        CHECK(randomIntervalTest(100, pwm, act, 98.0, 1, now, everySecond) == Approx(98.0).margin(0.2));
+        CHECK(randomIntervalTest(200, pwm, act, 98.0, 1, now, everySecond) == Approx(98.0).margin(1));
 
         AND_THEN("The log contains disconnect and reconnect logs")
         {
@@ -1382,6 +1382,7 @@ SCENARIO("ActuatorPWM driving mock DS2408 motor valve", "[pwm]")
     mockOw.attach(ds2408mock);
     auto ds = TestControlPtr<DS2408>(new DS2408(ow, addr));
     auto dsIo = TestControlPtr<IoArray>(new DS2408(ow, addr));
+    ds.ptr->update(); // connected update happens here
     MotorValve act(dsIo, 1);
 
     auto constrained = TestControlPtr<ActuatorDigitalConstrained>(new ActuatorDigitalConstrained(act));


### PR DESCRIPTION
When a DS2413 or DS2408 was disconnected, it would try to reconnected as often as possible, resulting in heavy onewire traffic and system slowness. With fixes in this PR, it will only try to reconnect every second instead and skip immediate writes while disconnected in the state setter.

Other small fixes uncovered while fixing this:
- Don't abort on CRC error in EEPROM data, but skip and dispose block instead
- When deleting a single object, don't destruct it until its share pointer has been removed from the object container, because it can otherwise use the container in its destructor while the container is modified.