### PR TITLE
sync time from sntp server on esp

### DIFF
--- a/app/brewblox-esp/main/main.cpp
+++ b/app/brewblox-esp/main/main.cpp
@@ -25,6 +25,7 @@
 #include "network/CboxServer.hpp"
 #include "network/mdns.hpp"
 #include "ota.hpp"
+#include "sntp.hpp"
 #include "static_gui/staticGui.hpp"
 #include "task_stats.hpp"
 #include <algorithm>
@@ -83,11 +84,14 @@ void app_main()
     spark4::adc_init();
     setupSystemBlocks();
     screen::init();
+    screen::update();
 
     // auto testScreen = gui::dynamic_interface::testScreen();
     // if (testScreen) {
     //     screen::interface->setNewScreen(std::move(*testScreen));
     // }
+    network::connect();
+    initialize_sntp();
 
     static asio::io_context io;
 
@@ -135,7 +139,6 @@ void app_main()
     updater.start(true);
 
     cbox::discoverBlocks();
-    network::connect();
     mdns::start();
     io.run();
 }

--- a/app/brewblox-esp/main/sntp.hpp
+++ b/app/brewblox-esp/main/sntp.hpp
@@ -1,0 +1,10 @@
+#include "esp_sntp.h"
+
+void initialize_sntp(void)
+{
+    sntp_setoperatingmode(SNTP_OPMODE_POLL);
+    sntp_setservername(0, "pool.ntp.org");
+    sntp_init();
+    // sntp_set_time_sync_notification_cb(time_sync_notification_cb);
+    sntp_set_sync_mode(SNTP_SYNC_MODE_SMOOTH);
+}


### PR DESCRIPTION
Synchonizes system time from sntp server.
Shouldn't affect system timers that are based on steady_clock.