### PR TITLE
Fix channel setup for ActuatorDigital

### DIFF
--- a/app/brewblox-esp/main/ExpOwGpio.cpp
+++ b/app/brewblox-esp/main/ExpOwGpio.cpp
@@ -120,6 +120,9 @@ IoValue::variant ExpOwGpio::readChannelImpl(uint8_t channel) const
     auto setup = channelSetup(channel);
     if (std::holds_alternative<IoValue::Setup::OutputPwm>(setup)) {
         IoValue::PWM::duty_t duty = (IoValue::PWM::duty_t{100} * chan.appliedDuty) / 255;
+        if ((pullUpStatus() & pins) < (pullDownStatus() & pins)) {
+            duty = -duty;
+        }
         return IoValue::PWM(duty);
     }
 

--- a/lib/blocks/inc/blocks/DigitalActuatorBlock.hpp
+++ b/lib/blocks/inc/blocks/DigitalActuatorBlock.hpp
@@ -16,6 +16,16 @@ public:
     {
     }
 
+    [[nodiscard]] State state() const final
+    {
+        if (auto pAct = std::get_if<ActuatorDigital>(&act)) {
+            return pAct->state();
+        } else if (auto pAct = std::get_if<ActuatorDigitalSoft>(&act)) {
+            return pAct->state();
+        }
+        return State::Unknown;
+    }
+
     void state(State v) final
     {
         if (auto pAct = std::get_if<ActuatorDigital>(&act)) {
@@ -25,15 +35,43 @@ public:
         }
     }
 
-    [[nodiscard]] State state() const final
+    [[nodiscard]] bool invert() const
     {
-
         if (auto pAct = std::get_if<ActuatorDigital>(&act)) {
-            return pAct->state();
+            return pAct->invert();
         } else if (auto pAct = std::get_if<ActuatorDigitalSoft>(&act)) {
-            return pAct->state();
+            return pAct->invert();
         }
-        return State::Unknown;
+        return false;
+    }
+
+    void invert(bool v)
+    {
+        if (auto pAct = std::get_if<ActuatorDigital>(&act)) {
+            pAct->invert(v);
+        } else if (auto pAct = std::get_if<ActuatorDigitalSoft>(&act)) {
+            pAct->invert(v);
+        }
+    }
+
+    [[nodiscard]] uint8_t channel() const
+    {
+        if (auto pAct = std::get_if<ActuatorDigital>(&act)) {
+            return pAct->channel();
+        } else if (auto pAct = std::get_if<ActuatorDigitalSoft>(&act)) {
+            return pAct->channel();
+        }
+        return false;
+    }
+
+    void channel(uint8_t v)
+    {
+        hwDevice.setChannel(v);
+        if (auto pAct = std::get_if<ActuatorDigital>(&act)) {
+            pAct->channel(v);
+        } else if (auto pAct = std::get_if<ActuatorDigitalSoft>(&act)) {
+            pAct->channel(v);
+        }
     }
 
     void swapImplementation();

--- a/lib/control/inc/control/ActuatorDigitalBase.hpp
+++ b/lib/control/inc/control/ActuatorDigitalBase.hpp
@@ -35,23 +35,11 @@ public:
         Reverse = 3,
     };
 
-    virtual void state(State v) = 0;
+    virtual ~ActuatorDigitalBase() = default;
 
     [[nodiscard]] virtual State state() const = 0;
 
-    virtual ~ActuatorDigitalBase() = default;
-
-    [[nodiscard]] bool invert() const
-    {
-        return m_invert;
-    }
-
-    void invert(bool inv)
-    {
-        auto active = state();
-        m_invert = inv;
-        state(active);
-    }
+    virtual void state(State v) = 0;
 
 protected:
     ActuatorDigitalBase() = default;
@@ -59,7 +47,6 @@ protected:
     ActuatorDigitalBase(ActuatorDigitalBase&&) noexcept = default;
     ActuatorDigitalBase& operator=(const ActuatorDigitalBase&) = default;
     ActuatorDigitalBase& operator=(ActuatorDigitalBase&&) noexcept = default;
-    bool m_invert = false;
 };
 
 inline ActuatorDigitalBase::State invertState(ActuatorDigitalBase::State s)

--- a/lib/control/inc/control/ActuatorDigitalSoft.hpp
+++ b/lib/control/inc/control/ActuatorDigitalSoft.hpp
@@ -96,13 +96,13 @@ public:
     void channel(uint8_t newChannel)
     {
         pwm.channel(newChannel);
-        update();
     }
 
     ticks_millis_t update(ticks_millis_t now)
     {
         return pwm.update(now);
     }
+
     ticks_millis_t update()
     {
         return pwm.update();

--- a/lib/control/inc/control/FastPwm.hpp
+++ b/lib/control/inc/control/FastPwm.hpp
@@ -57,6 +57,8 @@ private:
     IoValue::Setup::Frequency m_frequency = IoValue::Setup::Frequency::FREQ_100HZ;
     duration_millis_t m_transitionTime = 0;
 
+    bool ensureChannelSetup(std::shared_ptr<IoArray>& devPtr);
+
 public:
     static constexpr auto maxForwardDuty = duty_t{100};
     static constexpr auto maxReverseDuty = duty_t{-100};
@@ -101,8 +103,6 @@ public:
     {
         m_channel = newChannel;
     }
-
-    bool ensureChannelSetup(std::shared_ptr<IoArray>& devPtr);
 
     [[nodiscard]] bool invert() const
     {

--- a/test/control/ActuatorDigitalChangeLogged_test.cpp
+++ b/test/control/ActuatorDigitalChangeLogged_test.cpp
@@ -28,16 +28,14 @@ SCENARIO("ActuatorDigitalChangeLogged test", "[ActuatorChangeLog]")
 {
     using State = ActuatorDigitalBase::State;
     auto io = TestControlPtr<IoArray>(new MockIoArray());
-    ActuatorDigital mock(io, 1);
-    ActuatorDigitalChangeLogged logged(mock);
+    ActuatorDigital act(io, 1);
+    ActuatorDigitalChangeLogged logged(act);
     ticks_millis_t now = 1000;
 
     WHEN("ActuatorDigitalChangeLogged is newly constructed")
     {
-
         THEN("History is initialized at Unknown in the past and current state since construction")
         {
-
             auto times = logged.getLastStartEndTime(State::Unknown, now);
             CHECK(times.start == ticks_millis_t(-1));
             CHECK(times.end == 0);
@@ -106,7 +104,7 @@ SCENARIO("ActuatorDigitalChangeLogged test", "[ActuatorChangeLog]")
 
         THEN("Inverting target actuator has no effect on durations")
         {
-            mock.invert(true);
+            act.invert(true);
             logged.state(State::Active, 0);
             logged.state(State::Inactive, 1000);
             logged.state(State::Active, 2000);

--- a/test/control/ActuatorDigital_test.cpp
+++ b/test/control/ActuatorDigital_test.cpp
@@ -28,44 +28,37 @@ SCENARIO("ActuatorDigital test", "[ActuatorDigital]")
 {
     using State = ActuatorDigitalBase::State;
     auto io = TestControlPtr<IoArray>(new MockIoArray());
-    ActuatorDigital mock(io, 1);
+    ActuatorDigital act(io, 1);
 
     WHEN("ActuatorDigital is newly constructed")
     {
-        THEN("The state is set to Inactive")
+        THEN("The state is initialized as Inactive")
         {
-
-            CHECK(mock.state() == State::Inactive);
-        }
-
-        THEN("The channel is ready")
-        {
-
-            CHECK(mock.channelReady() == true);
+            CHECK(act.state() == State::Inactive);
         }
 
         THEN("It can be toggled between active and inactive")
         {
-            mock.state(State::Active);
-            CHECK(mock.state() == State::Active);
+            act.state(State::Active);
+            CHECK(act.state() == State::Active);
 
-            mock.state(State::Inactive);
-            CHECK(mock.state() == State::Inactive);
+            act.state(State::Inactive);
+            CHECK(act.state() == State::Inactive);
 
-            mock.state(State::Active);
-            CHECK(mock.state() == State::Active);
+            act.state(State::Active);
+            CHECK(act.state() == State::Active);
         }
 
         THEN("Writing a value other than Active sets it to inactive")
         {
-            mock.state(State::Active);
-            CHECK(mock.state() == State::Active);
+            act.state(State::Active);
+            CHECK(act.state() == State::Active);
 
-            mock.state(State::Unknown);
-            CHECK(mock.state() == State::Inactive);
+            act.state(State::Unknown);
+            CHECK(act.state() == State::Inactive);
 
-            mock.state(State::Reverse);
-            CHECK(mock.state() == State::Inactive);
+            act.state(State::Reverse);
+            CHECK(act.state() == State::Inactive);
         }
     }
 }


### PR DESCRIPTION
- Add ensureChannel behavior as seen in FastPwm
- Both FastPwm and DigitalActuator can now change channel setup
- All block get_if calls moved to the proxy
- swapImplementation() now also swaps invert
- removed update() calls when setting channel / invert
