### PR TITLE
Keep track of conversion time for DS18B20

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -18,17 +18,18 @@
   },
   // Add the IDs of extensions you want installed when the container is created.
   "extensions": [
-    "editorconfig.editorconfig",
-    "ms-vscode.cpptools",
-    "ms-python.python",
-    "zxh404.vscode-proto3",
-    "timonwong.shellcheck",
-    "huizhou.githd",
-    "letmaik.git-tree-compare",
-    "foxundermoon.shell-format",
-    "GitHub.vscode-pull-request-github",
-    "twxs.cmake"
-  ],
+	"editorconfig.editorconfig",
+	"ms-vscode.cpptools",
+	"ms-python.python",
+	"zxh404.vscode-proto3",
+	"timonwong.shellcheck",
+	"huizhou.githd",
+	"letmaik.git-tree-compare",
+	"foxundermoon.shell-format",
+	"GitHub.vscode-pull-request-github",
+	"twxs.cmake",
+	"matepek.vscode-catch2-test-adapter"
+],
   // Use 'forwardPorts' to make a list of ports inside the container available locally.
   // "forwardPorts": [],
   "mounts": [

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -18,18 +18,18 @@
   },
   // Add the IDs of extensions you want installed when the container is created.
   "extensions": [
-	"editorconfig.editorconfig",
-	"ms-vscode.cpptools",
-	"ms-python.python",
-	"zxh404.vscode-proto3",
-	"timonwong.shellcheck",
-	"huizhou.githd",
-	"letmaik.git-tree-compare",
-	"foxundermoon.shell-format",
-	"GitHub.vscode-pull-request-github",
-	"twxs.cmake",
-	"matepek.vscode-catch2-test-adapter"
-],
+    "editorconfig.editorconfig",
+    "ms-vscode.cpptools",
+    "ms-python.python",
+    "zxh404.vscode-proto3",
+    "timonwong.shellcheck",
+    "huizhou.githd",
+    "letmaik.git-tree-compare",
+    "foxundermoon.shell-format",
+    "GitHub.vscode-pull-request-github",
+    "twxs.cmake",
+    "matepek.vscode-catch2-test-adapter"
+  ],
   // Use 'forwardPorts' to make a list of ports inside the container available locally.
   // "forwardPorts": [],
   "mounts": [

--- a/lib/blocks/src/TempSensorOneWireBlock.cpp
+++ b/lib/blocks/src/TempSensorOneWireBlock.cpp
@@ -106,8 +106,7 @@ TempSensorOneWireBlock::write(const cbox::Payload& payload)
 
 cbox::update_t TempSensorOneWireBlock::updateHandler(cbox::update_t now)
 {
-    sensor.update();
-    return next_update_1s(now);
+    return sensor.update(now);
 }
 
 void* TempSensorOneWireBlock::implements(cbox::obj_type_t iface)

--- a/test/blocks/OneWireTempSensorBlock_test.cpp
+++ b/test/blocks/OneWireTempSensorBlock_test.cpp
@@ -68,9 +68,10 @@ SCENARIO("A TempSensorOneWireBlock")
                   "address: 9084060688381448488 "
                   "oneWireBusId: 4");
 
+            // After 2 updates, the sensor returns a valid temperature
             cbox::update(1000);
+            cbox::update(2000);
 
-            // After an update, the sensor returns a valid temperature
             cmd.responses.clear();
             CHECK(cbox::readBlock(cmd.request, cmd.callback) == cbox::CboxError::OK);
             payloadToMessage(cmd, message);


### PR DESCRIPTION
Keep track of when a conversion was started for DS18B20 so the result is read only when it is ready, and only once.
Detach conversion interval from update interval.
This fixes that a sensor that is just plugged in could be read as 85C (the initial value) when it was read twice before the first conversion was finished. The reset detection would prevent 85C on the first read, but not on the second.